### PR TITLE
Comment in the debugging  'n_omp_threads = ' print out in CRTM_K_Matrix_Module.f90

### DIFF
--- a/src/CRTM_K_Matrix_Module.f90
+++ b/src/CRTM_K_Matrix_Module.f90
@@ -415,7 +415,7 @@ CONTAINS
 !$OMP END SINGLE
 !$OMP END PARALLEL
 
-    print *,' n_omp_threads = ',n_omp_threads, n_Profiles
+    ! print *,' n_omp_threads = ',n_omp_threads, n_Profiles
     ! Determine how many threads to use for profiles and channels
     ! After profiles get what they need, we use the left-over threads
     ! to parallelize channels


### PR DESCRIPTION

Remove left over debugging print at line [418](https://github.com/JCSDA/CRTMv3/blob/7c79b96739abd7574949a6e8ec886d43a3283a43/src/CRTM_K_Matrix_Module.f90#L418) of src/CRTM_K_Matrix_Module.f90

## Description

In an effort to limit the size of JEDI logs, remove this print out that is repeated many times.

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:


## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
