### PR TITLE
updated internal versioning to be v3.1.0 in preparation for release.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright and License: see LICENSE
 
 cmake_minimum_required( VERSION 3.12 )
-project( crtm VERSION 3.0.0 LANGUAGES Fortran )
+project( crtm VERSION 3.1.0 LANGUAGES Fortran )
 
 option(OPENMP "Build crtm with OpenMP support" ON)
 

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -1,29 +1,31 @@
-#https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.0.0_20230802.tgz
-foldername="fix_REL-3.0.0_20230802"
+#https://bin.ssec.wisc.edu/pub/s4/CRTM/file/crtm_coefficients_3.1.0_skylab_7.0.tar.gz
+foldername="3.1.0_skylab_7.0"
+filename="crtm_coefficients_${foldername}.tar.gz"
+echo "$filename"
+break
 
-filename="${foldername}.tgz"
 if test -f "$filename"; then
     if [ -d "fix/" ]; then #fix directory exists
         echo "fix/ already exists, doing nothing."
     else
         #untar the file and move directory to fix
 				tar -zxvf $filename
-				cd $foldername/
-				mv fix ..
-				cd ..
-				rmdir $foldername
+				mkdir fix
+				mv crtm/$foldername/* fix/.
+				rm -rf $foldername
 				echo "fix/ directory created from existing $filename file."
     fi 
 else
     #download, untar, move
 		echo "Downloading $filename, please wait about 5 minutes (4 GB tar file)"
-	  wget  https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename # CRTM binary files, add "-q" to suppress output. 
+	  wget  https://bin.ssec.wisc.edu/pub/s4/CRTM/file/$filename # CRTM binary files, add "-q" to suppress output. 
 		
-	  tar -zxvf $filename
-		cd $foldername/
-		mv fix ..
-		cd ..
-		rmdir $foldername
-		echo "fix/ directory created from downloaded $filename."
+		
+    #untar the file and move directory to fix
+    tar -zxvf $filename
+    mkdir fix
+    mv crtm/$foldername/* fix/.
+    rm -rf crtm/$foldername
+  	echo "fix/ directory created from downloaded $filename."
 fi
 echo "Completed."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CRTM REL-3.0.0 
+CRTM REL-3.1.0
 ====================
 
 [![Build Status](https://app.travis-ci.com/JCSDA-internal/crtm.svg?token=r6aaq9P13fHcTi8yBgdM&branch=develop)](https://app.travis-ci.com/JCSDA-internal/crtm)
@@ -6,13 +6,14 @@ CRTM REL-3.0.0
 Preamble
 --------
 
-CRTM v3.0.0 release (`REL-3.0.0`)  
+CRTM v3.1.0 release (`REL-3.1.0`)  
 
+v3.1.0 (alpha) Released October 31, 2023
 v3.0.0 Released March, 2023  
 v2.4.1-alpha Released on April 1, 2021 (internal realease only)
 v2.4.0 Released on October 23, 2020
 
-This is an experimental/early release of CRTM v3.0.0, some features may not be fully functional. Contact crtm-support@googlegroups.com.  
+This is an experimental release of CRTM v3.0, some features may not be fully functional. Contact crtm-support@googlegroups.com.  
 v3.x features will be rolled out in incremental updates. 
 
 Basic requirements:  
@@ -21,15 +22,14 @@ Basic requirements:
 (3) A linux, macOS, or unix-style environment.  This has not been tested under any Windows Fortran environments.
 (4) Bash shell is preferred. 
 (5) git and git-lfs (minimum version TBD, but has been tested on git-lfs v2.10 and higher )
+(6) cmake / make build system
 
 =========================================================
 
-**Important Note**: If reading this, you're cloning the CRTM development repository.  The development repository is structured in a way that makes it less user friendly, but more amenable to development and testing.
-
-**JEDI NOTE** This develop (or master) branch is also designed to work directly in a JEDI container or JEDI environment. If you're doing JEDI things, you're probably in the right spot. However, you should stop reading right now and have a look at the README_JEDI.md file.   
+**JEDI NOTE** This develop branch is also designed to work directly in a JEDI container or JEDI environment. If you're doing JEDI things, you're probably in the right spot. However, you should stop reading right now and have a look at the README_JEDI.md file.   
 
 If you're looking for an older version of CRTM (v2.3.0 or older) you should obtain the appropriate tarball from
-https://ftp.emc.ncep.noaa.gov/jcsda/CRTM/
+https://bin.ssec.wisc.edu/pub/s4/CRTM/   OR https://github.com/JCSDA/crtm (old versions).   
 
 If you're looking for version 2.4.0 or newer in a structure similar to older CRTM tarball releases, you should check out the appropriate release/ branch.
 `git branch --remote | grep "release/"` to see a list of release branches OR you may checkout the appropriate tag on the master branch and build it yourself. 
@@ -64,11 +64,10 @@ The CRTM **development** repository directory structure looks like:
 
 <pre>
  .
-  ├── LICENSE  (CC0 license)
-  ├── COPYING  (CC0 legal document)
+  ├── LICENSE  (Public Domain)
+  ├── COPYING  (Public Domain)
   ├── NOTES
   ├── README.md 
-  ├── Set_CRTM_Environment.sh
   ├── Get_CRTM_Binary_Files.sh  
   ├── <b>configuration/</b>
   ├── <b>documentation/</b>
@@ -78,18 +77,13 @@ The CRTM **development** repository directory structure looks like:
   │   ├── EmisCoeff/
   │   ├── SpcCoeff/
   │   └── TauCoeff/
-  ├── scripts/
-  │   └── shell/
-  ├── <b>src/</b>
+  |── <b>src/</b>
   │   ├── Ancillary/
   │   ├── AntennaCorrection/
   │   ├── AtmAbsorption/
   │   ├── AtmOptics/
   │   ├── AtmScatter/
   │   ├── Atmosphere/
-  │   ├── <b>Build/</b>
-  │   │   └── <b>libsrc/</b>
-  │   │       └── <b>test/</b>
   │   ├── CRTM_Utility/
   │   ├── ChannelInfo/
   │   ├── Coefficients/
@@ -123,219 +117,37 @@ But after a clean clone of the development repository, none of the links to sour
 
 Configuration
 -------------
-At present, the 'fix/' directory is provided through ftp, rather than git-LFS.  We're working on a way to make the process of getting binary data equitable and easy for all users.
+At present, the `fix/` directory is provided either through ftp or during the ctest step. We're working on a way to make the process of getting binary data equitable and easy for all users.
 
 The files therein are gzipped (*.gz extension).  Use the Get_CRTM_Binary_Files.sh script to obtain and unpack the dataset.    
 
-At the top level (`crtm/`), the `configuration` directory contains the various compiler-specific configuration files.
-<pre>
-  ls  configuration/
-  ftn.setup                 ftn.setup.csh
-  g95-debug.setup           gfortran.setup.csh     pgf95.setup
-  g95-debug.setup.csh       ifort-debug.setup      pgf95.setup.csh
-  g95.setup                 ifort-debug.setup.csh  xlf2003-debug.setup
-  g95.setup.csh             ifort.setup            xlf2003-debug.setup.csh
-  gfortran-debug.setup      ifort.setup.csh        xlf2003.setup
-  gfortran-debug.setup.csh  pgf95-debug.setup      xlf2003.setup.csh
-  gfortran.setup            pgf95-debug.setup.csh
-
-</pre>
-[Note: as of the time of writing, October 2020, only `ifort.setup`, `ifort-debug.setup`, `gfortran.setup`, `gfortran-debug.setup` have been actively developed and tested.  It is strongly recommended that the user use one of these compilers until the remaining setup files are updated, or update them yourself.  Contact the support email address for specific compiler support requests.  The c-shell (.csh) extension files have not been updated.]
-
-All of the above files define values for the environment variables `FC`, `FCFLAGS`, `LDFLAGS`, and `LIBS`.
-
-It is also inside of these files that you should specify the path to your netCDF4 and HDF5 installations.  
-Here's a trick to find these on your system:
-find / -name "libnetcdff.a" -type f
-find / -name "netcdf.mod" -type f
-find / -name "libhdf5.a" -type f  
-
-For example, if you're using the intel fortran compiler version 19.0.5:
-```
-find / -name "libhdf5.a" -type f  
-<...>
-/opt/hdf5/1.8.21-intel-19.0.5/lib/libhdf5.a
-<...>
-```
-and you would modify the base path in the appropriate `ifort.setup` file, for example:
-`export HDF_DIR="/opt/hdf5/1.8.21-intel-19.0.5"`
-similarly for the `NC4_DIR` line.   
-
-To use these files to define the CRTM build environment, you should source them. For example, if you use the sh/bash/ksh shells and you want to setup
-for a build using the gfortran compiler using debug options you would type:
-
-**Configuration Step 1**
-
-    . configuration/gfortran-debug.setup
-
-(note the `. ` -- for a detailed discussion of `.` vs. `source` see: https://unix.stackexchange.com/questions/58514/what-is-the-difference-between-and-source-in-shells)
-
-**Configuration Step 2**
-
-    . ./Set_CRTM_Environment.sh
-
-Again noting the leading `. `.  This sets the required environment variables to identify various paths needed to build.  `CRTM_ROOT`, `CRTM_SOURCE_ROOT`, etc.
-
-**Configuration Step 3**
-<pre>
-sh Uncompress_Binary_Files.sh
-cd src/
-cd Build/
-make clean  
-cd ..  
-make realclean  
-make  
-</pre>
-The commands `make clean` and `make realclean` ensures that the underlying links, compiled files, generated Makefiles. are removed to avoid conflicts with a clean build.
-The command `make` at the `src/` level performs the linking process between the upper level `src/**` directories and the `src/Build/libsrc` directory.  
-
-Note: After runnin `make`, you may see certain "nc4" files listed as missing, these are files that will be converted to netCDF4 format, but have not yet been added.  
-
-Assuming no fatal error messages, continue to the Build steps below.
+As of CRTM v3.0.0, we no longer support legacy build system using autotools. (i.e., configure/make).  Only cmake / ecbuild (a cmake wrapper, but not required) is supported. 
 
 **Build Step 1**
+From the top level of the CRTM directory, e.g., `CRTMv3/` 
 <pre>
-cd Build/
-./configure --prefix=${PWD}
+mkdir build/
+cd build/
+cmake ..
 make clean
-make -j4
+make -j8
+ctest -j8
 </pre>
 
-(See additional options for `configure` below.  `-j4` sets the number of parallel `make` processes to 4.)
-
-Now we have finally compiled the linked source codes that reside in the `libsrc/` directory.    Please note that once the source codes are linked in the libsrc directory, all development and testing can occur at the `Build/` level.  In the `libsrc/` directory, the source codes link back to the version-controlled counterparts, so you'll want to answer "yes" to any queries about opening the version controlled codes when trying to edit them (this occurs in `emacs`, for example).
-
-**Build Step 2**
-<pre>
-cd libsrc/
-ls -l *.mod
-ls -l *.a
-make check
-make install
-</pre>
-
-The `ls` commands are to verify that indeed the .mod files have been created and the library file (which external codes link against) has also been created.
-The `make check` command builds and runs the default CRTM test `check_crtm`, located in the `src/Build/libsrc/test` directory.
-
-`make install` installs the library in the directory defined by the command `configure --prefix=directory_name`.
-
-
-Summary of Build Script
------------------------
-<pre>
-. configuration/gfortran-debug.setup (or whatever compiler you're using)  
-. ./Set_CRTM_Environment.sh  
-sh Uncompress_Binary_Files.sh
-cd src/  
-make realclean  
-make  
-cd Build/  
-./configure --prefix=${PWD}  
-make clean  
-make -j4  
-cd libsrc/  
-ls -l *.mod  
-ls -l *.a  
-rm -rf make_check.out  
-make check > make_check.out  
-head -n10 make_check.out  
-tail -n10 make_check.out  
-make install  
-</pre>
-
+`-j8` runs 8 processes in parallel, adjust to your system. 
+Now we have compiled the linked source codes that reside in the `src/` directory, and the ctests are built as well.
 
 Linking to the library
 ----------------------
 
-Let's assume the above install was moved into "/home/username/CRTM/crtm_v3.0.0/", to use the library in this structure in your own application, the usual environment variables would need to be be modified something like:
+Let's assume the above install was moved into "/home/username/CRTMv3/", to use the library in this structure in your own application, the usual environment variables would need to be be modified something like:
 
 <pre>
-libroot="/home/username/CRTM/crtm_v3.0.0"
-FCFLAGS="-I${libroot}/include ${FCFLAGS}"
-LDFLAGS="-L${libroot}/lib ${LDFLAGS}"
+libroot="/home/username/CRTMv3/"
+FCFLAGS="-I${libroot}/build/module/crtm/GNU/13.1.0 ${FCFLAGS}"  (as appropriate for your build environment)
+LDFLAGS="-L${libroot}/src ${LDFLAGS}"
 LIBS="-lcrtm ${LIBS}"
 </pre>
-
-Uninstalling the library
-------------------------
-
-To uninstall the library (assuming you haven't moved the installation directory contents somewhere else) you can type:
-
-    make uninstall
-
-This will DELETE the created installation directory. So, for a library version, say, v3.0.0, if your configure script invocation was something like
-
-    ./configure --prefix=${PWD} ...other command line arguments...
-
-then the "uninstall" target will delete the "${PWD}/crtm_v3.0.0" directory.
-
-
-Cleaning Up
------------
-
-Two targets are provided for cleaning up after the build. To remove all the build products type
-
-<pre>
-cd src/Build
-make clean
-</pre>
-
-To also remove all the configuration products (i.e. the makefiles) type
-
-<pre>
-cd src/Build
-make distclean
-</pre>
-
-
-(optional) "Build Release" Setup and Configuration:
---------------------------------------------------
-
-Within the 'src/Build' directory, The legacy build system for the CRTM uses an autoconf-generated `configure` script, which depends on the existence of a few key files.  
-(1) the `configure.ac` file, which contains instructions for how the `configure` file will be built when the `autoconf` command is executed, this is finicky, contact support for help.  
-(2) The `Makefile.in` file, which contains instructions on how executing the `configure` script will generate `Makefile` in libsrc and test subdirectories.  
-
-The Build `Makefile`s assume that environment variables (envars) will be defined that describe the compilation environment. The envars
-that *must* be defined are:  
-  FC:      the Fortran95/2003 compiler executable,  
-  FCFLAGS: the flags/switches provided to the Fortran compiler.
-These can be set (in the Build directory) by `. ./config-setup/<compiler>.setup` as described previously).
-
-In src/Build:
-<pre>
-. ./config-setup/gfortran-debug.setup
-./configure --prefix=${PWD}
-make clean
-make -j4
-make check
-make install
-</pre>
-
-
-**Additional options for `configure`**
-
-`configure` sets an install path environment variable, among other things.  This, by default, will set the `lib/` and `include/` directory paths in the `/usr/local/crtm_v3.0.0/` (or whatever string in in `src/CRTM_Version.inc`).  
-
-The `--prefix` switch sets the installation directory, make sure you have write access to that directory.  
-
-You can override this by setting a different install directory as follows:  
-  `   ./configure --prefix=<install directory>`  
-For example, `./configure --prefix=${PWD}` will create the library in the directory in which you're currently in (e.g., crtm/src/Build/crtm_v3.0.0y/).
-
-By default, the CRTM is built for big-endian I/O. The --disable-big-endian switch builds the library and test programs for little-endian I/O:
-
-  `   ./configure --disable-big-endian --prefix=<install directory>`
-
-If you need more flexibility in the library build you can specify the necessary information directly to the configure script that generates the Makefiles. For
-example, for the Intel ifort compiler:
-<pre>
-  ./configure --prefix=${PWD} \
-                --disable-big-endian \
-                FC="ifort" \
-                FCFLAGS="-O3 -qopenmp -g -traceback"  
-</pre>
-This overrides the FC and FCFLAGS variables that were set by "sourcing" the `configuration/` file earlier, it is strongly recommended that you use the provided configuration files since they contain flags that have been added after substantial debugging and testing.
-
 
 
 **Feedback and Contact Information**
@@ -348,43 +160,10 @@ Known Issues
 ------------
 
 (1) Any "Transmitance Coefficient" generation codes included in src/ are not functional.  Contact CRTM support above for details.  
-(2) No testing was done on PGI, XLF, or other less popular compilers.  
-(3) Compiler setup files do not contain "generic" ways to point to netCDF libraries - you need to edit those files and ensure that the paths point to the correct place.  This is the netCDF life.  Note: Building inside of a JEDI environment (e.g., singularity container) using ecbuild makes this part much easier. 
-
-Troubleshooting
----------------
-<pre>
-Installing <path>/crtm based scripts...
-  crtm_install_scripts.sh(INFORMATION): CRTM root directory is crtm
-  crtm_install_scripts.sh(INFORMATION): /bin exists...
-  crtm_install_scripts.sh(INFORMATION): Your $PATH does NOT contain /bin...
-  crtm_install_scripts.sh(INFORMATION): Creating a crtmrc file with $PATH modification. For a permanent change modify your .bash_profile (or similar) file.
-</pre>
-
-This uncommon error message relates to the fact that you do not have a `$HOME` environment variable set.  You'll also need a `$HOME/bin` directory. Typically something like: `export HOME="/home/users/username/"` or `export HOME="~"` may work as well.    However, usually `$HOME` is set automatically by your system. If you're having this problem, you're likely to have even more problems later -- contact your Sysadmin first.  
-
-<pre>
-checking whether the Fortran compiler works... no
-configure: error: in `<path>/src/Build':
-configure: error: Fortran compiler cannot create executables
-</pre>
-
-Bash users, type `export | grep "FC"`, it should be set to the name of a compiler, e.g., `declare -x FC="ifort"`.  next simply type `ifort` (or whatever FC is trying to use)  at the command prompt to see if it's accessible.   If it says `command not found`, then you're missing the path to your compiler.  This could be a `module` command that needs to be run, or a valid compiler needs to be installed.  This varies based on operating system. 
+(2) No testing was done on PGI, XLF, or other less commonr compilers.  Feedback from users suggest that there's no major concerns though.  Please contact us with specifics.
 
 
-<pre>
-When issuing the `make` command in src/ :
 
-File Type_Kinds.f90 not found in CRTM_Module.F90 hierarchy.
-File File_Utility.f90 not found in CRTM_Module.F90 hierarchy.
-<...> dozens of similar lines <...>
-File FitCoeff_WriteFile.inc not found in CRTM_Module.F90 hierarchy.
-File FitCoeff_Equal.inc not found in CRTM_Module.F90 hierarchy.
-
-Returning to directory <directory>/crtm/src
-</pre>
-You forgot to `. ./Set_CRTM_Environment.sh` in the crtm/ directory, paying close attention to that leading `. `.
-Then `cd src/` and `make`.
 
 
 

--- a/README_JEDI.md
+++ b/README_JEDI.md
@@ -1,28 +1,28 @@
 README_JEDI.md
 
-CRTM REL-3.0.0 
-Released April 1, 2021
+CRTM REL-3.1.0  Released October 31, 2023
+CRTM REL-3.0.0  Released April 1, 2021
 
 
 
 The README.md file contains a lot of general information about this repository and the legacy build system based on autotools.
 
-CRTM REL-3.0.0 JEDI environment build instructions
+CRTM REL-3.1.0 JEDI environment build instructions
 =========================================================
 
 Preamble
 --------
 
-CRTM v3.0.0-alpha release (`REL-3.0.0`)  
+CRTM v3.1.0 release (`REL-3.1.0`)  
 
-This is a fully functional release of CRTM v3.0.0-alpha. 
+This is a fully functional release of CRTM v3.1.0.
 
 Basic requirements:  
 (1) A Fortran 2003 compatible compiler.  
 (2) A netCDF4 / HDF5 library.   
 (3) A linux, macOS, or unix-style environment.  This has not been tested under any Windows Fortran environments.
 (4) Bash shell is preferred.
-(5) A suitable JCSDA JEDI environment: either HPC enabled, a JEDI container, JEDI-stacks, or at a bare minimum ecbuild from ectools (google it). 
+(5) A suitable JCSDA JEDI environment: either HPC enabled, a JEDI container, JEDI-stacks, or at a bare minimum ecbuild from ectools OR cmake.
 (6) git and git-lfs > version 2.0 (tested on 2.10).
 
 =========================================================
@@ -40,9 +40,6 @@ Contents
 2. Building the library  
 3. Testing the library  
 4. Installing the library  
-  a. GNU Install  
-      - Linking to the library  
-  b. Uninstalling the library  
 5. Cleaning up  
 6. Feedback and contact info  
 
@@ -50,7 +47,7 @@ Contents
 
 Configuration, building, and testing the library
 ================================================  
-JCSDA CRTM v3.0.0 Build Instructions
+JCSDA CRTM v3.1.0 Build Instructions
   
 The CRTM **development** repository directory structure looks like:
 
@@ -60,9 +57,8 @@ The CRTM **development** repository directory structure looks like:
   ├── COPYING  (CC0 legal document)
   ├── NOTES
   ├── README.md 
-  ├── Set_CRTM_Environment.sh
   ├── Get_CRTM_Binary_Files.sh (downloads the "fix" directory binary data from ftp, this is useful if you're doing out-of-jedi tests or if you want to override the default binary datasets. ) 
-  ├── CMakeLists.txt           (top-level configuration file for ecbuild)
+  ├── CMakeLists.txt           (top-level configuration file for ecbuild/cmake)
   ├── <b>configuration/</b>
   ├── <b>documentation/</b>
   ├── <b>fix/</b>
@@ -109,52 +105,46 @@ In the above list, the directories highlighted in bold (bold in markdown), are t
 
 JEDI Configuration
 ------------------
-As of v3.0.0, binary data is obtained during the ecbuild step, it downloads a tarball from UCAR's GDEX service and unpacks it.  see `test/CMakeLists.txt`.   
+As of v3.1.0, binary data is obtained during the ecbuild/cmake step, it downloads a tarball from UCAR's GDEX service and unpacks it.  see `test/CMakeLists.txt`.   
 
 
 **Configuration**
-    git clone https://github.com/JCSDA/crtm      (you've probably done this already)  
-    cd crtm/
-    git fetch
+    git clone https://github.com/JCSDA/CRTMv3      (you've probably done this already)  
+    cd CRTMv3
+    git fetch 
     git pull
-    sh Uncompress_Binary_Files.sh
 
 **Build Instructions**
 <pre>
     mkdir build
     cd build
-    ecbuild pathtocrtm  
+    cmake pathtocrtm 
 </pre>
-where `pathrocrtm` is where the `crtm/` diretory is located.  In this example if you're in the `crtm/build` directory, typing `ecbuild ..` will work.
+where `pathrocrtm` is where the `crtm/` diretory is located.  In this example if you're in the `crtm/build` directory, typing `cmake ..` will work.
 
 <pre>
     make -j8     (-j8 means 8 parallel make processes, adjust the number to your machine)
-    ctest
+    ctest -j8
 </pre>
 This should compile all of the source codes, create a libcrtm.so file, compile the tests, and finally run the various ctests.  If you're making changes to code, simply running the make command will detect your code changes and rebuild everything for you.  
-
-Linking to the library
-----------------------
-You'll find the library file (`libcrtm.so`) in `build/lib` and the module files (e.g., `*.mod`) in `module/crtm/**`.
-You can link to these files using any codes that call the CRTM.  
 
 Uninstalling the library
 ------------------------
 
 To "uninstall" the library (assuming you haven't moved the installation directory contents somewhere else) you can type:
     cd build/
-    rm -rf *  (make sure you do this in the build/ directory where you ran `ecbuild`)
+    rm -rf *  (make sure you do this in the build/ directory where you ran `cmake`)
 
 Cleaning Up
 -----------
 <pre>
 cd build/
-rm -rf *  (make sure you do this in the build/ directory where you ran `ecbuild`)
+make clean (removes compiled files, but not binary assets)
 </pre>
 
 
 **Additional options**
-You can modify the various compiler flags, etc in the `crtm/cmake/` directory.  There you will find several configuration files based on differen compilers.
+You can modify the various compiler flags, etc in the `CRTMv3/cmake/` directory.  There you will find several configuration files based on differen compilers.
 
 
 **Feedback and Contact Information**

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -3,5 +3,5 @@
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
 
-set( ${PROJECT_NAME}_VERSION_STR  "3.0.0" )
+set( ${PROJECT_NAME}_VERSION_STR  "3.1.0" )
 

--- a/src/CRTM_Version.inc
+++ b/src/CRTM_Version.inc
@@ -1,1 +1,1 @@
-#define CRTM_VERSION 'v3.0.0'
+#define CRTM_VERSION 'v3.1.0'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
     set(CRTM_TEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-set( CRTM_COEFFS_BRANCH "3.0.0" )
+
 
 # If local path to testfiles is defined don't download
 #if( DEFINED LOCAL_PATH_JEDI_TESTFILES )
@@ -66,10 +66,11 @@ IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
   set( CRTM_COEFFS_PATH ${CMAKE_SOURCE_DIR}/fix )
   message(STATUS "use LOCAL_PATH_JEDI_TESTFILES: ${CRTM_COEFFS_PATH}")
   message("Using existing local fix directory instead of downloading.")
-# Download CRTM coefficients
-else()
+  set( CRTM_COEFFS_BRANCH "" )
+
+else() # Download CRTM coefficients
 	set( CRTM_COEFFS_BRANCH_PREFIX "crtm" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
-  set( CRTM_COEFFS_BRANCH "3.0.0_skylab_6.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
+  set( CRTM_COEFFS_BRANCH "3.1.0_skylab_7.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
 	# it is my intention is to not have any difference between jedi/ufo versions of CRTM and stand-alond versions of CRTM -- they should both work "out of the box"
   set( CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION})   #this is where the symlinks point to binary files for the testinput/* directory after ecbuild.
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
@@ -77,7 +78,7 @@ else()
   set( ECBUILD_DOWNLOAD_BASE_URL https://bin.ssec.wisc.edu/pub/s4/CRTM )
   message(STATUS "download CRTM coeffs files from: ${ECBUILD_DOWNLOAD_BASE_URL}/file to ${CRTM_COEFFS_PATH}")
   ecbuild_get_test_multidata( TARGET   get_crtm_coeffs
-                              NAMES    crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz:5e72e2788acbd7b1a71538ff12ad98b0
+                              NAMES    crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz:2b56a7a55dc9fd440ba97d7719082889
                               DIRNAME  file
                               DIRLOCAL ${CRTM_COEFFS_PATH}
                               EXTRACT )
@@ -524,6 +525,7 @@ AerosolCoeff/netCDF/AerosolCoeff.nc4
 CloudCoeff/Little_Endian/CloudCoeff.bin
 CloudCoeff/netCDF/CloudCoeff.nc4
 CloudCoeff/netCDF/CloudCoeff_DDA_ARTS.nc4
+CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2022.nc4
 EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
 EmisCoeff/IR_Ice/SEcategory/Little_Endian/NPOESS.IRice.EmisCoeff.bin
 EmisCoeff/IR_Ice/SEcategory/netCDF/NPOESS.IRice.EmisCoeff.nc4


### PR DESCRIPTION
Just a quick hotfix for internal versioning, some fixes to CMakeLists.txt to point to appropriate v3.1.0 tarball.  This isn't ready for release yet, just prepping.

 updated internal versioning to be v3.1.0 in preparation for release.

:100644 100644 47edbe3 1879a42 M        CMakeLists.txt
:100755 100755 56b6949 6769281 M        Get_CRTM_Binary_Files.sh
:100644 100644 f30f7ae 4a153cf M        README.md
:100644 100644 4d4e47b 3fe1679 M        README_JEDI.md
:100644 100644 8486620 095b702 M        VERSION.cmake
:100644 100644 e973695 eda29cc M        src/CRTM_Version.inc
:100644 100644 2353c5a 362913e M        test/CMakeLists.txt

