### PR TITLE
Update CMakeLists.txt - remove hardcoded CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ option(OPENMP "Build crtm with OpenMP support" ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
-set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" FORCE)
-message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
 
 ## Configuration options
 include(${PROJECT_NAME}_compiler_flags)


### PR DESCRIPTION
## Description

See https://github.com/JCSDA/spack-stack/issues/1088 for a description of the error. We fix this in spack with a patch for `v3.1.0-skylabv8` (only tagged version affected I think), but it needs to be fixed on develop for future versions.

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1088

## Dependencies

n/a

## Impact

Hopefully none! If an install in the build tree is needed by a system, then it needs to specify that when configuring `crtm`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
