### PR TITLE
Add CRTM coefficent tarball download logic that allows specification of a local tarball.

### DIFF
--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -11,7 +11,13 @@ echo "$filename"
 download_url=https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename
 md5sum_url="${download_url}.md5sum"
 
-set -x
+
+# Check if the fix directory already exists, indicating that no download is needed.
+if [ -d "fix/" ]; then #fix directory exists
+    echo "fix/ already exists, doing nothing."
+    exit 0
+fi
+
 # If var $CRTM_BINARY_FILES_TARBALL is set, confirm the checksum then
 # update the "filename" var.
 if [ -f "$CRTM_BINARY_FILES_TARBALL" ]; then
@@ -27,16 +33,8 @@ if [ -f "$CRTM_BINARY_FILES_TARBALL" ]; then
     fi
 fi
 
-# If this script downloaded the file, it will have written the checksum
-# to fix/checksum. Check for the existence of this file and end execution
-# if it is present.
-mkdir -p fix
-if test -f fix/checksum ; then
-    exit 0
-fi
-
 # If the file is not present in the pwd (or at the location set by
-# $CRTM_BINARY_FILES_TARBALL) download it.
+# $CRTM_BINARY_FILES_TARBALL) download the coefficients file.
 if ! test -f "$filename"; then
     echo "Downloading $filename, please wait about 7 minutes (7 GB tar file: sorry!)"
     wget $download_url # CRTM binary files, add "-q" to suppress output.
@@ -45,10 +43,8 @@ fi
 # Extract the file to pwd and write the checksum.
 untar the file and move directory to fix
 tar -zxvf $filename -C "${PWD}"
-mkdir fix
+mkdir -p fix
 mv $foldername/fix/* fix/.
 rm -rf $foldername
-# Write the indicator file.
-echo "${foldername}: ${checksum}" > fix/checksum
 
 echo "Completed."

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -7,9 +7,7 @@ foldername="fix_REL-3.1.1.2"
 checksum=58e0a5c698a438a31dc4914fcda39846
 filename="${foldername}.tgz"
 echo "$filename"
-
 download_url=https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename
-md5sum_url="${download_url}.md5sum"
 
 
 # Check if the fix directory already exists, indicating that no download is needed.

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -40,7 +40,7 @@ if ! test -f "$filename"; then
     wget $download_url # CRTM binary files, add "-q" to suppress output.
 fi
 
-# Extract the file to pwd and write the checksum.
+# Extract the file to the working directory.
 untar the file and move directory to fix
 tar -zxvf $filename -C "${PWD}"
 mkdir -p fix

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,23 +74,31 @@ else() # Download CRTM coefficients
   set(test_files_dirname ${CRTM_COEFFS_BRANCH}.tgz) 
   set(checksum "58e0a5c698a438a31dc4914fcda39846") # MD5SUM of fix_REL-3.1.1.2.tgz
   
-  set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
-  set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")
-  
-  # Download during CMake configure step
-  message(STATUS "Downloading CRTM coeffs files from: ${DOWNLOAD_URL} to ${DOWNLOAD_DEST}")
-  file(DOWNLOAD ${DOWNLOAD_URL} ${DOWNLOAD_DEST}
-    EXPECTED_MD5 ${checksum}
-    SHOW_PROGRESS)
+  # Check if the CRTM binary tarball is already present otherwise download it.
+  if (DEFINED ENV{CRTM_BINARY_FILES_TARBALL})
+    file(MD5 "$ENV{CRTM_BINARY_FILES_TARBALL}" computed_checksum )
+    if (NOT "${computed_checksum}" STREQUAL "${checksum}")
+      message(FATAL_ERROR "Environment provided CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL} had checksum '${computed_checksum}' not matching expected '${checksum}'")
+    endif()
+    message(STATUS "Using CRTM coeffs tarball file CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL}")
+    set(DOWNLOAD_DEST "$ENV{CRTM_BINARY_FILES_TARBALL}")
+  else()
+    set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
+    set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")
+    message(STATUS "Downloading CRTM coeffs files from: ${DOWNLOAD_URL} to ${DOWNLOAD_DEST}")
+    file(DOWNLOAD ${DOWNLOAD_URL} ${DOWNLOAD_DEST}
+      EXPECTED_MD5 ${checksum}
+      SHOW_PROGRESS)
+  endif()
 
   # -- UNTAR -- 
   
   # Define the directory to untar into
   set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION}")
-	message(STATUS "Checking if ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH} already exists...")
+    message(STATUS "Checking if ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH} already exists...")
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
-		message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
+    message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
     execute_process(COMMAND tar -xzf ${DOWNLOAD_DEST} -C ${UNTAR_DEST}
                     RESULT_VARIABLE result
                     OUTPUT_QUIET ERROR_QUIET)


### PR DESCRIPTION
With this change a user, script, or sysadmin may set the environment variable "CRTM_BINARY_FILES_TARBALL" to be equal to the file path of the current CRTM binary tarball location and both the download script and the cmake tool will recognize this environment setting and use the provided tarball instead of downloading a new one each time. The updated logic also verifies the provided tarball against the expected md5 checksum.

This logic will help with our testing system which will keep a copy of this tarball locally rather than downloading it each time. This also has benefits for users with slower internet since they can download it once and reuse it many times. Finally this may be beneficial for users on systems with restricted internet access since they may load this requirement explicitly before a build rather than relying on bringing it in during build which may be prohibited.

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation - ?? (where would I document this)
- [x] I have run the unit tests before creating the PR
