### PR TITLE
explicitly zero allocated arrays in RTV_Create

### DIFF
--- a/src/RTSolution/RTV_Define.f90
+++ b/src/RTSolution/RTV_Define.f90
@@ -452,6 +452,18 @@ CONTAINS
               STAT = alloc_stat )
     IF ( alloc_stat /= 0 ) RETURN
 
+    ! zero items after allocation to prevent underflow / overflow issues
+    RTV%Pff      = ZERO
+    RTV%Pbb      = ZERO
+    RTV%Pplus    = ZERO
+    RTV%Pminus   = ZERO
+    RTV%Pleg     = ZERO
+    RTV%Off      = ZERO
+    RTV%Obb      = ZERO
+    RTV%n_Factor = ZERO
+    RTV%sum_fac  = ZERO
+    
+
     ! Perform the allocation for adding-doubling variables
     ALLOCATE( RTV%Inv_Gamma( nZ, nZ, n_Layers)       , &
               RTV%Inv_GammaT(nZ, nZ, n_Layers)       , &
@@ -464,6 +476,18 @@ CONTAINS
               RTV%s_Layer_Source_DOWN(nZ, n_Layers)        , &
               STAT = alloc_stat )
     IF ( alloc_stat /= 0 ) RETURN
+
+    ! zero items after allocation
+    RTV%Inv_Gamma           = ZERO
+    RTV%Inv_GammaT          = ZERO
+    RTV%Refl_Trans          = ZERO
+    RTV%s_Layer_Trans       = ZERO
+    RTV%s_Layer_Refl        = ZERO
+    RTV%s_Level_Refl_UP     = ZERO
+    RTV%s_Level_Rad_UP      = ZERO
+    RTV%s_Layer_Source_UP   = ZERO
+    RTV%s_Layer_Source_DOWN = ZERO
+    
 
     ! Perform the allocation for AMOM variables
     ALLOCATE( RTV%Thermal_C(nZ, n_Layers)        , &
@@ -493,6 +517,33 @@ CONTAINS
               RTV%i_Gm_A5(nZ, nZ, n_Layers), & 
               STAT = alloc_stat )
     IF ( alloc_stat /= 0 ) RETURN
+    
+    ! zero items after allocation
+    RTV%Thermal_C = ZERO
+    RTV%EigVa     = ZERO
+    RTV%Exp_x     = ZERO
+    RTV%EigValue  = ZERO
+    RTV%HH        = ZERO
+    RTV%PM        = ZERO
+    RTV%PP        = ZERO
+    RTV%PPM       = ZERO
+    RTV%PPP       = ZERO
+    RTV%i_PPM     = ZERO
+    RTV%i_PPP     = ZERO
+    RTV%EigVe     = ZERO
+    RTV%Gm        = ZERO
+    RTV%i_Gm      = ZERO
+    RTV%Gp        = ZERO
+    RTV%EigVeF    = ZERO
+    RTV%EigVeVa   = ZERO
+    RTV%A1        = ZERO
+    RTV%A2        = ZERO
+    RTV%A3        = ZERO
+    RTV%A4        = ZERO
+    RTV%A5        = ZERO
+    RTV%A6        = ZERO
+    RTV%Gm_A5     = ZERO
+    RTV%i_Gm_A5   = ZERO
 
     ! Perform the allocation for SOI variables
     ALLOCATE( RTV%e_Layer_Trans( nZ, n_Layers), &
@@ -510,6 +561,21 @@ CONTAINS
               RTV%Source_down(nZ, 0:MAX_N_DOUBLING, n_Layers), &   
               STAT = alloc_stat )
 
+    RTV%e_Layer_Trans        = ZERO
+    RTV%s_Level_IterRad_DOWN = ZERO
+    RTV%s_Level_IterRad_UP   = ZERO
+    RTV%EXPFACT              = ZERO
+    RTV%Number_Doubling      = ZERO
+    RTV%Delta_Tau   = ZERO
+    RTV%Refl        = ZERO
+    RTV%Trans       = ZERO
+    RTV%Inv_BeT     = ZERO
+    RTV%C1          = ZERO
+    RTV%C2          = ZERO
+    RTV%Source_up   = ZERO
+    RTV%Source_down = ZERO
+
+
     IF ( alloc_stat /= 0 ) RETURN
     IF(RTV%RT_Algorithm_Id == RT_VMOM) THEN
       ALLOCATE( RTV%ADS1(nZ, nZ, MAX_N_AMOM, n_Layers), &
@@ -521,6 +587,16 @@ CONTAINS
               RTV%AmBS4(nZ, nZ, n_Layers), &
               RTV%ApBS3(nZ, nZ, n_Layers), &
               STAT = alloc_stat )
+
+      RTV%ADS1  = ZERO
+      RTV%ADS2  = ZERO
+      RTV%ADS3  = ZERO
+      RTV%ADS4  = ZERO
+      RTV%ADS   = ZERO
+      RTV%ADSr  = ZERO
+      RTV%AmBS4 = ZERO
+      RTV%ApBS3 = ZERO
+
  
       IF ( alloc_stat /= 0 ) RETURN
     END IF


### PR DESCRIPTION
Certain compilers / optimizations don't explicitly zero out newly allocated arrays.   For the `RTV` structure (an internal structure for carrying adding doubling information and other variables between modules), it has `intent (IN OUT)` in many cases.  For K_Matrix and Adjoint codes, this means that the structure gets called before it's properly created, resulting in some underflow / overflow situations in later portions of the ADA_Module code, in particular where 
```
! Compute tranmission and reflection matrices for a layer
    IF(w(k) > SCATTERING_ALBEDO_THRESHOLD .and. maxval(abs(RTV%Pff(1:nZ,1:nZ,k))) > ZERO) THEN 
```
Pff was occasionally picking up very small or very large value (E-308 or E+308) due (presumably) to this non-zeroing.  

 