### PR TITLE
CRTM AOD module

### DIFF
--- a/src/AtmScatter/CRTM_AOD_Module.f90
+++ b/src/AtmScatter/CRTM_AOD_Module.f90
@@ -37,7 +37,8 @@ MODULE CRTM_AOD_Module
                                       CRTM_Compute_AerosolScatter_AD
   USE CRTM_RTSolution_Define,   ONLY: CRTM_RTSolution_type, &
                                       CRTM_RTSolution_Associated
-  USE CRTM_AerosolCoeff,        ONLY: CRTM_AerosolCoeff_IsLoaded
+  USE CRTM_AerosolCoeff,        ONLY: CRTM_AerosolCoeff_IsLoaded, &
+                                      AeroC
 
   ! Internal variable definition modules
   ! ...AerosolScatter
@@ -269,7 +270,7 @@ CONTAINS
       CALL CRTM_AtmOptics_Create( AtmOptics, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS, &
-                                  MAX_N_PHASE_ELEMENTS  )
+                                  AeroC%N_PHASE_ELEMENTS  )
       IF ( .NOT. CRTM_AtmOptics_Associated( Atmoptics ) ) THEN
         Error_Status = FAILURE
         WRITE( Message,'("Error allocating AtmOptics data structure for profile #",i0)' ) m
@@ -573,11 +574,11 @@ CONTAINS
       CALL CRTM_AtmOptics_Create( AtmOptics, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       CALL CRTM_AtmOptics_Create( AtmOptics_TL, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       IF ( .NOT. CRTM_AtmOptics_Associated( Atmoptics ) .OR. &
            .NOT. CRTM_AtmOptics_Associated( Atmoptics_TL ) ) THEN
         Error_Status = FAILURE
@@ -906,11 +907,11 @@ CONTAINS
       CALL CRTM_AtmOptics_Create( AtmOptics, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       CALL CRTM_AtmOptics_Create( AtmOptics_AD, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       IF ( .NOT. CRTM_AtmOptics_Associated( Atmoptics ) .OR. &
            .NOT. CRTM_AtmOptics_Associated( Atmoptics_AD ) ) THEN
         Error_Status = FAILURE
@@ -1258,11 +1259,11 @@ CONTAINS
       CALL CRTM_AtmOptics_Create( AtmOptics, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       CALL CRTM_AtmOptics_Create( AtmOptics_K, &
                                   Atmosphere(m)%n_Layers, &
                                   MAX_N_LEGENDRE_TERMS  , &
-                                  MAX_N_PHASE_ELEMENTS    )
+                                  AeroC%N_PHASE_ELEMENTS    )
       IF ( .NOT. CRTM_AtmOptics_Associated( Atmoptics ) .OR. &
            .NOT. CRTM_AtmOptics_Associated( Atmoptics_K ) ) THEN
         Error_Status = FAILURE


### PR DESCRIPTION
This PR updates CRTM AOD module, aiming at fixing the UFO AOD tests.
For more details, see issue https://github.com/JCSDA/CRTMv3/issues/33

CRTM standalone test `test_forward_AOD_v.abi_g18`  passed.

UFO AOD tests should also be preformed with these updates to confirm if it fixes the previous failed ufo AOD tests.