### PR TITLE
update to SpcCoeff_Binary_IO to fix version number check 

### DIFF
--- a/src/Coefficients/SpcCoeff/SpcCoeff_Binary_IO.f90
+++ b/src/Coefficients/SpcCoeff/SpcCoeff_Binary_IO.f90
@@ -418,7 +418,7 @@ CONTAINS
     END IF
     
     ! ...Read the channel data
-    IF( dummy%Version > 2 ) THEN
+    IF( dummy%Version > 3 ) THEN
       ! Binary coefficient version 3 introduced for TROPICS instrument.
       ! The SpcCoeff coefficients contain 'PolAngle' as an additional
       ! array.
@@ -435,7 +435,7 @@ CONTAINS
         SpcCoeff%Band_C2                   , &
         SpcCoeff%Cosmic_Background_Radiance, &
         SpcCoeff%Solar_Irradiance
-    ELSE IF( dummy%Version < 3 ) THEN
+    ELSE IF( dummy%Version < 4 ) THEN
       ! Version 2 is the default binary SpcCoeff version for 
       ! REL-2.4.0 and older.
       READ ( fid, IOSTAT=io_stat, IOMSG=io_msg ) &


### PR DESCRIPTION
per https://github.com/JCSDA/crtm/pull/43

The version check was off by one version.  Andrew Collard pointed this out, and we created an update for v2.4.0, but that fix wasn't propagated into v3.

