### PR TITLE
merging release/REL-3.1.0 back into develop

### DIFF
--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -1,6 +1,10 @@
-#https://bin.ssec.wisc.edu/pub/s4/CRTM/file/crtm_coefficients_3.1.0_skylab_7.0.tar.gz
-foldername="3.1.0_skylab_7.0"
-filename="crtm_coefficients_${foldername}.tar.gz"
+#https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.1.0.1_01252024.tgz  (use this for jedi and stand-alone, some files have changed).
+
+# This script is used to manually download the tarball of binary and netcdf coefficient files.
+# The same files also download automatically during the cmake step, so you don't have to actually run this manually. 
+
+foldername="fix_REL-3.1.0.1_01252024"
+filename="${foldername}.tgz"
 echo "$filename"
 break
 
@@ -10,17 +14,15 @@ if test -f "$filename"; then
     else
         #untar the file and move directory to fix
 				tar -zxvf $filename
-				mkdir fix
-				mv crtm/$foldername/* fix/.
+				mv $foldername/fix .
 				rm -rf $foldername
 				echo "fix/ directory created from existing $filename file."
     fi 
 else
     #download, untar, move
 		echo "Downloading $filename, please wait about 5 minutes (4 GB tar file)"
-	  wget  https://bin.ssec.wisc.edu/pub/s4/CRTM/file/$filename # CRTM binary files, add "-q" to suppress output. 
-		
-		
+	  wget  https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename # CRTM binary files, add "-q" to suppress output. 
+				
     #untar the file and move directory to fix
     tar -zxvf $filename
     mkdir fix

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 project("CRTM_Tests" VERSION 1.0.1 LANGUAGES Fortran C)
+
 enable_testing ()
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
@@ -60,15 +61,15 @@ IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
   set( CRTM_COEFFS_BRANCH "" )
 
 else() # Download CRTM coefficients
-  set( CRTM_COEFFS_BRANCH_PREFIX "crtm" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
-  set( CRTM_COEFFS_BRANCH "3.1.0_skylab_7.0" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
+  set( CRTM_COEFFS_BRANCH_PREFIX "" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
+  set( CRTM_COEFFS_BRANCH "fix_REL-3.1.0.1_01252024" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
   
-  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION})
+  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${CMAKE_PROJECT_VERSION})
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
   
-  set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/file")
-  set(test_files_dirname crtm_coefficients_${CRTM_COEFFS_BRANCH}.tar.gz) 
-  set(checksum "29a9b6a77096006cc76dbbb9c9569b75") # MD5SUM
+  set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
+  set(test_files_dirname ${CRTM_COEFFS_BRANCH}.tgz) 
+  set(checksum "b37602ea463be55451de1e61ff80b2ba") # MD5SUM of fix_REL-3.1.0.1_01252024.tgz
   
   set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
   set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")
@@ -82,10 +83,11 @@ else() # Download CRTM coefficients
   # -- UNTAR -- 
   
   # Define the directory to untar into
-  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${REPO_VERSION}")
-
+  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${CMAKE_PROJECT_VERSION}")
+	message(STATUS "Checking if ${UNTAR_DEST} already exists...")
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/})
+		message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
     execute_process(COMMAND tar -xzf ${DOWNLOAD_DEST} -C ${UNTAR_DEST}
                     RESULT_VARIABLE result
                     OUTPUT_QUIET ERROR_QUIET)
@@ -520,6 +522,6 @@ SpcCoeff/Little_Endian/ssu_n14.SpcCoeff.bin
 
 # Symlink all CRTM files
 # Version 3
-CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}
+CREATE_SYMLINK_FILENAME( ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}/fix
                          ${CMAKE_CURRENT_BINARY_DIR}/testinput
                          ${crtm_test_input} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,9 +87,9 @@ else() # Download CRTM coefficients
   
   # Define the directory to untar into
   set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION}")
-	message(STATUS "Checking if ${UNTAR_DEST} already exists...")
+	message(STATUS "Checking if ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH} already exists...")
   # Only untar if the CHECK_PATH does not exist
-  if(NOT EXISTS ${UNTAR_DEST})
+  if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
 		message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
     execute_process(COMMAND tar -xzf ${DOWNLOAD_DEST} -C ${UNTAR_DEST}
                     RESULT_VARIABLE result

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,9 @@ project("CRTM_Tests" VERSION 1.0.1 LANGUAGES Fortran C)
 
 enable_testing ()
 
+include (${CMAKE_SOURCE_DIR}/crtm/VERSION.cmake) #grab the version number information
+message (STATUS "Building tests for CRTM v ${CRTM_VERSION_STR}.") 
+
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 
@@ -64,7 +67,7 @@ else() # Download CRTM coefficients
   set( CRTM_COEFFS_BRANCH_PREFIX "" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
   set( CRTM_COEFFS_BRANCH "fix_REL-3.1.0.1_01252024" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
   
-  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${CMAKE_PROJECT_VERSION})
+  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${CRTM_VERSION_STR})
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
   
   set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
@@ -83,7 +86,7 @@ else() # Download CRTM coefficients
   # -- UNTAR -- 
   
   # Define the directory to untar into
-  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${CMAKE_PROJECT_VERSION}")
+  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${CRTM_VERSION_STR}")
 	message(STATUS "Checking if ${UNTAR_DEST} already exists...")
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,12 +4,12 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 cmake_minimum_required (VERSION 3.12)
-project("CRTM_Tests" VERSION 1.0.1 LANGUAGES Fortran C)
+project("CRTM_Tests" VERSION 3.1.0 LANGUAGES Fortran C)
 
 enable_testing ()
 
-include (${CMAKE_SOURCE_DIR}/crtm/VERSION.cmake) #grab the version number information
-message (STATUS "Building tests for CRTM v ${CRTM_VERSION_STR}.") 
+
+message (STATUS "Building tests for CRTM v${PROJECT_VERSION}.") 
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
@@ -67,7 +67,7 @@ else() # Download CRTM coefficients
   set( CRTM_COEFFS_BRANCH_PREFIX "" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
   set( CRTM_COEFFS_BRANCH "fix_REL-3.1.0.1_01252024" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
   
-  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${CRTM_VERSION_STR})
+  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION})
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
   
   set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
@@ -86,10 +86,10 @@ else() # Download CRTM coefficients
   # -- UNTAR -- 
   
   # Define the directory to untar into
-  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${CRTM_VERSION_STR}")
+  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION}")
 	message(STATUS "Checking if ${UNTAR_DEST} already exists...")
   # Only untar if the CHECK_PATH does not exist
-  if(NOT EXISTS ${UNTAR_DEST}/})
+  if(NOT EXISTS ${UNTAR_DEST})
 		message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
     execute_process(COMMAND tar -xzf ${DOWNLOAD_DEST} -C ${UNTAR_DEST}
                     RESULT_VARIABLE result


### PR DESCRIPTION
## Description

merges release/REL-3.1.0 back into develop, which corrects some issues in develop.     release/REL-3.1.0 work will continue with the visible reflectance PR.  

## Impact

CI tests that were failing on develop should stop failing (hopefully).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
