### PR TITLE
first elements toward v3.1.1, not a release.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.12 )
 
-project(crtm VERSION 3.1.0 LANGUAGES Fortran)
+project(crtm VERSION 3.1.1 LANGUAGES Fortran)
 
 option(OPENMP "Build crtm with OpenMP support" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,27 @@ set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" )
 message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
 
+# Function to get the current git commit hash
+function(get_git_hash result)
+    execute_process(
+        COMMAND git rev-parse --short HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(${result} ${GIT_HASH} PARENT_SCOPE)
+endfunction()
+
+# Get the git hash
+get_git_hash(PROJECT_HASH)
+
+# Define ANSI color code for green
+string(ASCII 27 ESCAPE)
+set(RESET "${ESCAPE}[0m")
+set(GREEN "${ESCAPE}[32m")
+
+# Output the project name, version, and hash in green text
+message(STATUS "${GREEN}[${PROJECT_NAME}] (${PROJECT_VERSION}) [${PROJECT_HASH}]${RESET}")
 
 ## Configuration options
 include(${PROJECT_NAME}_compiler_flags)

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -26,8 +26,8 @@ else
     #untar the file and move directory to fix
     tar -zxvf $filename
     mkdir fix
-    mv crtm/$foldername/* fix/.
-    rm -rf crtm/$foldername
+    mv $foldername/fix/* fix/.
+    rm -rf $foldername
   	echo "fix/ directory created from downloaded $filename."
 fi
 echo "Completed."

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -3,7 +3,7 @@
 # This script is used to manually download the tarball of binary and netcdf coefficient files.
 # The same files also download automatically during the cmake step, so you don't have to actually run this manually. 
 
-foldername="fix_REL-3.1.0.1_01252024"
+foldername="fix_REL-3.1.1.0"
 filename="${foldername}.tgz"
 echo "$filename"
 break

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -1,4 +1,4 @@
-#https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.1.0.1_01252024.tgz  (use this for jedi and stand-alone, some files have changed).
+#https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.1.1.0.tgz  (use this for jedi and stand-alone, some files have changed).
 
 # This script is used to manually download the tarball of binary and netcdf coefficient files.
 # The same files also download automatically during the cmake step, so you don't have to actually run this manually. 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 cmake_minimum_required (VERSION 3.12)
-project("CRTM_Tests" VERSION 3.1.0 LANGUAGES Fortran C)
+project("CRTM_Tests" VERSION 3.1.1 LANGUAGES Fortran C)
 
 enable_testing ()
 
@@ -65,14 +65,14 @@ IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
 
 else() # Download CRTM coefficients
   set( CRTM_COEFFS_BRANCH_PREFIX "" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
-  set( CRTM_COEFFS_BRANCH "fix_REL-3.1.0.1_01252024" ) #this version is the CRTM version, not the jedi / skylab version (again, following prior installations -- I'm not tied to this in any way)
+  set( CRTM_COEFFS_BRANCH "fix_REL-3.1.1.0" ) 
   
   set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION})
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
   
   set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
   set(test_files_dirname ${CRTM_COEFFS_BRANCH}.tgz) 
-  set(checksum "b37602ea463be55451de1e61ff80b2ba") # MD5SUM of fix_REL-3.1.0.1_01252024.tgz
+  set(checksum "3cd30437fb4b3ac7927ca871c9587f6e") # MD5SUM of fix_REL-3.1.1.0.tgz
   
   set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
   set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")


### PR DESCRIPTION
## Description

This PR is a quick rollup of some modifications to CMakeLists.txt, test/CMakeLists.txt, and Get_CRTM_Binary_Files.sh that point to the fix_REL-3.1.1.0.tgz tarball, updates the md5sum, and provides a QoL update to CMakeLists.txt to provide green output during the cmake step, which should mimic the same type of output that's seen during ecbuild. 

This also serves as the first PR to change the version number to 3.1.1 in develop, in preparation for upcoming PRs.

