### PR TITLE
Feature/v241 merge test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,17 @@
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
+cmake_minimum_required (VERSION 3.12)
+project("CRTM_Tests" VERSION 1.0.1 LANGUAGES Fortran C)
+enable_testing ()
+
+## Ecbuild integration
+find_package( ecbuild QUIET )
+include( ecbuild_system NO_POLICY_SCOPE )
+ecbuild_declare_project()
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
+
 # macro to create a symlink from src to dst
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -38,30 +49,72 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/results/forward)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/results/unit)
 CREATE_SYMLINK( ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${crtm_test_input} )
 
-set( REPO_VERSION crtm/3.0.0 )
-# If local path to testfiles is defined don't download
 
-# IF the fix/ directory already exists locally, don't download the tarball from gdex
-# this supports non-jedi users.
+if( DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES})
+    set(LOCAL_PATH_JEDI_TESTFILES "$ENV{LOCAL_PATH_JEDI_TESTFILES}")
+endif()
+
+if ( DEFINED ENV{CRTM_TEST_ROOT})
+    set(CRTM_TEST_ROOT "$ENV{CRTM_TEST_ROOT}")
+else()
+    set(CRTM_TEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+set( CRTM_COEFFS_BRANCH "3.0.0" )
+
+# If local path to testfiles is defined don't download
+#if( DEFINED LOCAL_PATH_JEDI_TESTFILES )
 IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
   set( CRTM_COEFFS_PATH ${CMAKE_SOURCE_DIR}/fix )
   message(STATUS "use LOCAL_PATH_JEDI_TESTFILES: ${CRTM_COEFFS_PATH}")
   message("Using existing local fix directory instead of downloading.")
 # Download CRTM coefficients
 else()
-	set( CRTM_COEFFS_BRANCH_PREFIX "crtm" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
-  set( CRTM_COEFFS_BRANCH "3.0.0_skylab_4.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
-	# it is my intention is to not have any difference between jedi/ufo versions of CRTM and stand-alond versions of CRTM -- they should both work "out of the box"
-  set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION})   #this is where the symlinks point to binary files for the testinput/* directory after ecbuild. 
-  file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})  
-#  set( ECBUILD_DOWNLOAD_BASE_URL https://gdex.ucar.edu/dataset/jedi-skylab )   
-  set( ECBUILD_DOWNLOAD_BASE_URL https://ftp.ssec.wisc.edu/pub/s4/CRTM )   
-  message(STATUS "download CRTM coeffs files from: ${ECBUILD_DOWNLOAD_BASE_URL}/file to ${CRTM_COEFFS_PATH}")
-  ecbuild_get_test_multidata( TARGET   get_crtm_coeffs
-                              NAMES    crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz:9941a3c099704108830e33e49792478   #i'm assuming these are md5sums, this is the md5sum for crtm_coefficients_3.0.0_skylab_4.0.tar.gz as of March 8, 2023 that was sent to gdex
-                              DIRNAME  file
-                              DIRLOCAL ${CRTM_COEFFS_PATH}
-                              EXTRACT )
+   #### Version 3
+   #set( CRTM_COEFFS_BRANCH_PREFIX "crtm" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
+   #set( CRTM_COEFFS_BRANCH "3.0.0_skylab_4.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)     
+   # it is my intention is to not have any difference between jedi/ufo versions of CRTM and stand-alond versions of CRTM -- they should both work "out of the box"
+   #set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION})   #this is where the symlinks point to binary files for the testinput/* directory after ecbuild.
+   #file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
+#  set( ECBUILD_DOWNLOAD_BASE_URL https://gdex.ucar.edu/dataset/jedi-skylab )
+   #set( ECBUILD_DOWNLOAD_BASE_URL https://ftp.ssec.wisc.edu/pub/s4/CRTM )
+   #message(STATUS "download CRTM coeffs files from: ${ECBUILD_DOWNLOAD_BASE_URL}/file to ${CRTM_COEFFS_PATH}")
+   #ecbuild_get_test_multidata( TARGET   get_crtm_coeffs
+   #                            NAMES    crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz:9941a3c099704108830e33e49792478   #i'm assuming these are md5sums, this is the md5sum for crtm_coefficients_3.0.0_skylab_4.0.tar.gz as of March 8, 2023 that was sent to gdex
+   #                            DIRNAME  file
+   #                            DIRLOCAL ${CRTM_COEFFS_PATH}
+   #                            EXTRACT )
+
+  ####Version 2.4.1	
+  set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/crtm/${CRTM_COEFFS_BRANCH})
+  file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
+  set( ECBUILD_DOWNLOAD_BASE_URL https://gdex.ucar.edu/dataset/jedi-skylab/file )
+  set( test_files_dirname crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz )
+  set( checksum "0")
+  message(STATUS "download CRTM coeffs files from: ${ECBUILD_DOWNLOAD_BASE_URL} to ${CRTM_COEFFS_PATH}")
+
+  list( APPEND CRTM_DATA_DOWNLOADER_ARGS
+                ${ECBUILD_DOWNLOAD_BASE_URL}
+                ${CMAKE_BINARY_DIR}/test_data
+                ${test_files_dirname}
+                ${checksum} )
+
+  # Create download script for ufo_get_*_test_data test
+  set ( FILENAME crtm_data_downloader.py)
+  set ( SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME} )
+  set ( DEST_FILE ${CMAKE_BINARY_DIR}/bin/${FILENAME} )
+
+  if( EXISTS "${SOURCE_FILE}.in" )
+    configure_file( ${SOURCE_FILE}.in ${DEST_FILE} @ONLY )
+  else()
+    configure_file( ${SOURCE_FILE}    ${DEST_FILE} @ONLY )
+  endif()
+
+  # add test for downloading data
+  ecbuild_add_test( TARGET    get_crtm_coeffs
+                    TYPE      SCRIPT
+                    COMMAND   ${CMAKE_BINARY_DIR}/bin/crtm_data_downloader.py
+                    ARGS      ${CRTM_DATA_DOWNLOADER_ARGS} )
 endif()
 
 # Add files to cmake resources
@@ -75,6 +128,10 @@ list( APPEND Simple_Sensor_Ids
         atms_n21
         cris-fsr_n21
         v.abi_g18
+	atms_npp
+        cris399_np
+        v.abi_gr
+	abi_g18
         modis_aqua
 )
 
@@ -82,20 +139,32 @@ list( APPEND ScatteringSwitch_Sensor_Ids
         atms_n21
         cris-fsr_n21
         v.abi_g18
+	atms_npp
+        cris399_npp
+        v.abi_gr
+	abi_g18
         modis_aqua
 )
 
 list( APPEND SOI_Sensor_Ids
         atms_n21
         cris-fsr_n21
-        v.abi_g18
+        v.abi_g18	
+        atms_npp
+        cris399_npp
+        v.abi_gr
+	abi_g18
         modis_aqua
 )
 
 list( APPEND VerticalCoordinates_Sensor_Ids
         atms_n21
         cris-fsr_n21
-        v.abi_g18
+        v.abi_g18	
+        atms_npp
+        cris399_npp
+        v.abi_gr
+	abi_g18
         modis_aqua
 )
 
@@ -108,13 +177,20 @@ list( APPEND ClearSky_Sensor_Ids
         atms_n21
         cris-fsr_n21
         v.abi_g18
+        atms_npp
+        cris399_npp
+        v.abi_gr
+	abi_g18
         modis_aqua
 )
 
 # Create list of sensor ids for testing
 list( APPEND AOD_Sensor_Ids
-        cris-fsr_n21
-        v.abi_g18
+	cris-fsr_n21
+	v.abi_g18
+        cris399_npp
+        v.abi_gr
+	abi_g18
         airs_aqua
 )
 
