### PR TITLE
Quiet linker output when linking test execs

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,6 @@ list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 
 # macro to create a symlink from src to dst
-set(CMAKE_VERBOSE_MAKEFILE ON)
-
 function(CREATE_SYMLINK src dst)
     foreach (FILENAME ${ARGN})
         execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink


### PR DESCRIPTION
## Description

Reduce verbosity of linking execs in the CRTM test directory

## Issue(s) addressed

Resolves #87 

## Dependencies

## Impact

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
