### PR TITLE
Comment out alert messages with Invalid WMO Satellite Id

### DIFF
--- a/src/Surface/SensorData/CRTM_SensorData_Define.f90
+++ b/src/Surface/SensorData/CRTM_SensorData_Define.f90
@@ -353,14 +353,14 @@ CONTAINS
       CALL Display_Message( ROUTINE_NAME, msg, INFORMATION )
       IsValid = .FALSE.
     ENDIF
-    IF ( SensorData%WMO_Satellite_Id == INVALID_WMO_SATELLITE_ID ) THEN
-      msg = 'Invalid WMO Satellite Id found. Continuing...'
-      CALL Display_Message( ROUTINE_NAME, msg, WARNING )
-    ENDIF
-    IF ( SensorData%WMO_Sensor_Id == INVALID_WMO_SENSOR_ID ) THEN
-      msg = 'Invalid WMO Sensor Id Continuing...'
-      CALL Display_Message( ROUTINE_NAME, msg, WARNING )
-    ENDIF
+    ! IF ( SensorData%WMO_Satellite_Id == INVALID_WMO_SATELLITE_ID ) THEN
+    !   msg = 'Invalid WMO Satellite Id found. Continuing...'
+    !   CALL Display_Message( ROUTINE_NAME, msg, WARNING )
+    ! ENDIF
+    ! IF ( SensorData%WMO_Sensor_Id == INVALID_WMO_SENSOR_ID ) THEN
+    !   msg = 'Invalid WMO Sensor Id Continuing...'
+    !   CALL Display_Message( ROUTINE_NAME, msg, WARNING )
+    ! ENDIF
     ! ...Listed sensor channels
     IF ( ANY(SensorData%Sensor_Channel < 1) ) THEN
       msg = 'Invalid Sensor Channel found'
@@ -397,14 +397,14 @@ CONTAINS
 !                    ATTRIBUTES: INTENT(IN)
 !
 ! OPTIONAL INPUTS:
-!       Unit:        Unit number for an already open file to which the output  
-!                    will be written.                                          
-!                    If the argument is specified and the file unit is not     
-!                    connected, the output goes to stdout.                     
-!                    UNITS:      N/A                                           
-!                    TYPE:       INTEGER                                       
-!                    DIMENSION:  Scalar                                        
-!                    ATTRIBUTES: INTENT(IN), OPTIONAL                          
+!       Unit:        Unit number for an already open file to which the output
+!                    will be written.
+!                    If the argument is specified and the file unit is not
+!                    connected, the output goes to stdout.
+!                    UNITS:      N/A
+!                    TYPE:       INTEGER
+!                    DIMENSION:  Scalar
+!                    ATTRIBUTES: INTENT(IN), OPTIONAL
 !
 !:sdoc-:
 !--------------------------------------------------------------------------------
@@ -415,14 +415,14 @@ CONTAINS
     INTEGER,          OPTIONAL, INTENT(IN) :: Unit
     ! Local variables
     INTEGER :: fid
-    
+
     ! Setup
     fid = OUTPUT_UNIT
     IF ( PRESENT(Unit) ) THEN
       IF ( File_Open(Unit) ) fid = Unit
     END IF
 
-    
+
     WRITE(fid,'(1x,"SENSORDATA OBJECT")')
     ! Dimensions
     WRITE(fid,'(3x,"n_Channels:",1x,i0)') SensorData%n_Channels


### PR DESCRIPTION
## Description

This PR removes the alert messages when the satellite id is an invalid WMO id.

For now some of the sensor IDs are set as `INVALID_WMO_SATELLITE_ID` in `SensorInfo/CRTM_SensorInfo.f90` and perhaps during instrument coefficient generation. CRTM simulations for these sensors will log extensive warning messages from calling function `CRTM_SensorData_IsValid` (see issue https://github.com/JCSDA/CRTMv3/issues/96), which is probably unnecessary.

This PR provides an temporary fix, and should be reconsidered if in the future:
- a valid WMO_SATELLITE_ID (from CRTM instrument coefficients) is required elsewhere in the DA system. 
- a sensor must have a valid WMO_SATELLITE_ID for CRTM to support it.

## Issue(s) addressed
https://github.com/JCSDA/CRTMv3/issues/96
https://github.com/JCSDA/CRTMv3/issues/50