@@ -134,6 +210,11 @@ list( APPEND ChannelSubset_Sensor_Ids
 
 list( APPEND Aircraft_Sensor_Ids
       cris-fsr_n21
+      crisB1_npp
+)
+
+list( APPEND OMPoverChannels_Sensor_Ids
+        atms_npp
 )
 
 list (APPEND common_tests
@@ -147,6 +228,10 @@ list (APPEND common_tests
      SOI
      SSU
      VerticalCoordinates
+)
+
+list (APPEND omp_tests
+     OMPoverChannels
 )
 
 
@@ -201,6 +286,120 @@ ecbuild_add_test (
     TEST_DEPENDS get_crtm_coeffs
     )
 
+#(PS) SpcCoeff Version 3 I/O test
+ecbuild_add_executable (
+	TARGET "test_spc_io"
+	SOURCES mains/unit/input_output/test_SpcCoeff/test_spc_io.f90
+	LIBS crtm
+	NOINSTALL
+	)
+ecbuild_add_test(
+	TARGET "Unit_test_spc_io"
+	COMMAND "test_spc_io"
+	OMP     $ENV{OMP_NUM_THREADS}
+	TEST_DEPENDS get_crtm_coeffs
+	)
+
+#(PS) SpcCoeff netCDF I/O test
+ecbuild_add_executable (
+    TARGET "test_spc_io_nc"
+	SOURCES mains/unit/input_output/test_SpcCoeff_NC/test_spc_io_nc.f90
+	LIBS crtm
+	NOINSTALL
+	)
+ecbuild_add_test(
+    TARGET "Unit_test_spc_io_nc"
+	COMMAND "test_spc_io_nc"
+	OMP $ENV{OMP_NUM_THREADS}
+	TEST_DEPENDS get_crtm_coeffs
+	)
+
+#(PS) TauCoeff netCDF I/O test
+ecbuild_add_executable (
+	TARGET "test_taucoeff_io_nc"
+	SOURCES mains/unit/input_output/test_TauCoeff_NC/test_taucoeff_io_nc.f90 
+	LIBS crtm
+	NOINSTALL
+	)
+
+ecbuild_add_test(
+	TARGET "Unit_test_tc_io_nc"
+	COMMAND "test_taucoeff_io_nc"
+	OMP $ENV{OMP_NUM_THREADS}
+	TEST_DEPENDS get_crtm_coeffs
+	)
+
+#(CD) AerosolCoeff I/O test
+ecbuild_add_executable (
+    TARGET "test_aerosol_coeff_io"
+        SOURCES mains/unit/input_output/test_AerosolCoeff/test_aerosol_coeff_io.f90
+        LIBS crtm
+        NOINSTALL
+        )
+ecbuild_add_test(
+    TARGET "Unit_test_aerosol_coeff_io"
+        COMMAND "test_aerosol_coeff_io"
+        OMP $ENV{OMP_NUM_THREADS}
+        TEST_DEPENDS get_crtm_coeffs
+        )
+
+#(CD) AerosolCoeff netCDF I/O test
+ecbuild_add_executable (
+    TARGET "test_aerosol_coeff_io_nc"
+        SOURCES mains/unit/input_output/test_AerosolCoeff_NC/test_aerosol_coeff_io_nc.f90
+        LIBS crtm
+        NOINSTALL
+        )
+ecbuild_add_test(
+    TARGET "Unit_test_aerosol_coeff_io_nc"
+        COMMAND "test_aerosol_coeff_io_nc"
+        OMP $ENV{OMP_NUM_THREADS}
+        TEST_DEPENDS get_crtm_coeffs
+        )
+
+#(CD) EmisCoeff I/O test
+#ecbuild_add_executable (
+#    TARGET "test_emis_coeff_io"
+#        SOURCES mains/unit/input_output/test_EmisCoeff/test_emis_coeff_io.f90
+#        LIBS crtm
+#        NOINSTALL
+#        )
+#ecbuild_add_test(
+#    TARGET "Unit_test_emis_coeff_io"
+#        COMMAND "test_emis_coeff_io"
+#        OMP $ENV{OMP_NUM_THREADS}
+#        TEST_DEPENDS get_crtm_coeffs
+#        )
+
+#(CD) EmisCoeff netCDF I/O test
+#ecbuild_add_executable (
+#    TARGET "test_emis_coeff_io_nc"
+#        SOURCES mains/unit/input_output/test_EmisCoeff_NC/test_emis_coeff_io_nc.f90
+#        LIBS crtm
+#        NOINSTALL
+#        )
+#ecbuild_add_test(
+#    TARGET "Unit_test_emis_coeff_io_nc"
+#        COMMAND "test_emis_coeff_io_nc"
+#        OMP $ENV{OMP_NUM_THREADS}
+#        TEST_DEPENDS get_crtm_coeffs
+#        )
+
+#(PS) Hypsometric Equation test
+ecbuild_add_executable (
+    TARGET "test_hypsometric_eq"
+    SOURCES mains/unit/Unit_Test/test_Hypsometric.f90
+    LIBS crtm
+    NOINSTALL
+    )
+
+ecbuild_add_test(
+    TARGET "Unit_test_hypsometric_eq"
+    COMMAND "test_hypsometric_eq"
+    OMP $ENV{OMP_NUM_THREADS}
+    )
+
+
 #=================================================================================
 #forward and k_matrix regression tests
 foreach(regtype IN LISTS regression_types)
@@ -226,6 +425,7 @@ foreach(regtype IN LISTS regression_types)
   endforeach() 
 endforeach()
 
+
 #---------------------------------------------------------------------------------
 #TLAD Regression tests
 foreach(regtype IN LISTS TLAD_types)
@@ -249,6 +449,30 @@ foreach(regtype IN LISTS TLAD_types)
 endforeach()
 
 
+#=================================================================================
+#OpenMP regression tests
+foreach(regtype IN LISTS regression_types)
+  string(COMPARE EQUAL ${regtype} "k_matrix" isregtype)
+  if (isregtype)
+    continue() #skip all k_matrix tests
+  endif()
+  foreach(testtype IN LISTS omp_tests)
+    ecbuild_add_executable( TARGET  "test_${regtype}_test_${testtype}"
+                            SOURCES "mains/regression/${regtype}/test_${testtype}/test_${testtype}.F90"
+                            LIBS    crtm
+                            NOINSTALL)
+ 
+    foreach(sensor_id IN LISTS ${testtype}_Sensor_Ids)
+  
+          ecbuild_add_test( TARGET  "test_${regtype}_${testtype}_${sensor_id}"
+                            OMP     $ENV{OMP_NUM_THREADS}
+                            COMMAND "test_${regtype}_test_${testtype}"
+                            ARGS    "${sensor_id}"
+                            TEST_DEPENDS get_crtm_coeffs)
+    endforeach()
+  endforeach() 
+endforeach()
+
 
 
 #####################################################################
@@ -256,12 +480,17 @@ endforeach()
 #####################################################################
 
 list( APPEND crtm_test_input
+Test_Input/ECMWF_5K/Big_Endian/ecmwf_5k_atmosphereccol.bin
+Test_Input/ECMWF_5K/Big_Endian/ecmwf_5k_surfaceccol.bin
+Test_Input/ECMWF_5K/Big_Endian/ecmwf_5k_geometryccol.bin
 AerosolCoeff/Little_Endian/AerosolCoeff.bin
+AerosolCoeff/netCDF/AerosolCoeff.nc4
 CloudCoeff/Little_Endian/CloudCoeff.bin
 EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
 EmisCoeff/IR_Ice/SEcategory/Little_Endian/NPOESS.IRice.EmisCoeff.bin
 EmisCoeff/IR_Land/SEcategory/Little_Endian/NPOESS.IRland.EmisCoeff.bin
 EmisCoeff/IR_Snow/SEcategory/Little_Endian/NPOESS.IRsnow.EmisCoeff.bin
+EmisCoeff/IR_Snow/Nalli/Little_Endian/Nalli.IRsnow.EmisCoeff.bin
 EmisCoeff/VIS_Ice/SEcategory/Little_Endian/NPOESS.VISice.EmisCoeff.bin
 EmisCoeff/VIS_Land/SEcategory/Little_Endian/NPOESS.VISland.EmisCoeff.bin
 EmisCoeff/VIS_Snow/SEcategory/Little_Endian/NPOESS.VISsnow.EmisCoeff.bin
@@ -275,12 +504,16 @@ SpcCoeff/Little_Endian/amsua_n19.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/amsua_n19.TauCoeff.bin
 SpcCoeff/Little_Endian/amsua_metop-a.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/amsua_metop-a.TauCoeff.bin
+SpcCoeff/netCDF/amsua_aqua.SpcCoeff.nc
+TauCoeff/ODPS/netCDF/amsua_aqua.TauCoeff.nc
 SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
 SpcCoeff/Little_Endian/seviri_m08.SpcCoeff.bin
 TauCoeff/ODAS/Little_Endian/seviri_m08.TauCoeff.bin
 SpcCoeff/Little_Endian/cris-fsr_n21.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/cris-fsr_n21.TauCoeff.bin
+SpcCoeff/Little_Endian/cris-fsr_npp.SpcCoeff.bin
+TauCoeff/ODPS/Little_Endian/cris-fsr_npp.TauCoeff.bin
 SpcCoeff/Little_Endian/iasi_metop-a.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/iasi_metop-a.TauCoeff.bin
 SpcCoeff/Little_Endian/iasi_metop-b.SpcCoeff.bin
@@ -307,6 +540,18 @@ SpcCoeff/Little_Endian/v.viirs-m_j2.SpcCoeff.bin
 TauCoeff/ODPS/Little_Endian/v.viirs-m_j2.TauCoeff.bin
 SpcCoeff/Little_Endian/v.abi_g18.SpcCoeff.bin
 TauCoeff/ODAS/Little_Endian/v.abi_g18.TauCoeff.bin
+SpcCoeff/Little_Endian/abi_g18.SpcCoeff.bin
+TauCoeff/ODPS/Little_Endian/abi_g18.TauCoeff.bin
+SpcCoeff/Little_Endian/cris399_npp.SpcCoeff.bin
+TauCoeff/ODPS/Little_Endian/cris399_npp.TauCoeff.bin
+SpcCoeff/Little_Endian/crisB1_npp.SpcCoeff.bin
+TauCoeff/ODPS/Little_Endian/crisB1_npp.TauCoeff.bin
+SpcCoeff/Little_Endian/atms_npp.SpcCoeff.bin
+TauCoeff/ODPS/Little_Endian/atms_npp.TauCoeff.bin
+SpcCoeff/Little_Endian/v.viirs-m_npp.SpcCoeff.bin
+TauCoeff/ODAS/Little_Endian/v.viirs-m_npp.TauCoeff.bin
+SpcCoeff/Little_Endian/v.abi_gr.SpcCoeff.bin
+TauCoeff/ODAS/Little_Endian/v.abi_gr.TauCoeff.bin
 TauCoeff/ODPS/Little_Endian/zssmis_f20.TauCoeff.bin
 TauCoeff/ODPS/Little_Endian/zssmis_f19.TauCoeff.bin
 TauCoeff/ODPS/Little_Endian/zssmis_f18.TauCoeff.bin
@@ -336,8 +581,9 @@ SpcCoeff/Little_Endian/ssu_n11.SpcCoeff.bin
 SpcCoeff/Little_Endian/ssu_n14.SpcCoeff.bin
 )
 
-
 # Symlink all CRTM files
-CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}
+# Version 3
+# CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}
+CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}
                          ${CMAKE_CURRENT_BINARY_DIR}/testinput
                          ${crtm_test_input} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -551,7 +551,6 @@ SpcCoeff/Little_Endian/ssu_n14.SpcCoeff.bin
 
 # Symlink all CRTM files
 # Version 3
-# CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}
-CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}
+CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}
                          ${CMAKE_CURRENT_BINARY_DIR}/testinput
                          ${crtm_test_input} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -130,7 +130,7 @@ list( APPEND Simple_Sensor_Ids
         cris-fsr_n21
         v.abi_g18
 	atms_npp
-        cris399_np
+        cris399_npp
         v.abi_gr
 	abi_g18
         modis_aqua

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,7 @@ IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
 else()
    #### Version 3
    #set( CRTM_COEFFS_BRANCH_PREFIX "crtm" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
-   #set( CRTM_COEFFS_BRANCH "3.0.0_skylab_4.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)     
+   set( CRTM_COEFFS_BRANCH "3.0.0_skylab_4.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)     
    # it is my intention is to not have any difference between jedi/ufo versions of CRTM and stand-alond versions of CRTM -- they should both work "out of the box"
    #set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION})   #this is where the symlinks point to binary files for the testinput/* directory after ecbuild.
    #file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
@@ -88,7 +88,8 @@ else()
   ####Version 2.4.1	
   set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/crtm/${CRTM_COEFFS_BRANCH})
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
-  set( ECBUILD_DOWNLOAD_BASE_URL https://gdex.ucar.edu/dataset/jedi-skylab/file )
+  #set( ECBUILD_DOWNLOAD_BASE_URL https://gdex.ucar.edu/dataset/jedi-skylab/file )
+  set( ECBUILD_DOWNLOAD_BASE_URL https://ftp.ssec.wisc.edu/pub/s4/CRTM )
   set( test_files_dirname crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz )
   set( checksum "0")
   message(STATUS "download CRTM coeffs files from: ${ECBUILD_DOWNLOAD_BASE_URL} to ${CRTM_COEFFS_PATH}")

--- a/test/crtm_data_downloader.py
+++ b/test/crtm_data_downloader.py
@@ -23,6 +23,11 @@ def DownloadUntar(download_base_url, testfiles_path, testfiles_name, md5check):
       urllib.request.urlretrieve( download_base_url+"/"+testfiles_name, testfiles_path+"/"+testfiles_name)
     except:
       raise RuntimeError("Downloading CRTM test data file failed!")
+  else:
+    try:
+      urllib.request.urlretrieve( download_base_url+"/"+testfiles_name, testfiles_path+"/"+testfiles_name)
+    except:
+      raise RuntimeError("Downloading CRTM test data file failed!")
   tar_file = tarfile.open(testfiles_path+"/"+testfiles_name)
   tar_file.extractall(testfiles_path)
   tar_file.close()

--- a/test/crtm_data_downloader.py
+++ b/test/crtm_data_downloader.py
@@ -15,9 +15,14 @@ md5check = sys.argv[4]
 
 def DownloadUntar(download_base_url, testfiles_path, testfiles_name, md5check):
   if (md5check == "1"):
-    urllib.request.urlretrieve( download_base_url+"/"+testfiles_name+".md5", testfiles_path+"/"+testfiles_name+".md5")
-
-  urllib.request.urlretrieve( download_base_url+"/"+testfiles_name, testfiles_path+"/"+testfiles_name)
+    try:
+      urllib.request.urlretrieve( download_base_url+"/"+testfiles_name+".md5", testfiles_path+"/"+testfiles_name+".md5")
+    except:
+      raise RuntimeError("Downloading md5 checksum file failed!")
+    try:
+      urllib.request.urlretrieve( download_base_url+"/"+testfiles_name, testfiles_path+"/"+testfiles_name)
+    except:
+      raise RuntimeError("Downloading CRTM test data file failed!")
   tar_file = tarfile.open(testfiles_path+"/"+testfiles_name)
   tar_file.extractall(testfiles_path)
   tar_file.close()
@@ -30,7 +35,10 @@ if (md5check == "1") :
     print("local files found")
 
     #  dl md5 save it as *.md5.dl
-    urllib.request.urlretrieve( download_base_url+"/"+testfiles_name+".md5", testfiles_path+"/"+testfiles_name+".md5.dl")
+    try:
+      urllib.request.urlretrieve( download_base_url+"/"+testfiles_name+".md5", testfiles_path+"/"+testfiles_name+".md5.dl")
+    except:
+      raise RuntimeError("Downloading md5.dl checksum file from S3 failed!")
 
     #  compare *md5.dl with md5 local
     with open(testfiles_path+"/"+testfiles_name+".md5", 'r') as f:

--- a/test/mains/application/check_crtm.fpp
+++ b/test/mains/application/check_crtm.fpp
@@ -71,8 +71,8 @@ PROGRAM check_crtm
 #else
   CHARACTER(*), PARAMETER :: ENDIAN_TYPE='big_endian'
 #endif
-  CHARACTER(*), PARAMETER :: COEFFICIENT_PATH='coefficients/'//ENDIAN_TYPE//'/'
-  CHARACTER(*), PARAMETER :: NC_COEFFICIENT_PATH='coefficients/netcdf/'
+  CHARACTER(*), PARAMETER :: COEFFICIENT_PATH='./testinput/'
+  CHARACTER(*), PARAMETER :: NC_COEFFICIENT_PATH='./testinput/'
 
   ! Aerosol/Cloud coefficient format
   CHARACTER(*), PARAMETER :: Coeff_Format = 'Binary'
@@ -94,7 +94,7 @@ PROGRAM check_crtm
   INTEGER, PARAMETER :: N_ABSORBERS = 2
   INTEGER, PARAMETER :: N_CLOUDS    = 1
   INTEGER, PARAMETER :: N_AEROSOLS  = 1
-  
+
   ! Sensor information
   INTEGER     , PARAMETER :: N_SENSORS = 2
   CHARACTER(*), PARAMETER :: SENSOR_ID(N_SENSORS) = (/'cris399_npp', &
@@ -114,6 +114,8 @@ PROGRAM check_crtm
   CHARACTER(256) :: AerosolCoeff_Format
   CHARACTER(256) :: CloudCoeff_File
   CHARACTER(256) :: CloudCoeff_Format
+  CHARACTER(256) :: Aerosol_Scheme
+  CHARACTER(256) :: Cloud_Scheme
   INTEGER :: err_stat, alloc_stat
   INTEGER :: n_channels
   INTEGER :: l, m, n, nc
@@ -155,69 +157,29 @@ PROGRAM check_crtm
   !
   ! 4a. Initialise all the sensors at once
   ! --------------------------------------
-  !.. Cloud coefficient information
-  IF ( Coeff_Format == 'Binary' ) THEN
-    CloudCoeff_Format   = 'Binary'
-    CloudCoeff_File     = 'CloudCoeff.bin'
-  ! if netCDF I/O
-  ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-    CloudCoeff_Format   = 'netCDF'
-    CloudCoeff_File     = 'CloudCoeff.nc4'
+  ! ... Cloud coefficient information
+  IF ( Cloud_Model /= 'CRTM' ) THEN
+      Cloud_Scheme = Cloud_Model//'.'
   ELSE
-    message = 'Aerosol/Cloud coefficient format is not supported'
-    CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-    STOP
+      Cloud_Scheme = ' '
   END IF
-
-  !.....Aerosol
-  IF ( Aerosol_Model == 'CRTM' ) THEN
-    IF ( Coeff_Format == 'Binary' ) THEN
-      AerosolCoeff_Format = 'Binary'
-      AerosolCoeff_File   = 'AerosolCoeff.bin'
-    ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-      AerosolCoeff_Format = 'netCDF'
-      AerosolCoeff_File   = 'AerosolCoeff.nc4'
-    ELSE
-      message = 'Aerosol coefficient format is not supported'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-  ELSEIF ( Aerosol_Model == 'CMAQ' ) THEN
-    IF ( Coeff_Format == 'Binary' ) THEN
-      AerosolCoeff_Format = 'Binary'
-      AerosolCoeff_File   = 'AerosolCoeff.CMAQ.bin'
-    ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-      AerosolCoeff_Format = 'netCDF'
-      AerosolCoeff_File   = 'AerosolCoeff.CMAQ.nc4'
-    ELSE
-      message = 'Aerosol coefficient format is not supported'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-  ELSEIF ( Aerosol_Model == 'GOCART-GEOS5' ) THEN
-    IF ( Coeff_Format == 'Binary' ) THEN
-      AerosolCoeff_Format = 'Binary'
-      AerosolCoeff_File   = 'AerosolCoeff.GOCART-GEOS5.bin'
-    ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-      AerosolCoeff_Format = 'netCDF'
-      AerosolCoeff_File   = 'AerosolCoeff.GOCART-GEOS5.nc4'
-    ELSE
-      message = 'Aerosol coefficient format is not supported'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-  ELSEIF ( Aerosol_Model == 'NAAPS' ) THEN
-    IF ( Coeff_Format == 'Binary' ) THEN
-      AerosolCoeff_Format = 'Binary'
-      AerosolCoeff_File   = 'AerosolCoeff.NAAPS.bin'
-    ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-      AerosolCoeff_Format = 'netCDF'
-      AerosolCoeff_File   = 'AerosolCoeff.NAAPS.nc4'
-    ELSE
-      message = 'Aerosol coefficient format is not supported'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
+  ! ... Aerosol coefficient information
+  IF ( Aerosol_Model /= 'CRTM' ) THEN
+      Aerosol_Scheme = Aerosol_Model//'.'
+  ELSE
+      Aerosol_Scheme = ' '
+  END IF
+  ! ... Coefficient table format
+  IF ( Coeff_Format == 'Binary' ) THEN
+    AerosolCoeff_Format = 'Binary'
+    AerosolCoeff_File   = 'AerosolCoeff.'//TRIM(Aerosol_Scheme)//'bin'
+    CloudCoeff_Format   = 'Binary'
+    CloudCoeff_File     = 'CloudCoeff.'//TRIM(Cloud_Scheme)//'bin'
+  ELSE IF ( Coeff_Format == 'netCDF' ) THEN
+    AerosolCoeff_Format = 'netCDF'
+    AerosolCoeff_File   = 'AerosolCoeff.'//TRIM(Aerosol_Scheme)//'nc4'
+    CloudCoeff_Format   = 'netCDF'
+    CloudCoeff_File     = 'CloudCoeff.'//TRIM(Cloud_Scheme)//'nc4'
   END IF
 
   WRITE( *,'(/5x,"Initializing the CRTM...")' )

--- a/test/mains/regression/forward/test_OMPoverChannels/Load_Atm_Data.inc
+++ b/test/mains/regression/forward/test_OMPoverChannels/Load_Atm_Data.inc
@@ -1,429 +1,5 @@
-!
-! check_crtm_full
-!
-! Check/example program for the CRTM Forward and K-Matrix functions.
-!
-! NOTE: No results are output or compared in this program.
-!       At this stage, it is included as an example only,
-!       and to determine that the CRTM library built
-!       correctly such that it can be linked to create
-!       an executable.
-!
-
-! Aerosol-Index mapping:
-!  --- CRTM ---
-!  1 = Dust
-!  2 = Sea salt-SSAM
-!  3 = Sea salt-SSCM1
-!  4 = Sea salt-SSCM2
-!  5 = Sea salt-SSCM3
-!  6 = Organic carbon
-!  7 = Black carbon
-!  8 = Sulfate
-!  --- CMAQ ---
-!  1 = Dust
-!  2 = Soot
-!  3 = Water soluble
-!  4 = Sulfate
-!  5 = Sea salt
-!  6 = Water
-!  7 = Insoluble
-!  8 = dust-like
-!  --- GOCART-GEOS5 ---
-!  1 = Dust
-!  2 = Sea salt
-!  3 = Organic carbon hydrophobic
-!  4 = Organic carbon hydrophilic
-!  5 = Black carbon hydrophobic
-!  6 = Black carbon hydrophilic
-!  7 = Sulfate
-!  8 = Nitrate
-!  --- NAAPS ---
-!  1 = Dust
-!  2 = Smoke
-!  3 = Sea Salt
-!  4 = Anthropogenic and Biogenic Fine Particles
-
-PROGRAM check_crtm
-
-  ! ============================================================================
-  ! STEP 1. **** ENVIRONMENT SETUP FOR CRTM USAGE ****
   !
-  ! Module usage
-  USE CRTM_Module
-  ! Disable all implicit typing
-  IMPLICIT NONE
-  ! ============================================================================
-
-
-
-  ! --------------------------
-  ! Some non-CRTM-y Parameters
-  ! --------------------------
-  CHARACTER(*), PARAMETER :: PROGRAM_NAME   = 'check_crtm'
-
-  ! ============================================================================
-  ! STEP 2. **** SET UP SOME PARAMETERS FOR THE CRTM RUN ****
-  !
-  ! Directory location of coefficients
-#ifdef LITTLE_ENDIAN
-  CHARACTER(*), PARAMETER :: ENDIAN_TYPE='little_endian'
-#else
-  CHARACTER(*), PARAMETER :: ENDIAN_TYPE='big_endian'
-#endif
-  CHARACTER(*), PARAMETER :: COEFFICIENT_PATH='./testinput/'
-  CHARACTER(*), PARAMETER :: NC_COEFFICIENT_PATH='./testinput/'
-
-  ! Aerosol/Cloud coefficient format
-  CHARACTER(*), PARAMETER :: Coeff_Format = 'Binary'
-  !CHARACTER(*), PARAMETER :: Coeff_Format = 'netCDF'
-
-  ! Aerosol/Cloud coefficient scheme
-  CHARACTER(*), PARAMETER :: Aerosol_Model = 'CRTM'
-  !CHARACTER(*), PARAMETER :: Aerosol_Model = 'CMAQ'
-  !CHARACTER(*), PARAMETER :: Aerosol_Model = 'GOCART-GEOS5'
-  !CHARACTER(*), PARAMETER :: Aerosol_Model = 'NAAPS'
-  CHARACTER(*), PARAMETER :: Cloud_Model   = 'CRTM'
-
-  ! Directory location of results for comparison [NOT USED YET]
-  CHARACTER(*), PARAMETER :: RESULTS_PATH = './results/'
-
-  ! Profile dimensions
-  INTEGER, PARAMETER :: N_PROFILES  = 4
-  INTEGER, PARAMETER :: N_LAYERS    = 92
-  INTEGER, PARAMETER :: N_ABSORBERS = 2
-  INTEGER, PARAMETER :: N_CLOUDS    = 1
-  INTEGER, PARAMETER :: N_AEROSOLS  = 1
-
-  ! Sensor information
-  INTEGER     , PARAMETER :: N_SENSORS = 2
-  CHARACTER(*), PARAMETER :: SENSOR_ID(N_SENSORS) = (/'cris399_npp', &
-                                                      'atms_npp   '/)
-
-  ! Some pretend geometry angles. The scan angle is based
-  ! on the default Re (earth radius) and h (satellite height)
-  REAL(fp), PARAMETER :: ZENITH_ANGLE = 30.0_fp
-  REAL(fp), PARAMETER :: SCAN_ANGLE   = 26.37293341421_fp
-  ! ============================================================================
-
-  ! ---------
-  ! Variables
-  ! ---------
-  CHARACTER(256) :: message, version
-  CHARACTER(256) :: AerosolCoeff_File
-  CHARACTER(256) :: AerosolCoeff_Format
-  CHARACTER(256) :: CloudCoeff_File
-  CHARACTER(256) :: CloudCoeff_Format
-  CHARACTER(256) :: Aerosol_Scheme
-  CHARACTER(256) :: Cloud_Scheme
-  INTEGER :: err_stat, alloc_stat
-  INTEGER :: n_channels
-  INTEGER :: l, m, n, nc
-  ! ============================================================================
-  ! STEP 3. **** DEFINE THE CRTM INTERFACE STRUCTURES ****
-  !
-  ! 3a. Define the "non-demoninational" arguments
-  ! ---------------------------------------------
-  TYPE(CRTM_ChannelInfo_type)             :: chinfo(N_SENSORS)
-  TYPE(CRTM_Geometry_type)                :: geo(N_PROFILES)
-
-
-  ! 3b. Define the FORWARD variables
-  ! --------------------------------
-  TYPE(CRTM_Atmosphere_type)              :: atm(N_PROFILES)
-  TYPE(CRTM_Surface_type)                 :: sfc(N_PROFILES)
-  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: rts(:,:)
-
-  ! 3c. Define the K-MATRIX variables
-  ! ---------------------------------
-  TYPE(CRTM_Atmosphere_type), ALLOCATABLE :: atm_K(:,:)
-  TYPE(CRTM_Surface_type)   , ALLOCATABLE :: sfc_K(:,:)
-  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: rts_K(:,:)
-  ! ============================================================================
-
-
-  ! Program header
-  ! --------------
-  CALL CRTM_Version( Version )
-  CALL Program_Message( PROGRAM_NAME, &
-    'Check/example program for the CRTM Forward and K-Matrix functions using '//&
-    ENDIAN_TYPE//' coefficient datafiles', &
-    'CRTM Version: '//TRIM(Version) )
-
-
-
-  ! ============================================================================
-  ! STEP 4. **** INITIALIZE THE CRTM ****
-  !
-  ! 4a. Initialise all the sensors at once
-  ! --------------------------------------
-  ! ... Cloud coefficient information
-  IF ( Cloud_Model /= 'CRTM' ) THEN
-      Cloud_Scheme = Cloud_Model//'.'
-  ELSE
-      Cloud_Scheme = ' '
-  END IF
-  ! ... Aerosol coefficient information
-  IF ( Aerosol_Model /= 'CRTM' ) THEN
-      Aerosol_Scheme = Aerosol_Model//'.'
-  ELSE
-      Aerosol_Scheme = ' '
-  END IF
-  ! ... Coefficient table format
-  IF ( Coeff_Format == 'Binary' ) THEN
-    AerosolCoeff_Format = 'Binary'
-    AerosolCoeff_File   = 'AerosolCoeff.'//TRIM(Aerosol_Scheme)//'bin'
-    CloudCoeff_Format   = 'Binary'
-    CloudCoeff_File     = 'CloudCoeff.'//TRIM(Cloud_Scheme)//'bin'
-  ELSE IF ( Coeff_Format == 'netCDF' ) THEN
-    AerosolCoeff_Format = 'netCDF'
-    AerosolCoeff_File   = 'AerosolCoeff.'//TRIM(Aerosol_Scheme)//'nc4'
-    CloudCoeff_Format   = 'netCDF'
-    CloudCoeff_File     = 'CloudCoeff.'//TRIM(Cloud_Scheme)//'nc4'
-  END IF
-
-  WRITE( *,'(/5x,"Initializing the CRTM...")' )
-  err_stat = CRTM_Init( SENSOR_ID, &
-                        chinfo, &
-                        Aerosol_Model, &
-                        AerosolCoeff_Format, &
-                        AerosolCoeff_File, &
-                        Cloud_Model, &
-                        CloudCoeff_Format, &
-                        CloudCoeff_File, &
-                        File_Path=COEFFICIENT_PATH, &
-                        NC_File_Path=NC_COEFFICIENT_PATH, &
-                        Quiet=.TRUE.)
-  IF ( err_stat /= SUCCESS ) THEN
-    message = 'Error initializing CRTM'
-    CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-    STOP
-  END IF
-
-  ! 4b. Output some channel information
-  ! -----------------------------------
-  n_channels = SUM(CRTM_ChannelInfo_n_Channels(chinfo))
-  WRITE( *,'(/5x,"Processing a total of ",i0," channels...")' ) n_channels
-  DO n = 1, N_SENSORS
-    WRITE( *,'(7x,i0," from ",a)' ) &
-      CRTM_ChannelInfo_n_Channels(chinfo(n)), TRIM(SENSOR_ID(n))
-  END DO
-  ! ============================================================================
-
-
-
-  ! Begin loop over sensors
-  ! ----------------------
-  Sensor_Loop: DO n = 1, N_SENSORS
-
-    ! ==========================================================================
-    ! STEP 5. **** ALLOCATE STRUCTURE ARRAYS ****
-    !
-    ! 5a. Determine the number of channels
-    !     for the current sensor
-    ! ------------------------------------
-    n_channels = CRTM_ChannelInfo_n_Channels(chinfo(n))
-
-    ! 5b. Allocate the ARRAYS
-    ! -----------------------
-    ALLOCATE( rts( n_channels, N_PROFILES ), &
-              atm_K( n_channels, N_PROFILES ), &
-              sfc_K( n_channels, N_PROFILES ), &
-              rts_K( n_channels, N_PROFILES ), &
-              STAT = alloc_stat )
-    IF ( alloc_stat /= 0 ) THEN
-      message = 'Error allocating structure arrays'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-
-
-    ! 5c. Allocate the STRUCTURE INTERNALS
-    !     NOTE: Only the Atmosphere structures
-    !           are allocated in this example
-    ! ----------------------------------------
-    ! The input FORWARD structure
-    CALL CRTM_Atmosphere_Create( atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
-    IF ( ANY(.NOT. CRTM_Atmosphere_Associated(atm)) ) THEN
-      message = 'Error allocating CRTM Forward Atmosphere structure'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-
-    ! The output K-MATRIX structure
-    CALL CRTM_Atmosphere_Create( atm_K, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
-    IF ( ANY(.NOT. CRTM_Atmosphere_Associated(atm_K)) ) THEN
-      message = 'Error allocating CRTM K-matrix Atmosphere structure'
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-    ! ==========================================================================
-
-    ! ==========================================================================
-    ! STEP 6. **** ASSIGN INPUT DATA ****
-    !
-    ! 6a. Atmosphere and Surface input
-    !     NOTE: that this is the hard part (in my opinion :o). The mechanism by
-    !     by which the atmosphere and surface data are loaded in to their
-    !     respective structures below was done purely to keep the step-by-step
-    !     instructions in this program relatively "clean".
-    ! ------------------------------------------------------------------------
-    CALL Load_Atm_Data()
-    CALL Load_Sfc_Data()
-    DO m = 1, 2
-      DO nc = 1, atm(m)%n_Clouds
-        WHERE(atm(m)%Cloud(nc)%Water_Content > ZERO) atm(m)%Cloud_Fraction = ZERO
-      END DO
-    END DO
-
-    ! The true fractional cloud fraction cases
-    atm(3) = atm(1)
-    atm(4) = atm(2)
-    sfc(3) = sfc(1)
-    sfc(4) = sfc(2)
-    DO m = 3, 4
-      DO nc = 1, atm(m)%n_Clouds
-        WHERE(atm(m)%Cloud(nc)%Water_Content > ZERO) atm(m)%Cloud_Fraction = 0.1426_fp
-      END DO
-    END DO
-
-    ! 6b. Geometry input
-    ! ------------------
-    ! All profiles are given the same value
-    !  The Sensor_Scan_Angle is optional.
-    CALL CRTM_Geometry_SetValue( geo, &
-                                 Sensor_Zenith_Angle = ZENITH_ANGLE, &
-                                 Sensor_Scan_Angle   = SCAN_ANGLE )
-    ! ==========================================================================
-
-
-
-
-    ! ==========================================================================
-    ! STEP 7. **** INITIALIZE THE K-MATRIX ARGUMENTS ****
-    !
-    ! 7a. Zero the K-matrix OUTPUT structures
-    ! ---------------------------------------
-    CALL CRTM_Atmosphere_Zero( atm_K )
-    CALL CRTM_Surface_Zero( sfc_K )
-
-
-    ! 7b. Inintialize the K-matrix INPUT so
-    !     that the results are dTb/dx
-    ! -------------------------------------
-    rts_K%Radiance               = ZERO
-    rts_K%Brightness_Temperature = ONE
-    ! ==========================================================================
-
-    ! ==========================================================================
-    ! STEP 8. **** CALL THE CRTM FUNCTIONS FOR THE CURRENT SENSOR ****
-    !
-    WRITE( *, '( /5x, "Calling the CRTM functions for ",a,"..." )' ) TRIM(SENSOR_ID(n))
-
-    ! 8a. The forward model
-    ! ---------------------
-    err_stat = CRTM_Forward( atm        , &  ! Input
-                             sfc        , &  ! Input
-                             geo        , &  ! Input
-                             chinfo(n:n), &  ! Input
-                             rts          )  ! Output
-    IF ( err_stat /= SUCCESS ) THEN
-      message = 'Error calling CRTM Forward Model for '//TRIM(SENSOR_ID(n))
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-
-
-    ! 8b. The K-matrix model
-    ! ----------------------
-    err_stat = CRTM_K_Matrix( atm        , &  ! FORWARD  Input
-                              sfc        , &  ! FORWARD  Input
-                              rts_K      , &  ! K-MATRIX Input
-                              geo        , &  ! Input
-                              chinfo(n:n), &  ! Input
-                              atm_K      , &  ! K-MATRIX Output
-                              sfc_K      , &  ! K-MATRIX Output
-                              rts          )  ! FORWARD  Output
-    IF ( err_stat /= SUCCESS ) THEN
-      message = 'Error calling CRTM K-Matrix Model for '//TRIM(SENSOR_ID(n))
-      CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-      STOP
-    END IF
-    ! ==========================================================================
-
-   ! ============================================================================
-   ! 8c. **** OUTPUT THE RESULTS TO SCREEN ****
-   !
-   ! User should read the user guide or the source code of the routine
-   ! CRTM_RTSolution_Inspect in the file CRTM_RTSolution_Define.f90 to
-   ! select the needed variables for outputs.  These variables are contained
-   ! in the structure RTSolution.
-   DO m = 1, N_PROFILES
-     WRITE( *,'(//7x,"Profile ",i0," output for ",a )') m, TRIM(Sensor_Id(n))
-     DO l = 1, n_Channels
-       WRITE( *, '(/5x,"Channel ",i0," results")') chinfo(n)%Sensor_Channel(l)
-       CALL CRTM_RTSolution_Inspect(rts(l,m))
-       CALL CRTM_RTSolution_Inspect(rts_K(l,m))
-       CALL CRTM_Atmosphere_Inspect(atm_K(l,m))
-       CALL CRTM_Surface_Inspect(sfc_K(l,m))
-
-     END DO
-     CALL CRTM_Atmosphere_Inspect(atm(m))
-     CALL CRTM_Surface_Inspect(sfc(m))
-   END DO
-
-
-    ! ==========================================================================
-    ! STEP 9. **** CLEAN UP FOR NEXT SENSOR ****
-    !
-    ! 9a. Deallocate the structures
-    ! -----------------------------
-    CALL CRTM_Atmosphere_Destroy(atm_K)
-    CALL CRTM_Atmosphere_Destroy(atm)
-
-
-    ! 9b. Deallocate the arrays
-    ! -------------------------
-    DEALLOCATE(rts, rts_K, sfc_k, atm_k, STAT = alloc_stat)
-    ! ==========================================================================
-
-  END DO Sensor_Loop
-
-
-  ! ==========================================================================
-  ! 10. **** DESTROY THE CRTM ****
-  !
-  WRITE( *, '( /5x, "Destroying the CRTM..." )' )
-  err_stat = CRTM_Destroy( chinfo )
-  IF ( err_stat /= SUCCESS ) THEN
-    message = 'Error destroying CRTM'
-    CALL Display_Message( PROGRAM_NAME, message, FAILURE )
-    STOP
-  END IF
-  ! ==========================================================================
-
-
-
-
-  ! ==========================================================================
-  ! 11. **** CREATE A SIGNAL FILE FOR TESTING SUCCESS ****
-  !
-  ! This step is just to allow the CRTM library build process
-  ! to detect success or failure at the shell level
-  CALL SignalFile_Create()
-  ! ==========================================================================
-
-
-CONTAINS
-
-
-  ! ==========================================================================
-  !                Below are some internal procedures that load the
-  !                necessary input structures with some pretend data
-  ! ==========================================================================
-
-  !
-  ! Internal subprogam to load some test profile data
+  ! Include file containing an internal subprogam to load some test profile data
   !
   SUBROUTINE Load_Atm_Data()
     ! Local variables
@@ -480,20 +56,6 @@ CONTAINS
       259.358_fp, 261.010_fp, 262.779_fp, 264.702_fp, 266.711_fp, 268.863_fp, 271.103_fp, 272.793_fp, &
       273.356_fp, 273.356_fp, 273.356_fp, 273.356_fp/)
 
-    atm(1)%Relative_Humidity = &
-    (/0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp/)
-
     atm(1)%Absorber(:,1) = &
     (/4.187E-03_fp,4.401E-03_fp,4.250E-03_fp,3.688E-03_fp,3.516E-03_fp,3.739E-03_fp,3.694E-03_fp,3.449E-03_fp, &
       3.228E-03_fp,3.212E-03_fp,3.245E-03_fp,3.067E-03_fp,2.886E-03_fp,2.796E-03_fp,2.704E-03_fp,2.617E-03_fp, &
@@ -542,11 +104,11 @@ CONTAINS
       END DO
     END IF
 
+    
     ! Aerosol data. Three aerosol types can be loaded:
     !   Dust, Sulphate, and Sea Salt SSCM3
     Load_Aerosol_Data_1: IF ( atm(1)%n_Aerosols > 0 ) THEN
-
-      atm(1)%Aerosol(1)%Type = 1 ! dust (CRTM, CMAQ, GOCART-GEOS5)
+      atm(1)%Aerosol(1)%Type = DUST_AEROSOL
       atm(1)%Aerosol(1)%Effective_Radius = & ! microns
       (/0.000000E+00_fp, 0.000000E+00_fp, &
         0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, &
@@ -587,31 +149,9 @@ CONTAINS
         1.955759E-03_fp, 1.999206E-03_fp, 1.994698E-03_fp, 1.913109E-03_fp, 1.656122E-03_fp, &
         1.206328E-03_fp, 6.847261E-04_fp, 2.785695E-04_fp, 7.418821E-05_fp, 1.172680E-05_fp, &
         9.900895E-07_fp, 3.987399E-08_fp, 6.786932E-10_fp, 4.291151E-12_fp, 8.785440E-15_fp/)
-      IF ( Aerosol_Model== 'CMAQ' ) THEN
-        atm(1)%Aerosol(1)%Effective_Variance = & ! N/A
-        (/1.0500000E+00_fp, 1.500000E+00_fp, &
-          1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-          1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-          1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-          1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-          1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-          1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-          1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-          1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-          1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-          2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-          2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-          2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-          2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-          2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-          2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-          1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-          1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-          1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-      END IF
-
+        
       IF ( atm(1)%n_Aerosols > 1 ) THEN
-        atm(1)%Aerosol(2)%Type = 8 ! sulfate (CRTM), dust-like (CMAQ), Nitrate (GOCART-GEOS5)
+        atm(1)%Aerosol(2)%Type = SULFATE_AEROSOL
         atm(1)%Aerosol(2)%Effective_Radius = & ! microns
         (/0.000000E+00_fp, 0.000000E+00_fp, &
           0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, &
@@ -652,34 +192,10 @@ CONTAINS
           1.615474E-05_fp, 9.509965E-06_fp, 1.672265E-05_fp, 4.602962E-05_fp, 8.740809E-05_fp, &
           1.165118E-04_fp, 1.248318E-04_fp, 1.240508E-04_fp, 1.095622E-04_fp, 7.116027E-05_fp, &
           2.756351E-05_fp, 5.072010E-06_fp, 3.467497E-07_fp, 6.759169E-09_fp, 2.828000E-11_fp/)
-          IF ( Aerosol_Model== 'CMAQ' ) THEN
-            atm(1)%Aerosol(2)%Effective_Variance = & ! N/A
-            (/1.050000E+00_fp, 1.500000E+00_fp, &
-              1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-              1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-              1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-              1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-              1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-              1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-              1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-              1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-              1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-              2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-              2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-              2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-              2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-              2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-              2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-              1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-              1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-              1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-          END IF
       END IF
-
-
+      
       IF ( atm(1)%n_Aerosols > 2 ) THEN
-
-        atm(1)%Aerosol(3)%Type = 5 ! SEASALT_SSCM3_AEROSOL (CRTM), Sea salt (CMAQ), Black carbon (GOCART-GEOS5)
+        atm(1)%Aerosol(3)%Type = SEASALT_SSCM3_AEROSOL
         atm(1)%Aerosol(3)%Effective_Radius = & ! microns
         (/7.600000E+00_fp, 7.600000E+00_fp, &
           7.600000E+00_fp, 7.600000E+00_fp, 7.600000E+00_fp, 7.600000E+00_fp, 7.600000E+00_fp, &
@@ -720,28 +236,6 @@ CONTAINS
           2.735688E-04_fp, 3.486493E-04_fp, 3.889143E-04_fp, 3.997242E-04_fp, 3.991008E-04_fp, &
           3.826235E-04_fp, 3.287943E-04_fp, 2.344766E-04_fp, 1.275907E-04_fp, 4.835821E-05_fp, &
           1.156687E-05_fp, 1.570009E-06_fp, 1.078885E-07_fp, 3.321985E-09_fp, 4.023206E-11_fp/)
-          IF ( Aerosol_Model== 'CMAQ' ) THEN
-            atm(1)%Aerosol(3)%Effective_Variance = & ! N/A
-            (/1.050000E+00_fp, 1.500000E+00_fp, &
-              1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-              1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-              1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-              1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-              1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-              1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-              1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-              1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-              1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-              2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-              2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-              2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-              2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-              2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-              2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-              1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-              1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-              1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-          END IF
       END IF
     END IF Load_Aerosol_Data_1
 
@@ -796,20 +290,6 @@ CONTAINS
       295.609_fp, 298.173_fp, 300.787_fp, 303.379_fp, 305.960_fp, 308.521_fp, 310.916_fp, 313.647_fp, &
       315.244_fp, 315.244_fp, 315.244_fp, 315.244_fp/)
 
-    atm(2)%Relative_Humidity = &
-    (/0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp,&
-      0.5_fp, 0.5_fp, 0.5_fp, 0.5_fp/)
-
     atm(2)%Absorber(:,1) = &
     (/3.887E-03_fp,3.593E-03_fp,3.055E-03_fp,2.856E-03_fp,2.921E-03_fp,2.555E-03_fp,2.392E-03_fp,2.605E-03_fp, &
       2.573E-03_fp,2.368E-03_fp,2.354E-03_fp,2.333E-03_fp,2.312E-03_fp,2.297E-03_fp,2.287E-03_fp,2.283E-03_fp, &
@@ -858,6 +338,7 @@ CONTAINS
         3.300e+02_fp,3.300e+02_fp,3.300e+02_fp,3.300e+02_fp /)
     END IF
 
+      
     ! Cloud data
     IF ( atm(2)%n_Clouds > 0 ) THEN
       k1 = 73
@@ -866,15 +347,15 @@ CONTAINS
         atm(2)%Cloud(nc)%Type = RAIN_CLOUD
         atm(2)%Cloud(nc)%Effective_Radius(k1:k2) = 1000.0_fp ! microns
         atm(2)%Cloud(nc)%Water_Content(k1:k2)    =    5.0_fp ! kg/m^2
-      END DO
+      END DO 
     END IF
-
-
+    
+    
     ! Aerosol data. Three aerosol types can be loaded:
     !   Sea Sat SSAM, Sea Salt SSCM1, and Sea Salt SSCM2
     Load_Aerosol_Data_2: IF ( atm(2)%n_Aerosols > 0 ) THEN
-
-      atm(2)%Aerosol(1)%Type = 2 ! SEASALT_SSAM_AEROSOL (CRTM), Soot (CMAQ), Sea salt (GOCART-GEOS5)
+    
+      atm(2)%Aerosol(1)%Type = SEASALT_SSAM_AEROSOL
       atm(2)%Aerosol(1)%Effective_Radius = & ! microns
       (/0.000000E+00_fp, 0.000000E+00_fp, &
         0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, &
@@ -915,31 +396,9 @@ CONTAINS
         5.939634E-04_fp, 7.091114E-04_fp, 8.104756E-04_fp, 8.911259E-04_fp, 9.478373E-04_fp, &
         9.814733E-04_fp, 9.964914E-04_fp, 9.999501E-04_fp, 9.994838E-04_fp, 9.921395E-04_fp, &
         9.678320E-04_fp, 9.171414E-04_fp, 8.337592E-04_fp, 7.173667E-04_fp, 5.757384E-04_fp/)
-      IF ( Aerosol_Model== 'CMAQ' ) THEN
-        atm(2)%Aerosol(1)%Effective_Variance = & ! N/A
-        (/1.050000E+00_fp, 1.500000E+00_fp, &
-          1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-          1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-          1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-          1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-          1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-          1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-          1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-          1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-          1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-          2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-          2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-          2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-          2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-          2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-          2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-          1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-          1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-          1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-      END IF
-
+        
       IF ( atm(2)%n_Aerosols > 1 ) THEN
-        atm(2)%Aerosol(2)%Type = 3 ! SEASALT_SSCM1_AEROSOL (CRTM), Water soluble (CMAQ), Organic carbon (GOCART-GEOS5)
+        atm(2)%Aerosol(2)%Type = SEASALT_SSCM1_AEROSOL
         atm(2)%Aerosol(2)%Effective_Radius = & ! microns
         (/0.000000E+00_fp, 0.000000E+00_fp, &
           0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, &
@@ -980,32 +439,10 @@ CONTAINS
           9.116027E-12_fp, 3.241673E-10_fp, 6.673036E-09_fp, 8.162075E-08_fp, 6.123529E-07_fp, &
           2.926244E-06_fp, 9.306878E-06_fp, 2.071874E-05_fp, 3.418072E-05_fp, 4.455191E-05_fp, &
           4.926597E-05_fp, 5.000000E-05_fp, 4.924296E-05_fp, 4.412128E-05_fp, 3.247284E-05_fp/)
-        IF ( Aerosol_Model== 'CMAQ' ) THEN
-          atm(2)%Aerosol(2)%Effective_Variance = & ! N/A
-          (/1.050000E+00_fp, 1.500000E+00_fp, &
-            1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-            1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-            1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-            1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-            1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-            1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-            1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-            1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-            1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-            2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-            2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-            2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-            2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-            2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-            2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-            1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-            1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-            1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-        END IF
       END IF
-
+      
       IF ( atm(2)%n_Aerosols > 2 ) THEN
-        atm(2)%Aerosol(3)%Type = 4 ! SEASALT_SSCM2_AEROSOL (CRTM), Sulfate (CMAQ), Organic carbon (GOCART-GEOS5)
+        atm(2)%Aerosol(3)%Type = SEASALT_SSCM2_AEROSOL
         atm(2)%Aerosol(3)%Effective_Radius = & ! microns
         (/0.000000E+00_fp, 0.000000E+00_fp, &
           0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, 0.000000E+00_fp, &
@@ -1046,102 +483,7 @@ CONTAINS
           4.103532E-05_fp, 5.229739E-05_fp, 5.833714E-05_fp, 5.995863E-05_fp, 5.986513E-05_fp, &
           5.739352E-05_fp, 4.931915E-05_fp, 3.517150E-05_fp, 1.913860E-05_fp, 7.253731E-06_fp, &
           1.735030E-06_fp, 2.355013E-07_fp, 1.618327E-08_fp, 4.982977E-10_fp, 6.034809E-12_fp/)
-        IF ( Aerosol_Model== 'CMAQ' ) THEN
-          atm(2)%Aerosol(3)%Effective_Variance = & ! N/A
-          (/1.050000E+00_fp, 1.500000E+00_fp, &
-            1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, 1.100000E+00_fp, &
-            1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-            1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, 1.300000E+00_fp, &
-            1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, 1.400000E+00_fp, &
-            1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-            1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, 1.600000E+00_fp, &
-            1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, &
-            1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, 1.800000E+00_fp, &
-            1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, 1.900000E+00_fp, &
-            2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, 2.000000E+00_fp, &
-            2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, 2.100000E+00_fp, &
-            2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, 2.200000E+00_fp, &
-            2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, 2.300000E+00_fp, &
-            2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, 2.400000E+00_fp, &
-            2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, 2.500000E+00_fp, &
-            1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, 1.200000E+00_fp, &
-            1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, 1.500000E+00_fp, &
-            1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp, 1.700000E+00_fp/)
-        END IF
       END IF
     END IF Load_Aerosol_Data_2
 
   END SUBROUTINE Load_Atm_Data
-
-
-  !
-  ! Internal subprogam to load some test surface data
-  !
-  SUBROUTINE Load_Sfc_Data()
-
-
-    ! 4a.0 Surface type definitions for default SfcOptics definitions
-    !      For IR and VIS, this is the NPOESS reflectivities.
-    ! ---------------------------------------------------------------
-    INTEGER, PARAMETER :: TUNDRA_SURFACE_TYPE         = 10  ! NPOESS Land surface type for IR/VIS Land SfcOptics
-    INTEGER, PARAMETER :: SCRUB_SURFACE_TYPE          =  7  ! NPOESS Land surface type for IR/VIS Land SfcOptics
-    INTEGER, PARAMETER :: COARSE_SOIL_TYPE            =  1  ! Soil type                for MW land SfcOptics
-    INTEGER, PARAMETER :: GROUNDCOVER_VEGETATION_TYPE =  7  ! Vegetation type          for MW Land SfcOptics
-    INTEGER, PARAMETER :: BARE_SOIL_VEGETATION_TYPE   = 11  ! Vegetation type          for MW Land SfcOptics
-    INTEGER, PARAMETER :: SEA_WATER_TYPE              =  1  ! Water type               for all SfcOptics
-    INTEGER, PARAMETER :: FRESH_SNOW_TYPE             =  2  ! NPOESS Snow type         for IR/VIS SfcOptics
-    INTEGER, PARAMETER :: FRESH_ICE_TYPE              =  1  ! NPOESS Ice type          for IR/VIS SfcOptics
-
-
-
-    ! 4a.1 Profile #1
-    ! ---------------
-    ! ...Land surface characteristics
-    sfc(1)%Land_Coverage     = 0.1_fp
-    sfc(1)%Land_Type         = TUNDRA_SURFACE_TYPE
-    sfc(1)%Land_Temperature  = 272.0_fp
-    sfc(1)%Lai               = 0.17_fp
-    sfc(1)%Soil_Type         = COARSE_SOIL_TYPE
-    sfc(1)%Vegetation_Type   = GROUNDCOVER_VEGETATION_TYPE
-    ! ...Water surface characteristics
-    sfc(1)%Water_Coverage    = 0.5_fp
-    sfc(1)%Water_Type        = SEA_WATER_TYPE
-    sfc(1)%Water_Temperature = 275.0_fp
-    ! ...Snow coverage characteristics
-    sfc(1)%Snow_Coverage    = 0.25_fp
-    sfc(1)%Snow_Type        = FRESH_SNOW_TYPE
-    sfc(1)%Snow_Temperature = 265.0_fp
-    ! ...Ice surface characteristics
-    sfc(1)%Ice_Coverage    = 0.15_fp
-    sfc(1)%Ice_Type        = FRESH_ICE_TYPE
-    sfc(1)%Ice_Temperature = 269.0_fp
-
-
-
-    ! 4a.2 Profile #2
-    ! ---------------
-    ! Surface data
-    sfc(2)%Land_Coverage    = 1.0_fp
-    sfc(2)%Land_Type        = SCRUB_SURFACE_TYPE
-    sfc(2)%Land_Temperature = 318.0_fp
-    sfc(2)%Lai              = 0.65_fp
-    sfc(2)%Soil_Type        = COARSE_SOIL_TYPE
-    sfc(2)%Vegetation_Type  = BARE_SOIL_VEGETATION_TYPE
-
-  END SUBROUTINE Load_Sfc_Data
-
-
-  !
-  ! Internal subprogam to create a signal file
-  !
-  SUBROUTINE SignalFile_Create()
-    CHARACTER(256) :: Filename
-    INTEGER :: fid
-    Filename = '.signal'
-    fid = Get_Lun()
-    OPEN( fid, FILE = Filename )
-    WRITE( fid,* ) TRIM(Filename)
-    CLOSE( fid )
-  END SUBROUTINE SignalFile_Create
-
-END PROGRAM check_crtm

--- a/test/mains/regression/forward/test_OMPoverChannels/Load_Sfc_Data.inc
+++ b/test/mains/regression/forward/test_OMPoverChannels/Load_Sfc_Data.inc
@@ -1,0 +1,55 @@
+  !
+  ! Include file containing an internal subprogam to load some test surface data
+  !
+  SUBROUTINE Load_Sfc_Data()
+    
+    
+    ! 4a.0 Surface type definitions for default SfcOptics definitions
+    !      For IR and VIS, this is the NPOESS reflectivities.
+    ! ---------------------------------------------------------------
+    INTEGER, PARAMETER :: TUNDRA_SURFACE_TYPE         = 10  ! NPOESS Land surface type for IR/VIS Land SfcOptics
+    INTEGER, PARAMETER :: SCRUB_SURFACE_TYPE          =  7  ! NPOESS Land surface type for IR/VIS Land SfcOptics
+    INTEGER, PARAMETER :: COARSE_SOIL_TYPE            =  1  ! Soil type                for MW land SfcOptics
+    INTEGER, PARAMETER :: GROUNDCOVER_VEGETATION_TYPE =  7  ! Vegetation type          for MW Land SfcOptics
+    INTEGER, PARAMETER :: BARE_SOIL_VEGETATION_TYPE   = 11  ! Vegetation type          for MW Land SfcOptics
+    INTEGER, PARAMETER :: SEA_WATER_TYPE              =  1  ! Water type               for all SfcOptics
+    INTEGER, PARAMETER :: FRESH_SNOW_TYPE             =  2  ! NPOESS Snow type         for IR/VIS SfcOptics
+    INTEGER, PARAMETER :: FRESH_ICE_TYPE              =  1  ! NPOESS Ice type          for IR/VIS SfcOptics
+
+
+
+    ! 4a.1 Profile #1
+    ! ---------------
+    ! ...Land surface characteristics
+    sfc(1)%Land_Coverage     = 0.1_fp
+    sfc(1)%Land_Type         = TUNDRA_SURFACE_TYPE
+    sfc(1)%Land_Temperature  = 272.0_fp
+    sfc(1)%Lai               = 0.17_fp
+    sfc(1)%Soil_Type         = COARSE_SOIL_TYPE
+    sfc(1)%Vegetation_Type   = GROUNDCOVER_VEGETATION_TYPE
+    ! ...Water surface characteristics
+    sfc(1)%Water_Coverage    = 0.5_fp
+    sfc(1)%Water_Type        = SEA_WATER_TYPE
+    sfc(1)%Water_Temperature = 275.0_fp
+    ! ...Snow coverage characteristics
+    sfc(1)%Snow_Coverage    = 0.25_fp
+    sfc(1)%Snow_Type        = FRESH_SNOW_TYPE
+    sfc(1)%Snow_Temperature = 265.0_fp
+    ! ...Ice surface characteristics
+    sfc(1)%Ice_Coverage    = 0.15_fp
+    sfc(1)%Ice_Type        = FRESH_ICE_TYPE
+    sfc(1)%Ice_Temperature = 269.0_fp
+
+
+
+    ! 4a.2 Profile #2
+    ! ---------------
+    ! Surface data
+    sfc(2)%Land_Coverage    = 1.0_fp
+    sfc(2)%Land_Type        = SCRUB_SURFACE_TYPE
+    sfc(2)%Land_Temperature = 318.0_fp
+    sfc(2)%Lai              = 0.65_fp
+    sfc(2)%Soil_Type        = COARSE_SOIL_TYPE
+    sfc(2)%Vegetation_Type  = BARE_SOIL_VEGETATION_TYPE
+
+  END SUBROUTINE Load_Sfc_Data

--- a/test/mains/regression/forward/test_OMPoverChannels/Makefile.in
+++ b/test/mains/regression/forward/test_OMPoverChannels/Makefile.in
@@ -1,0 +1,65 @@
+# @configure_input@
+
+# individual test makefile template
+
+# The file definitions. This include must occur before targets.
+EXE_FILE=$(shell echo ${PWD} | sed 's,.*/,,')
+SRC_FILE=$(EXE_FILE).f90
+OBJ_FILE=${SRC_FILE:.f90=.o}
+
+# The test type (e.g. forward, k_matrix, etc)
+TEST_TYPE=`dirname ${PWD} | sed 's,.*/,,'`
+
+# Tool-specific substitution variables
+FC      = @FC@
+FCFLAGS = @FCFLAGS@ -I../../incsrc
+LDFLAGS = @LDFLAGS@
+LIBS    = @LIBS@
+
+# The targets
+all: $(EXE_FILE)
+
+$(OBJ_FILE): $(SRC_FILE)
+
+$(EXE_FILE): $(OBJ_FILE)
+	@echo; echo; \
+	echo "=============================================="; \
+	echo "Building $(TEST_TYPE) $(EXE_FILE) using:"; \
+	echo "  FC      : $(FC)"; \
+	echo "  FCFLAGS : $(FCFLAGS)"; \
+	echo "  LDFLAGS : $(LDFLAGS)"; \
+	echo "=============================================="
+	$(FC) $(LDFLAGS) $(OBJ_FILE) -o $(EXE_FILE) $(LIBS)
+
+clean:
+	@echo; echo; \
+	echo "=============================================="; \
+	echo "Cleaning up $(TEST_TYPE) $(EXE_FILE)"; \
+	echo "=============================================="
+	rm -fr $(OBJ_FILE) $(EXE_FILE) gmon.out *.output *.bin results/*.signal
+
+update:
+	@update() \
+	{ files=`find . -maxdepth 1 -name "$$1" -print`; \
+	  if [ -n "$$files" ]; then \
+	    mv $$files results; \
+	  else \
+	    echo "No $$1 files to update."; \
+	  fi \
+	}; \
+	echo; echo; \
+	echo "=============================================="; \
+	echo "Updating results for $(TEST_TYPE) $(EXE_FILE)"; \
+	echo "=============================================="; \
+	update "*.output"; update "*.bin"
+
+realclean: clean
+	-rm Makefile
+
+# Specify targets that do not generate filesystem objects
+.PHONY: all clean update realclean
+
+# Specify suffix rules
+.SUFFIXES: .f90 .o
+.f90.o:
+	@$(FC) $(FCFLAGS) -c $<

--- a/test/mains/regression/forward/test_OMPoverChannels/Map_To_NCEP_Model_Coordinates.inc
+++ b/test/mains/regression/forward/test_OMPoverChannels/Map_To_NCEP_Model_Coordinates.inc
@@ -1,0 +1,161 @@
+  ! 
+  ! Include file containing an internal subprogram to map
+  ! atmospheres to representative NCEP model coordinates
+  !
+  SUBROUTINE Map_To_NCEP_Model_Coordinates() 
+    ! Local parameter
+    REAL(fp), PARAMETER :: PRESSURE_DIFFERENCE_FILL_VALUE = 1500.0_fp
+    ! Local variables
+    INTEGER :: n_Profiles
+    INTEGER :: Best_Match_Index
+    REAL(fp) :: Pressure_Difference
+    ! Layer counters
+    INTEGER :: k, kr, kg
+    ! Profile counter
+    INTEGER :: m
+    
+    n_Profiles = SIZE(Atm)
+    
+    ! Assign profile 1 vertical coordinates 
+    Atm_NAM(1)%Pressure = &
+    (/7.557_fp,  18.680_fp,  29.832_fp,  41.024_fp,  52.266_fp,  63.614_fp, &
+     75.140_fp,  86.867_fp,  98.898_fp, 111.283_fp, 124.021_fp, 137.265_fp, &                               
+    151.065_fp, 165.624_fp, 181.345_fp, 198.683_fp, 217.994_fp, 239.376_fp, &                               
+    263.135_fp, 289.310_fp, 317.552_fp, 347.341_fp, 378.054_fp, 409.310_fp, &                               
+    441.043_fp, 473.178_fp, 505.540_fp, 537.933_fp, 570.153_fp, 602.116_fp, &                               
+    633.675_fp, 664.585_fp, 694.747_fp, 723.816_fp, 751.247_fp, 776.696_fp, &                               
+    799.965_fp, 821.053_fp, 839.864_fp, 856.496_fp, 871.196_fp, 884.014_fp, &                               
+    895.245_fp, 904.942_fp, 913.304_fp, 920.824_fp, 927.750_fp, 934.330_fp, &                               
+    940.613_fp, 946.599_fp, 952.337_fp, 957.878_fp, 963.221_fp, 968.415_fp, &                               
+    973.510_fp, 978.506_fp, 983.403_fp, 988.202_fp, 992.940_fp, 997.651_fp/)                                
+    Atm_NAM(1)%Level_Pressure = &
+    (/2.000_fp,  13.114_fp,  24.246_fp,  35.417_fp,  46.629_fp,  57.902_fp, &
+     69.326_fp,  80.953_fp,  92.781_fp, 105.014_fp, 117.551_fp, 130.492_fp, &                                     
+    144.039_fp, 158.092_fp, 173.156_fp, 189.534_fp, 207.833_fp, 228.154_fp, &                                     
+    250.598_fp, 275.671_fp, 302.949_fp, 332.154_fp, 362.528_fp, 393.579_fp, &                                     
+    425.042_fp, 457.045_fp, 489.310_fp, 521.770_fp, 554.095_fp, 586.211_fp, &                                     
+    618.021_fp, 649.329_fp, 679.840_fp, 709.653_fp, 737.978_fp, 764.517_fp, &                                     
+    788.875_fp, 811.054_fp, 831.053_fp, 848.675_fp, 864.316_fp, 878.076_fp, &                                     
+    889.952_fp, 900.539_fp, 909.346_fp, 917.262_fp, 924.386_fp, 931.114_fp, &                                     
+    937.546_fp, 943.680_fp, 949.518_fp, 955.157_fp, 960.598_fp, 965.843_fp, &                                     
+    970.987_fp, 976.032_fp, 980.980_fp, 985.827_fp, 990.577_fp, 995.302_fp, &                                     
+   1000.000_fp/)                                                                                                  
+    Atm_GFS(1)%Pressure = &
+    (/0.321_fp,   1.010_fp,   1.798_fp,   2.701_fp,   3.733_fp,   4.914_fp, &
+      6.264_fp,   7.807_fp,   9.570_fp,  11.584_fp,  13.882_fp,  16.503_fp, &
+     19.492_fp,  22.895_fp,  26.769_fp,  31.172_fp,  36.172_fp,  41.842_fp, &
+     48.263_fp,  55.520_fp,  63.709_fp,  72.928_fp,  83.282_fp,  94.879_fp, &
+    107.828_fp, 122.239_fp, 138.215_fp, 155.853_fp, 175.235_fp, 196.427_fp, &                               
+    219.467_fp, 244.369_fp, 271.106_fp, 299.614_fp, 329.784_fp, 361.464_fp, &                               
+    394.453_fp, 428.513_fp, 463.366_fp, 498.709_fp, 534.218_fp, 569.567_fp, &                               
+    604.432_fp, 638.510_fp, 671.523_fp, 703.229_fp, 733.431_fp, 761.972_fp, &                               
+    788.744_fp, 813.681_fp, 836.757_fp, 857.984_fp, 877.401_fp, 895.071_fp, &                               
+    911.079_fp, 925.518_fp, 938.495_fp, 950.117_fp, 960.493_fp, 969.733_fp, &                               
+    977.941_fp, 985.216_fp, 991.651_fp, 997.335_fp/)                                                        
+    Atm_GFS(1)%Level_Pressure = &
+    (/0.001_fp,   0.642_fp,   1.377_fp,   2.219_fp,   3.182_fp,   4.284_fp, &
+      5.544_fp,   6.984_fp,   8.630_fp,  10.510_fp,  12.657_fp,  15.107_fp, &                                     
+     17.900_fp,  21.083_fp,  24.707_fp,  28.830_fp,  33.514_fp,  38.830_fp, &                                     
+     44.854_fp,  51.671_fp,  59.370_fp,  68.048_fp,  77.808_fp,  88.756_fp, &                                     
+    101.002_fp, 114.655_fp, 129.823_fp, 146.607_fp, 165.099_fp, 185.372_fp, &                                     
+    207.481_fp, 231.454_fp, 257.284_fp, 284.928_fp, 314.300_fp, 345.269_fp, &                                     
+    377.659_fp, 411.248_fp, 445.778_fp, 480.955_fp, 516.463_fp, 551.974_fp, &                                     
+    587.160_fp, 621.705_fp, 655.315_fp, 687.730_fp, 718.729_fp, 748.133_fp, &                                     
+    775.811_fp, 801.676_fp, 825.685_fp, 847.830_fp, 868.138_fp, 886.663_fp, &
+    903.479_fp, 918.678_fp, 932.359_fp, 944.631_fp, 955.603_fp, 965.384_fp, & 
+    974.082_fp, 981.799_fp, 988.632_fp, 994.671_fp, 1000.000_fp/)  
+    
+    ! Assign profile 2 vertical coordinates                                              
+    Atm_NAM(2)%Pressure = &
+    (/7.557_fp,  18.680_fp,  29.832_fp,  41.024_fp,  52.266_fp,  63.614_fp, &
+     75.140_fp,  86.867_fp,  98.898_fp, 111.283_fp, 124.021_fp, 137.265_fp, &
+    151.065_fp, 165.624_fp, 181.345_fp, 198.683_fp, 217.994_fp, 239.376_fp, &
+    263.135_fp, 289.310_fp, 317.552_fp, 347.341_fp, 378.054_fp, 409.310_fp, &
+    441.043_fp, 473.178_fp, 505.540_fp, 537.933_fp, 570.153_fp, 602.116_fp, &
+    633.675_fp, 664.585_fp, 694.747_fp, 723.816_fp, 751.247_fp, 776.696_fp, &
+    799.965_fp, 821.053_fp, 839.864_fp, 856.496_fp, 871.196_fp, 884.014_fp, &
+    895.245_fp, 904.942_fp, 913.304_fp, 920.824_fp, 927.750_fp, 934.330_fp, &
+    940.613_fp, 946.599_fp, 952.337_fp, 957.878_fp, 963.221_fp, 968.415_fp, &
+    973.510_fp, 978.506_fp, 983.403_fp, 988.202_fp, 992.940_fp, 997.651_fp/)
+    Atm_NAM(2)%Level_Pressure = &
+    (/2.000_fp,  13.114_fp,  24.246_fp,  35.417_fp,  46.629_fp,  57.902_fp, &
+     69.326_fp,  80.953_fp,  92.781_fp, 105.014_fp, 117.551_fp, 130.492_fp, &
+    144.039_fp, 158.092_fp, 173.156_fp, 189.534_fp, 207.833_fp, 228.154_fp, &
+    250.598_fp, 275.671_fp, 302.949_fp, 332.154_fp, 362.528_fp, 393.579_fp, &
+    425.042_fp, 457.045_fp, 489.310_fp, 521.770_fp, 554.095_fp, 586.211_fp, &
+    618.021_fp, 649.329_fp, 679.840_fp, 709.653_fp, 737.978_fp, 764.517_fp, &
+    788.875_fp, 811.054_fp, 831.053_fp, 848.675_fp, 864.316_fp, 878.076_fp, &
+    889.952_fp, 900.539_fp, 909.346_fp, 917.262_fp, 924.386_fp, 931.114_fp, &
+    937.546_fp, 943.680_fp, 949.518_fp, 955.157_fp, 960.598_fp, 965.843_fp, &
+    970.987_fp, 976.032_fp, 980.980_fp, 985.827_fp, 990.577_fp, 995.302_fp, &
+   1000.000_fp/)
+    Atm_GFS(2)%Pressure = &
+    (/0.321_fp,   1.010_fp,   1.798_fp,   2.701_fp,   3.733_fp,   4.914_fp, &
+      6.264_fp,   7.807_fp,   9.570_fp,  11.584_fp,  13.882_fp,  16.503_fp, &
+     19.492_fp,  22.895_fp,  26.769_fp,  31.172_fp,  36.172_fp,  41.842_fp, &
+     48.263_fp,  55.520_fp,  63.709_fp,  72.928_fp,  83.282_fp,  94.879_fp, &
+    107.828_fp, 122.239_fp, 138.215_fp, 155.853_fp, 175.235_fp, 196.427_fp, &
+    219.467_fp, 244.369_fp, 271.106_fp, 299.614_fp, 329.784_fp, 361.464_fp, &
+    394.453_fp, 428.513_fp, 463.366_fp, 498.709_fp, 534.218_fp, 569.567_fp, &
+    604.432_fp, 638.510_fp, 671.523_fp, 703.229_fp, 733.431_fp, 761.972_fp, &
+    788.744_fp, 813.681_fp, 836.757_fp, 857.984_fp, 877.401_fp, 895.071_fp, &
+    911.079_fp, 925.518_fp, 938.495_fp, 950.117_fp, 960.493_fp, 969.733_fp, &
+    977.941_fp, 985.216_fp, 991.651_fp, 997.335_fp/)
+    Atm_GFS(2)%Level_Pressure = &
+    (/0.001_fp,   0.642_fp,   1.377_fp,   2.219_fp,   3.182_fp,   4.284_fp, &
+      5.544_fp,   6.984_fp,   8.630_fp,  10.510_fp,  12.657_fp,  15.107_fp, &
+     17.900_fp,  21.083_fp,  24.707_fp,  28.830_fp,  33.514_fp,  38.830_fp, &
+     44.854_fp,  51.671_fp,  59.370_fp,  68.048_fp,  77.808_fp,  88.756_fp, &
+    101.002_fp, 114.655_fp, 129.823_fp, 146.607_fp, 165.099_fp, 185.372_fp, &
+    207.481_fp, 231.454_fp, 257.284_fp, 284.928_fp, 314.300_fp, 345.269_fp, &
+    377.659_fp, 411.248_fp, 445.778_fp, 480.955_fp, 516.463_fp, 551.974_fp, &
+    587.160_fp, 621.705_fp, 655.315_fp, 687.730_fp, 718.729_fp, 748.133_fp, &
+    775.811_fp, 801.676_fp, 825.685_fp, 847.830_fp, 868.138_fp, 886.663_fp, &
+    903.479_fp, 918.678_fp, 932.359_fp, 944.631_fp, 955.603_fp, 965.384_fp, &
+    974.082_fp, 981.799_fp, 988.632_fp, 994.671_fp, 1000.000_fp/)
+    
+    !------------------------------
+    ! Assign layer temperatures,
+    ! absorber amounts and metadata
+    !------------------------------
+    DO m = 1, n_Profiles
+      ! Assign metadata
+      ! Regional
+      Atm_NAM(m)%Climatology = Atm(m)%Climatology
+      Atm_NAM(m)%Absorber_Id(:) = Atm(m)%Absorber_Id(:)
+      Atm_NAM(m)%Absorber_Units(:) = Atm(m)%Absorber_Units(:)
+      ! Global
+      Atm_GFS(m)%Climatology = Atm(m)%Climatology
+      Atm_GFS(m)%Absorber_Id(:) = Atm(m)%Absorber_Id(:)
+      Atm_GFS(m)%Absorber_Units(:) = Atm(m)%Absorber_Units(:)            
+      ! Regional assignments of temperature and absorber amounts
+      DO kr = 1, Atm_NAM(m)%n_Layers
+        Pressure_Difference = PRESSURE_DIFFERENCE_FILL_VALUE
+        DO k = 1, Atm(m)%n_Layers
+          IF(ABS(Atm_NAM(m)%Pressure(kr)-Atm(m)%Pressure(k)) < &
+             Pressure_Difference) THEN
+            Pressure_Difference = ABS(Atm_NAM(m)%Pressure(kr)-Atm(m)%Pressure(k))
+            Best_Match_Index = k
+          END IF
+        ENDDO
+        Atm_NAM(m)%Temperature(kr) = Atm(m)%Temperature(Best_Match_Index)
+        Atm_NAM(m)%Absorber(kr,1)  = Atm(m)%Absorber(Best_Match_Index,1)
+        Atm_NAM(m)%Absorber(kr,2)  = Atm(m)%Absorber(Best_Match_Index,2)
+      ENDDO
+      ! Global assignments of temperature and absorber amounts
+      DO kg = 1, Atm_GFS(m)%n_Layers
+        Pressure_Difference = PRESSURE_DIFFERENCE_FILL_VALUE
+        DO k = 1, Atm(m)%n_Layers
+          IF(ABS(Atm_GFS(m)%Pressure(kg)-Atm(m)%Pressure(k)) < &
+             Pressure_Difference) THEN
+            Pressure_Difference = ABS(Atm_GFS(m)%Pressure(kg)-Atm(m)%Pressure(k)) 
+            Best_Match_Index = k
+          END IF
+        ENDDO
+        Atm_GFS(m)%Temperature(kg) = Atm(m)%Temperature(Best_Match_Index)
+        Atm_GFS(m)%Absorber(kg,1)  = Atm(m)%Absorber(Best_Match_Index,1)
+        Atm_GFS(m)%Absorber(kg,2)  = Atm(m)%Absorber(Best_Match_Index,2)
+      ENDDO
+    ENDDO
+
+  END SUBROUTINE Map_To_NCEP_Model_Coordinates

--- a/test/mains/regression/forward/test_OMPoverChannels/SignalFile_Create.inc
+++ b/test/mains/regression/forward/test_OMPoverChannels/SignalFile_Create.inc
@@ -1,0 +1,9 @@
+  SUBROUTINE SignalFile_Create()
+    CHARACTER(256) :: Filename
+    INTEGER :: fid
+    Filename = RESULTS_PATH//TRIM(PROGRAM_NAME)//'_'//TRIM(Sensor_Id)//'.signal'
+    fid = Get_Lun()
+    OPEN( fid, FILE = Filename )
+    WRITE( fid,* ) TRIM(Filename)
+    CLOSE( fid )
+  END SUBROUTINE SignalFile_Create

--- a/test/mains/regression/forward/test_OMPoverChannels/coefficients/make.link_data
+++ b/test/mains/regression/forward/test_OMPoverChannels/coefficients/make.link_data
@@ -1,0 +1,28 @@
+#==============================================================================
+#
+# Makefile to create *local, working copy* coefficient data links
+# for the current example scenario
+#
+#==============================================================================
+
+# Define macros via include file
+include $(CRTM_SOURCE_ROOT)/make.macros
+
+# Define the endian type for ALL datafiles
+ENDIAN_TYPE = Big_Endian
+
+# Define common coefficient file link targets via include file
+include $(CRTM_SOURCE_ROOT)/make.common_coefficient_targets
+
+# Define sensor coefficient file link targets via include file
+TAUCOEFF_TYPE = ODPS
+SENSOR_IDS = amsua_metop-a mhs_n18 hirs4_n18 ssmis_f16 amsre_aqua
+include $(CRTM_SOURCE_ROOT)/make.sensor_coefficient_targets
+
+# Main targets
+# ...Subtargets used by main makefiles
+create_coeff_links:: create_common_coeff_links create_sensor_coeff_links
+remove_coeff_links:: remove_common_coeff_links remove_sensor_coeff_links
+# ..."Global" targets
+all:: create_coeff_links
+clean:: remove_coeff_links

--- a/test/mains/regression/forward/test_OMPoverChannels/sensor_id.list
+++ b/test/mains/regression/forward/test_OMPoverChannels/sensor_id.list
@@ -1,0 +1,3 @@
+amsr2_gcom-w1
+atms_npp
+cris399_npp

--- a/test/mains/regression/forward/test_OMPoverChannels/test_OMPoverChannels.F90
+++ b/test/mains/regression/forward/test_OMPoverChannels/test_OMPoverChannels.F90
@@ -1,0 +1,328 @@
+!
+! test_OMPoverChannels
+!
+! Test program for the CRTM Forward function including clouds and aerosols.
+!
+!
+
+PROGRAM test_OMPoverChannels
+
+  ! ============================================================================
+  ! **** ENVIRONMENT SETUP FOR RTM USAGE ****
+  !
+  ! Module usage
+  USE CRTM_Module
+#ifdef _OPENMP
+  USE OMP_LIB
+#endif
+  ! Disable all implicit typing
+  IMPLICIT NONE
+  ! ============================================================================
+
+
+  ! ----------
+  ! Parameters
+  ! ----------
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME   = 'test_OMPoverChannels'
+  CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = './testinput/'
+  CHARACTER(*), PARAMETER :: RESULTS_PATH = './results/forward/'
+
+  ! ============================================================================
+  ! 0. **** SOME SET UP PARAMETERS FOR THIS TEST ****
+  !
+  ! Profile dimensions...
+  INTEGER, PARAMETER :: N_PROFILES  = 2
+  INTEGER, PARAMETER :: N_LAYERS    = 92
+  INTEGER, PARAMETER :: N_ABSORBERS = 2
+  INTEGER, PARAMETER :: N_CLOUDS    = 1
+  INTEGER, PARAMETER :: N_AEROSOLS  = 1
+  ! ...but only ONE Sensor at a time
+  INTEGER, PARAMETER :: N_SENSORS = 1
+
+  ! Test GeometryInfo angles. The test scan angle is based
+  ! on the default Re (earth radius) and h (satellite height)
+  REAL(fp), PARAMETER :: ZENITH_ANGLE = 30.0_fp
+  REAL(fp), PARAMETER :: SCAN_ANGLE   = 26.37293341421_fp
+  ! ============================================================================
+
+
+  ! ---------
+  ! Variables
+  ! ---------
+  CHARACTER(256) :: Message
+  CHARACTER(256) :: Version
+  CHARACTER(256) :: Sensor_Id
+  INTEGER :: Error_Status
+  INTEGER :: Allocate_Status
+  INTEGER :: n_Channels
+  INTEGER :: l, m
+  ! Declarations for RTSolution comparison
+  INTEGER :: n_l, n_m
+  CHARACTER(256) :: rts_File
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: rts(:,:)
+
+
+  ! ============================================================================
+  ! 1. **** DEFINE THE CRTM INTERFACE STRUCTURES ****
+  !
+  TYPE(CRTM_ChannelInfo_type)             :: ChannelInfo(N_SENSORS)
+  TYPE(CRTM_Geometry_type)                :: Geometry(N_PROFILES)
+  TYPE(CRTM_Atmosphere_type)              :: Atm(N_PROFILES)
+  TYPE(CRTM_Surface_type)                 :: Sfc(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution(:,:)
+  ! ============================================================================
+
+  !First, make sure the right number of inputs have been provided
+  IF(COMMAND_ARGUMENT_COUNT().NE.1)THEN
+     WRITE(*,*)'test_OMPoverChannels.F90: ERROR, only one command-line argument required, returning'
+     STOP 1
+  ENDIF
+
+  CALL GET_COMMAND_ARGUMENT(1,Sensor_Id)   !read in the value
+  
+  ! Program header
+  ! --------------
+  CALL CRTM_Version( Version )
+  CALL Program_Message( PROGRAM_NAME, &
+    'Test program for the CRTM Forward function including clouds and aerosols.', &
+    'CRTM Version: '//TRIM(Version) )
+
+
+  ! Get sensor id from user
+  ! -----------------------
+  Sensor_Id = ADJUSTL(Sensor_Id)
+  WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id)
+
+  ! Set number of OpenMP threads, if present:
+  ! -----------------------------------------
+#ifdef _OPENMP
+  CALL OMP_SET_NUM_THREADS(8)
+!$OMP PARALLEL
+!$OMP SINGLE
+  WRITE(*,*) "Running the test for ", OMP_GET_NUM_THREADS(), " threads."
+!$OMP END SINGLE
+!$OMP END PARALLEL
+#endif
+
+
+
+  ! ============================================================================
+  ! 2. **** INITIALIZE THE CRTM ****
+  !
+
+  ! 2a. Initialise the requested sensor
+  ! -----------------------------------
+  WRITE( *,'(/5x,"Initializing the CRTM...")' )
+  Error_Status = CRTM_Init( (/Sensor_Id/), &
+                            ChannelInfo, &
+                            File_Path=COEFFICIENTS_PATH)
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error initializing CRTM'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 2b. Specify an instrument channel subset for processing
+  ! -------------------------------------------------------
+  Error_Status = CRTM_ChannelInfo_Subset( ChannelInfo(1), &
+                                          Channel_Subset = (/3,4,5,6,7,8,10/) )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Selecting channel subset unsuccessful!'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 2c. Determine the total number of channels
+  !     for which the CRTM was initialized
+  ! ------------------------------------------
+  n_Channels = SUM(CRTM_ChannelInfo_n_Channels(ChannelInfo))
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 3. **** ALLOCATE STRUCTURE ARRAYS ****
+  !
+  ! 3a. Allocate the ARRAYS
+  ! -----------------------
+  ALLOCATE( RTSolution( n_Channels, N_PROFILES ), STAT=Allocate_Status )
+  IF ( Allocate_Status /= 0 ) THEN
+    Message = 'Error allocating structure arrays'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 3b. Allocate the STRUCTURES
+  ! ---------------------------
+  CALL CRTM_Atmosphere_Create( Atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atm)) ) THEN
+    Message = 'Error allocating CRTM Atmosphere structures'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 4. **** ASSIGN INPUT DATA ****
+  !
+  ! 4a. Atmosphere and Surface input
+  ! --------------------------------
+  CALL Load_Atm_Data()
+  CALL Load_Sfc_Data()
+
+
+  ! 4b. GeometryInfo input
+  ! ----------------------
+  ! All profiles are given the same value
+  !  The Sensor_Scan_Angle is optional.
+  CALL CRTM_Geometry_SetValue( Geometry, &
+                               Sensor_Zenith_Angle = ZENITH_ANGLE, &
+                               Sensor_Scan_Angle   = SCAN_ANGLE )
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 5. **** CALL THE CRTM FORWARD MODEL ****
+  !
+  Error_Status = CRTM_Forward( Atm     , &
+                               Sfc     , &
+                               Geometry   , &
+                               ChannelInfo, &
+                               RTSolution  )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error in CRTM Forward Model'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 6. **** OUTPUT THE RESULTS TO SCREEN ****
+  !
+  DO m = 1, N_PROFILES
+    WRITE( *,'(//7x,"Profile ",i0," output for ",a )') m, TRIM(Sensor_Id)
+    DO l = 1, n_Channels
+      WRITE( *, '(/5x,"Channel ",i0," results")') RTSolution(l,m)%Sensor_Channel
+      CALL CRTM_RTSolution_Inspect(RTSolution(l,m))
+    END DO
+  END DO
+  ! ============================================================================
+
+  ! ============================================================================
+  ! 8. **** COMPARE RTSolution RESULTS TO SAVED VALUES ****
+  !
+  WRITE( *, '( /5x, "Comparing calculated results with saved ones..." )' )
+
+  ! 8a. Create the output file if it does not exist
+  ! -----------------------------------------------
+  ! ...Generate a filename
+  rts_File = RESULTS_PATH//TRIM(PROGRAM_NAME)//'_'//TRIM(Sensor_Id)//'.RTSolution.bin'
+  ! ...Check if the file exists
+  IF ( .NOT. File_Exists(rts_File) ) THEN
+    Message = 'RTSolution save file does not exist. Creating...'
+    CALL Display_Message( PROGRAM_NAME, Message, INFORMATION )
+    ! ...File not found, so write RTSolution structure to file
+    Error_Status = CRTM_RTSolution_WriteFile( rts_File, RTSolution, Quiet=.TRUE. )
+    IF ( Error_Status /= SUCCESS ) THEN
+      Message = 'Error creating RTSolution save file'
+      CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+      STOP 1
+    END IF
+  END IF
+ 
+  ! 8b. Inquire the saved file
+  ! --------------------------
+  Error_Status = CRTM_RTSolution_InquireFile( rts_File, &
+                                              n_Channels = n_l, &
+                                              n_Profiles = n_m )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error inquiring RTSolution save file'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 8c. Compare the dimensions
+  ! --------------------------
+  IF ( n_l /= n_Channels .OR. n_m /= 2 ) THEN
+    Message = 'Dimensions of saved data different from that calculated!'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 8d. Allocate the structure to read in saved data
+  ! ------------------------------------------------
+  ALLOCATE( rts( n_l, n_m ), STAT=Allocate_Status )
+  IF ( Allocate_Status /= 0 ) THEN
+    Message = 'Error allocating RTSolution saved data array'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 8e. Read the saved data
+  ! -----------------------
+  Error_Status = CRTM_RTSolution_ReadFile( rts_File, rts, Quiet=.TRUE. )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error reading RTSolution save file'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 8f. Compare the structures
+  ! --------------------------
+  IF ( ALL(CRTM_RTSolution_Compare(RTSolution, rts)) ) THEN
+    Message = 'RTSolution results are the same!'
+    CALL Display_Message( PROGRAM_NAME, Message, INFORMATION )
+  ELSE
+    Message = 'RTSolution results are different!'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    ! Write the current RTSolution results to file
+    rts_File = TRIM(PROGRAM_NAME)//'_'//TRIM(Sensor_Id)//'.RTSolution.bin'
+    Error_Status = CRTM_RTSolution_WriteFile( rts_File, RTSolution, Quiet=.TRUE. )
+    IF ( Error_Status /= SUCCESS ) THEN
+      Message = 'Error creating temporary RTSolution save file for failed comparison'
+      CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    END IF
+    STOP 1
+  END IF
+  ! ============================================================================
+
+  ! ============================================================================
+  ! 7. **** DESTROY THE CRTM ****
+  !
+  WRITE( *, '( /5x, "Destroying the CRTM..." )' )
+  Error_Status = CRTM_Destroy( ChannelInfo )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error destroying CRTM'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+  ! ============================================================================
+  ! 9. **** CLEAN UP ****
+  !
+  ! 9a. Deallocate the structures
+  ! -----------------------------
+  CALL CRTM_Atmosphere_Destroy(Atm)
+
+  ! 9b. Deallocate the arrays
+  ! -------------------------
+  DEALLOCATE(RTSolution, rts, STAT=Allocate_Status)
+  ! ============================================================================
+
+  
+CONTAINS
+
+  INCLUDE 'Load_Atm_Data.inc'
+  INCLUDE 'Load_Sfc_Data.inc'
+
+END PROGRAM test_OMPoverChannels

--- a/test/mains/regression/k_matrix/test_AOD/tx.sh
+++ b/test/mains/regression/k_matrix/test_AOD/tx.sh
@@ -1,0 +1,2 @@
+find ./ -name "*.f90" -exec sed -i "s/  WRITE( *,'\(/5x,\"Enter sensor id: \"\)',ADVANCE='NO' \)//'" {} \;
+echo  READ( *,'(a)' ) Sensor_Id

--- a/test/mains/regression/k_matrix/test_Simple/test_Simple.f90
+++ b/test/mains/regression/k_matrix/test_Simple/test_Simple.f90
@@ -159,15 +159,15 @@ PROGRAM test_Simple
     Message = 'Error allocating CRTM Atmosphere_K structure'
     CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
     STOP 1
-  END IF
-
+  END IF 
+  ! Deleted in V2.4.1
   ! The comparative K-MATRIX structure inside the results file
-  CALL CRTM_Atmosphere_Create( atm_K, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
-  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(atm_K)) ) THEN
-    Message = 'Error allocating CRTM atm_K structure'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
+  !CALL CRTM_Atmosphere_Create( atm_K, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  !IF ( ANY(.NOT. CRTM_Atmosphere_Associated(atm_K)) ) THEN
+  !  Message = 'Error allocating CRTM atm_K structure'
+  !  CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+  !  STOP 1
+  !END IF
 
   ! ============================================================================
 
@@ -201,7 +201,7 @@ PROGRAM test_Simple
   ! 5a. Zero the K-matrix OUTPUT structures
   ! ---------------------------------------
   CALL CRTM_Atmosphere_Zero( Atmosphere_K )
-  CALL CRTM_Atmosphere_Zero( atm_K )
+  !CALL CRTM_Atmosphere_Zero( atm_K ) ! deleted in V2.4.1
   CALL CRTM_Surface_Zero( Surface_K )
 
   ! 5b. Inintialize the K-matrix INPUT so

--- a/test/mains/unit/Unit_Test/Load_Atm_Data.inc
+++ b/test/mains/unit/Unit_Test/Load_Atm_Data.inc
@@ -95,10 +95,12 @@
 
     ! Cloud data
     IF ( atm(1)%n_Clouds > 0 ) THEN
-      k1 = 75
-      k2 = 79
+      k1 = 60
+      k2 = 80
       DO nc = 1, atm(1)%n_Clouds
-        atm(1)%Cloud(nc)%Type = WATER_CLOUD
+        atm(1)%Cloud_Fraction = 1.0_fp
+        atm(1)%Cloud(nc)%Is_Allocated = .TRUE.
+        atm(1)%Cloud(nc)%Type = SNOW_CLOUD
         atm(1)%Cloud(nc)%Effective_Radius(k1:k2) = 20.0_fp ! microns
         atm(1)%Cloud(nc)%Water_Content(k1:k2)    = 5.0_fp  ! kg/m^2
       END DO
@@ -345,7 +347,10 @@
       k1 = 73
       k2 = 90
       DO nc = 1, atm(2)%n_Clouds
-        atm(2)%Cloud(nc)%Type = RAIN_CLOUD
+        atm(2)%Cloud_Fraction = 0.5_fp
+        atm(2)%Cloud(nc)%Is_Allocated = .TRUE.
+
+        atm(2)%Cloud(nc)%Type = SNOW_CLOUD !RAIN_CLOUD
         atm(2)%Cloud(nc)%Effective_Radius(k1:k2) = 1000.0_fp ! microns
         atm(2)%Cloud(nc)%Water_Content(k1:k2)    =    5.0_fp ! kg/m^2
       END DO 

--- a/test/mains/unit/Unit_Test/test_AD.f90
+++ b/test/mains/unit/Unit_Test/test_AD.f90
@@ -25,8 +25,9 @@ PROGRAM test_AD
   ! ----------
   ! Parameters
   ! ----------
+  CHARACTER(*), PARAMETER :: ENDIAN_TYPE='little_endian'
   CHARACTER(*), PARAMETER :: PROGRAM_NAME   = 'test_AD'
-  CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = './testinput/'
+  CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = 'coefficients/'//ENDIAN_TYPE//'/'! './testinput/'
   CHARACTER(*), PARAMETER :: RESULTS_PATH = './results/unit/'
 
 
@@ -36,7 +37,7 @@ PROGRAM test_AD
   !
   ! Profile dimensions...
   INTEGER, PARAMETER :: N_PROFILES  = 2
-  INTEGER, PARAMETER :: N_LAYERS    = 72
+  INTEGER, PARAMETER :: N_LAYERS    = 92
   INTEGER, PARAMETER :: N_ABSORBERS = 2
   INTEGER, PARAMETER :: N_CLOUDS    = 0
   INTEGER, PARAMETER :: N_AEROSOLS  = 0
@@ -113,7 +114,7 @@ PROGRAM test_AD
   ! -----------------------
   !WRITE( *,'(/5x,"Enter sensor id [hirs4_n18, amsua_metop-a, or mhs_n18]: ")',ADVANCE='NO' )
   !READ( *,'(a)' ) Sensor_Id
-  Sensor_Id = 'amsua_metop-a'
+  Sensor_Id = 'atms_npp'
   Sensor_Id = ADJUSTL(Sensor_Id)
   WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id)
 

--- a/test/mains/unit/input_output/test_AerosolCoeff/data/AerosolCoeff.bin
+++ b/test/mains/unit/input_output/test_AerosolCoeff/data/AerosolCoeff.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e37c4047d8168868f6370468c3b246d508b54bf7850093d8c200860efbe2614
-size 207446968

--- a/test/mains/unit/input_output/test_AerosolCoeff_NC/data/AerosolCoeff.nc4
+++ b/test/mains/unit/input_output/test_AerosolCoeff_NC/data/AerosolCoeff.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfc47d9563f245fc442ec4adc23f3f11aa620429ecaaf6733e62323466549b09
-size 207468804

--- a/test/mains/unit/input_output/test_SpcCoeff_NC/data/amsua_aqua.SpcCoeff.nc
+++ b/test/mains/unit/input_output/test_SpcCoeff_NC/data/amsua_aqua.SpcCoeff.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2af0368a0e49b43f3f3316e99c2d8a81f1948eda376b1205d9844c8bd719c7e
-size 4572

--- a/test/mains/unit/input_output/test_TauCoeff_NC/data/amsua_aqua.TauCoeff.nc
+++ b/test/mains/unit/input_output/test_TauCoeff_NC/data/amsua_aqua.TauCoeff.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbd0db606d7f9ffede0ee7bf3aff635e791e12b3f3de3d56662da3deee58d6ac
-size 102900

--- a/test/readme_crtm_tests.txt
+++ b/test/readme_crtm_tests.txt
@@ -1,10 +1,9 @@
 B. Johnson JCSDA 10/2020
 
 Synopsis:
-Application, Unit, and Regression tests, largely culled from Paul van Delst's and Dave Groff's CRTM tests, modified to work with CRTM v2.4.0 in a CMake environment.
+Application, Unit, and Regression tests, largely culled from Paul van Delst's and Dave Groff's CRTM tests, modified to work with CRTM v3.0.0 in a CMake environment.
 Not a complete or comprehensive suite of tests, please add a test each time you add a new code element or substantially change code.
 
-In theory, these tests should work with CRTM v2.3.0, and possibly CRTM v2.2.3 (untested)
 
 Layout:
 
@@ -38,11 +37,11 @@ Prerequisites:
 
 	Currently, it is looking for the CRTM in the following folder:
 
-         ${CRTM_SOURCE_ROOT}/Build/crtm_v2.4.0-alpha/   
+         ${CRTM_SOURCE_ROOT}/Build/crtm_v3.0.0/   
 	
 			 In CMakeLists.txt it's looking for it in this line: 
 
-         HINTS "$ENV{CRTM_SOURCE_ROOT}/Build/crtm_v2.4.0-alpha/lib"
+         HINTS "$ENV{CRTM_SOURCE_ROOT}/Build/crtm_v3.0.0/lib"
 
 
 Running Tests:


### PR DESCRIPTION
This PR updates the test folder to include ctests we added in V2.4.1. 

Major ctests includes:

- [x] Binary/netCDF I/O for spectral, transmittance, and aerosol coefficients (unit tests for surface emissivity I/O are currently commented out pending updates to emissivity I/O) 
- [x] Hypsometric Equation test
- [x] OMPoverChannels_Sensor_Ids
- [x] Adding the following sensor IDs based on v2.4.1 test folder: atms_npp, cris399_npp, v.abi_gr, abi_g18

This branch is updated to reflect recent development merged into dev branch; all standalone ctest passed.

 