### PR TITLE
Feature/cd mw water emis

### DIFF
--- a/src/Build/libsrc/make.dependencies
+++ b/src/Build/libsrc/make.dependencies
@@ -61,7 +61,7 @@ CRTM_MoleculeScatter.o : CRTM_MoleculeScatter.f90 CRTM_AtmOptics_Define.o CRTM_A
 CRTM_MW_Ice_SfcOptics.o : CRTM_MW_Ice_SfcOptics.f90 CRTM_MW_Snow_SfcOptics.o NESDIS_ATMS_SeaICE_Module.o NESDIS_SSMIS_SeaIceEM_Module.o NESDIS_MHS_SICEEM_Module.o NESDIS_SEAICE_PHYEM_MODULE.o NESDIS_SSMI_SIceEM_Module.o NESDIS_AMSRE_SICEEM_Module.o NESDIS_AMSU_SICEEM_Module.o CRTM_SensorInfo.o CRTM_SfcOptics_Define.o CRTM_GeometryInfo_Define.o CRTM_Surface_Define.o CRTM_SpcCoeff.o CRTM_Parameters.o Message_Handler.o Type_Kinds.o 
 CRTM_MW_Land_SfcOptics.o : CRTM_MW_Land_SfcOptics.f90 NESDIS_LandEM_Module.o CRTM_SfcOptics_Define.o CRTM_GeometryInfo_Define.o CRTM_Surface_Define.o CRTM_SpcCoeff.o CRTM_Parameters.o Message_Handler.o Type_Kinds.o 
 CRTM_MW_Snow_SfcOptics.o : CRTM_MW_Snow_SfcOptics.f90 NESDIS_ATMS_SnowEM_Module.o NESDIS_SSMIS_SnowEM_Module.o NESDIS_MHS_SnowEM_Module.o NESDIS_AMSRE_SNOWEM_Module.o NESDIS_SSMI_SnowEM_Module.o NESDIS_AMSU_SnowEM_Module.o NESDIS_LandEM_Module.o CRTM_SensorInfo.o CRTM_SfcOptics_Define.o CRTM_GeometryInfo_Define.o CRTM_Surface_Define.o CRTM_SpcCoeff.o CRTM_Parameters.o Message_Handler.o Type_Kinds.o 
-CRTM_MWwaterCoeff.o : CRTM_MWwaterCoeff.f90 MWwaterCoeff_Define.o Message_Handler.o 
+CRTM_MWwaterCoeff.o : CRTM_MWwaterCoeff.f90 MWwaterCoeff_Define.o MWwaterCoeff_FASTEM6.o MWwaterCoeff_FASTEM4.o Message_Handler.o 
 CRTM_MW_Water_SfcOptics.o : CRTM_MW_Water_SfcOptics.f90 CRTM_MWwaterCoeff.o CRTM_FastemX.o CRTM_Fastem1.o CRTM_LowFrequency_MWSSEM.o CRTM_SfcOptics_Define.o CRTM_GeometryInfo_Define.o CRTM_Surface_Define.o CRTM_SpcCoeff.o CRTM_Parameters.o Message_Handler.o Type_Kinds.o 
 CRTM_NLTECorrection.o : CRTM_NLTECorrection.f90 NLTE_Predictor_Define.o NLTE_Parameters.o NLTECoeff_Define.o CRTM_GeometryInfo_Define.o CRTM_Atmosphere_Define.o CRTM_Parameters.o Type_Kinds.o 
 CRTM_Options_Define.o : CRTM_Options_Define.f90 CRTM_CloudCover_Define.o Zeeman_Input_Define.o SSU_Input_Define.o CRTM_Parameters.o Binary_File_Utility.o File_Utility.o Compare_Float_Numbers.o Message_Handler.o Type_Kinds.o 
@@ -135,6 +135,8 @@ NESDIS_SSMI_SIceEM_Module.o : NESDIS_SSMI_SIceEM_Module.f90 NESDIS_LandEM_Module
 NESDIS_SSMI_SnowEM_Module.o : NESDIS_SSMI_SnowEM_Module.f90 NESDIS_LandEM_Module.o Type_Kinds.o 
 NESDIS_SSMIS_SeaIceEM_Module.o : NESDIS_SSMIS_SeaIceEM_Module.f90 NESDIS_LandEM_Module.o Type_Kinds.o 
 NESDIS_SSMIS_SnowEM_Module.o : NESDIS_SSMIS_SnowEM_Module.f90 NESDIS_LandEM_Module.o Type_Kinds.o 
+MWwaterCoeff_FASTEM4.o : MWwaterCoeff_FASTEM4.F90 FitCoeff_Define.o MWwaterCoeff_Define.o Type_Kinds.o
+MWwaterCoeff_FASTEM6.o : MWwaterCoeff_FASTEM6.F90 FitCoeff_Define.o MWwaterCoeff_Define.o Message_Handler.o Type_Kinds.o
 netCDF_Utility.o : netCDF_Utility.f90 Type_Kinds.o Message_Handler.o netCDF_Attribute_Utility.o netCDF_Dimension_Utility.o netCDF_Variable_Utility.o
 netCDF_Attribute_Utility.o : netCDF_Attribute_Utility.f90 Type_Kinds.o Message_Handler.o
 netCDF_Dimension_Utility.o : netCDF_Dimension_Utility.f90 Type_Kinds.o Message_Handler.o

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,8 @@ list( APPEND crtm_src_files
       Coefficients/EmisCoeff/IR_Snow/IRsnowCoeff_netCDF_IO.f90
       Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_Define.f90
       Coefficients/EmisCoeff/MW_Water/MWwaterLUT/MWwaterLUT_Define.f90
+      Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM6.f90
+      Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM4.f90
       Coefficients/EmisCoeff/SEcategory/SEcategory_Define.f90
       Coefficients/EmisCoeff/SEcategory/SEcategory_IO.f90
       Coefficients/EmisCoeff/SEcategory/SEcategory_netCDF_IO.f90

--- a/src/Coefficients/CRTM_MWwaterCoeff.f90
+++ b/src/Coefficients/CRTM_MWwaterCoeff.f90
@@ -2,7 +2,7 @@
 ! CRTM_MWwaterCoeff
 !
 ! Module containing the shared CRTM microwave water surface emissivity
-! data and their load/destruction routines. 
+! data and their load/destruction routines.
 !
 ! PUBLIC DATA:
 !   MWwaterC:  Data structure containing the microwave water surface
@@ -32,6 +32,9 @@ MODULE CRTM_MWwaterCoeff
                                  MWwaterCoeff_Associated, &
                                  MWwaterCoeff_Destroy   , &
                                  MWwaterCoeff_Readfile
+  USE MWwaterCoeff_FASTEM6, ONLY: Load_FASTEM6 => MWwaterCoeff_LoadCoeffs
+  USE MWwaterCoeff_FASTEM4, ONLY: Load_FASTEM4 => MWwaterCoeff_LoadCoeffs
+
   ! Disable all implicit typing
   IMPLICIT NONE
 
@@ -44,6 +47,7 @@ MODULE CRTM_MWwaterCoeff
   ! The shared data
   PUBLIC :: MWwaterC
   ! Procedures
+  PUBLIC :: CRTM_MWwaterCoeff_Load_FASTEM
   PUBLIC :: CRTM_MWwaterCoeff_Load
   PUBLIC :: CRTM_MWwaterCoeff_Destroy
   PUBLIC :: CRTM_MWwaterCoeff_IsLoaded
@@ -64,6 +68,129 @@ MODULE CRTM_MWwaterCoeff
 
 CONTAINS
 
+!---------------------------------------------------------------
+!:sdoc+:
+!
+! NAME:
+!       CRTM_MWwaterCoeff_Load_FASTEM
+!
+! PURPOSE:
+!       Function to load the microwave water surface emissivity data into
+!       the public data structure MWwaterC
+!
+! CALLING SEQUENCE:
+!       Error_Status = CRTM_MWwaterCoeff_Load_FASTEM( &
+!                        FASTEM_Scheme,                         &
+!                        Quiet             = Quiet            , &
+!                        Process_ID        = Process_ID       , &
+!                        Output_Process_ID = Output_Process_ID  )
+!
+! INPUT ARGUMENTS:
+!   FASTEM_Scheme:          Name of the FASTEM Scheme
+!                           OPTIONS: FASTEM4 or FASTEM6
+!                           UNITS:      N/A
+!                           TYPE:       CHARACTER(*)
+!                           DIMENSION:  Scalar
+!                           ATTRIBUTES: INTENT(IN)
+!
+!
+! OPTIONAL INPUT ARGUMENTS:
+!       Quiet:              Set this logical argument to suppress INFORMATION
+!                           messages being printed to stdout
+!                           If == .FALSE., INFORMATION messages are OUTPUT [DEFAULT].
+!                              == .TRUE.,  INFORMATION messages are SUPPRESSED.
+!                           If not specified, default is .FALSE.
+!                           UNITS:      N/A
+!                           TYPE:       LOGICAL
+!                           DIMENSION:  Scalar
+!                           ATTRIBUTES: INTENT(IN), OPTIONAL
+!
+!       Process_ID:         Set this argument to the MPI process ID that this
+!                           function call is running under. This value is used
+!                           solely for controlling INFORMATIOn message output.
+!                           If MPI is not being used, ignore this argument.
+!                           This argument is ignored if the Quiet argument is set.
+!                           UNITS:      N/A
+!                           TYPE:       INTEGER
+!                           DIMENSION:  Scalar
+!                           ATTRIBUTES: INTENT(IN), OPTIONAL
+!
+!       Output_Process_ID:  Set this argument to the MPI process ID in which
+!                           all INFORMATION messages are to be output. If
+!                           the passed Process_ID value agrees with this value
+!                           the INFORMATION messages are output.
+!                           This argument is ignored if the Quiet argument
+!                           is set.
+!                           UNITS:      N/A
+!                           TYPE:       INTEGER
+!                           DIMENSION:  Scalar
+!                           ATTRIBUTES: INTENT(IN), OPTIONAL
+!
+! FUNCTION RESULT:
+!       Error_Status:       The return value is an integer defining the error
+!                           status. The error codes are defined in the
+!                           Message_Handler module.
+!                           If == SUCCESS the data load was successful
+!                              == FAILURE an unrecoverable error occurred.
+!                           UNITS:      N/A
+!                           TYPE:       INTEGER
+!                           DIMENSION:  Scalar
+!
+! SIDE EFFECTS:
+!       This function modifies the contents of the public data
+!       structure MWwaterC.
+!
+!:sdoc-:
+!------------------------------------------------------------------------------
+
+  FUNCTION CRTM_MWwaterCoeff_Load_FASTEM( &
+      FASTEM_Scheme    , &  ! Input
+      Quiet            , &  ! Optional input
+      Process_ID       , &  ! Optional input
+      Output_Process_ID) &  ! Optional input
+  RESULT( err_stat )
+    ! Arguments
+    CHARACTER(*),           INTENT(IN) :: FASTEM_Scheme
+    LOGICAL     , OPTIONAL, INTENT(IN) :: Quiet
+    INTEGER     , OPTIONAL, INTENT(IN) :: Process_ID
+    INTEGER     , OPTIONAL, INTENT(IN) :: Output_Process_ID
+    ! Function result
+    INTEGER :: err_stat
+    ! Local parameters
+    CHARACTER(*), PARAMETER :: ROUTINE_NAME = 'CRTM_MWwaterCoeff_Load_FASTEM'
+    CHARACTER(ML) :: msg, pid_msg
+    LOGICAL :: noisy
+
+    ! Setup
+    err_stat = SUCCESS
+    ! ...Check Quiet argument
+    noisy = .TRUE.
+    IF ( PRESENT(Quiet) ) noisy = .NOT. Quiet
+    ! ...Check the MPI Process Ids
+    IF ( noisy .AND. PRESENT(Process_ID) .AND. PRESENT(Output_Process_ID) ) THEN
+      IF ( Process_Id /= Output_Process_Id ) noisy = .FALSE.
+    END IF
+    ! ...Create a process ID message tag for error messages
+    IF ( PRESENT(Process_Id) ) THEN
+      WRITE( pid_msg,'("; Process ID: ",i0)' ) Process_ID
+    ELSE
+      pid_msg = ''
+    END IF
+
+    ! Load MWwaterCoeff data
+    SELECT CASE ( FASTEM_Scheme )
+      CASE ( 'FASTEM6' )
+        CALL Load_FASTEM6( MWwaterC )
+      CASE ( 'FASTEM4' )
+        CALL Load_FASTEM4( MWwaterC )
+      CASE DEFAULT
+        err_stat = FAILURE
+        msg = 'This option not yet implemented: '//TRIM(FASTEM_Scheme)//TRIM(pid_msg)
+        CALL Display_Message( ROUTINE_NAME, msg, err_stat )
+        RETURN
+    END SELECT
+
+  END FUNCTION CRTM_MWwaterCoeff_Load_FASTEM
 
 !------------------------------------------------------------------------------
 !:sdoc+:
@@ -123,7 +250,7 @@ CONTAINS
 !       Output_Process_ID:  Set this argument to the MPI process ID in which
 !                           all INFORMATION messages are to be output. If
 !                           the passed Process_ID value agrees with this value
-!                           the INFORMATION messages are output. 
+!                           the INFORMATION messages are output.
 !                           This argument is ignored if the Quiet argument
 !                           is set.
 !                           UNITS:      N/A
@@ -158,7 +285,7 @@ CONTAINS
     ! Arguments
     CHARACTER(*),           INTENT(IN) :: Filename
     CHARACTER(*), OPTIONAL, INTENT(IN) :: File_Path
-    LOGICAL     , OPTIONAL, INTENT(IN) :: Quiet             
+    LOGICAL     , OPTIONAL, INTENT(IN) :: Quiet
     INTEGER     , OPTIONAL, INTENT(IN) :: Process_ID
     INTEGER     , OPTIONAL, INTENT(IN) :: Output_Process_ID
     ! Function result
@@ -170,7 +297,7 @@ CONTAINS
     CHARACTER(ML) :: MWwaterCoeff_File
     LOGICAL :: noisy
 
-    ! Setup 
+    ! Setup
     err_stat = SUCCESS
     ! ...Assign the filename to local variable
     MWwaterCoeff_File = ADJUSTL(Filename)
@@ -189,8 +316,8 @@ CONTAINS
     ELSE
       pid_msg = ''
     END IF
-    
-    
+
+
     ! Read the MWwaterCoeff data file
     err_stat = MWwaterCoeff_ReadFile( &
                  MWwaterC, &
@@ -275,7 +402,7 @@ CONTAINS
 
   END FUNCTION CRTM_MWwaterCoeff_Destroy
 
-  
+
 !------------------------------------------------------------------------------
 !:sdoc+:
 !

--- a/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM4.f90
+++ b/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM4.f90
@@ -1,5 +1,5 @@
 MODULE MWwaterCoeff_FASTEM4
- 
+
   ! -----------------
   ! Environment setup
   ! -----------------
@@ -23,7 +23,7 @@ MODULE MWwaterCoeff_FASTEM4
   ! -----------------
   ! Module parameters
   ! -----------------
-  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = &
+  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = ' '
 
   ! No. of Stokes components
   INTEGER , PARAMETER :: N_STOKES = 4
@@ -39,7 +39,7 @@ MODULE MWwaterCoeff_FASTEM4
   REAL(fp), PARAMETER :: FCCOEFF(N_FCCOEFFS) = (/7.75e-06_fp, 3.231_fp/)
 
 
-  ! Foam reflectivity coefficients from section d of 
+  ! Foam reflectivity coefficients from section d of
   !
   !   Kazumori, M. et al. (2008) Impact Study of AMSR-E Radiances
   !     in the NCEP Global Data Assimilation System,
@@ -91,7 +91,7 @@ MODULE MWwaterCoeff_FASTEM4
   (/ -9.197134E-02_fp, 8.310678E-04_fp,-6.065411E-07_fp, 1.350073E-01_fp,-1.032096E-03_fp, 4.259935E-07_fp, &
      -4.373322E-02_fp, 2.545863E-04_fp, 9.835554E-08_fp,-1.199751E-03_fp, 1.360423E-05_fp,-2.088404E-08_fp, &
      -2.201640E-05_fp, 1.951581E-07_fp,-2.599185E-10_fp, 4.477322E-04_fp,-2.986217E-05_fp, 9.406466E-08_fp, &
-     
+
      -7.103127E-02_fp,-4.713113E-05_fp, 1.754742E-06_fp, 9.720859E-02_fp, 1.374668E-04_fp,-2.591771E-06_fp, &
      -2.687455E-02_fp,-3.677779E-05_fp, 7.548377E-07_fp,-3.049506E-03_fp,-5.412826E-05_fp, 2.285387E-07_fp, &
      -2.201640E-05_fp, 1.951581E-07_fp,-2.599185E-10_fp, 2.297488E-03_fp, 3.787032E-05_fp,-1.553581E-07_fp /), &
@@ -109,7 +109,7 @@ MODULE MWwaterCoeff_FASTEM4
       0.395290E+01_fp, 0.958580E+00_fp,-0.159080E+00_fp, &
       0.368500E-01_fp, 0.307100E-01_fp, 0.810000E-03_fp, &
      -0.619960E+01_fp,-0.172580E+01_fp, 0.641360E+00_fp, &
-     
+
      -0.675700E-01_fp, 0.214600E+00_fp,-0.363000E-02_fp, &
       0.636730E+01_fp, 0.900610E+00_fp,-0.524880E+00_fp, &
      -0.370920E+01_fp,-0.143310E+01_fp, 0.397450E+00_fp, &
@@ -124,7 +124,7 @@ MODULE MWwaterCoeff_FASTEM4
   INTEGER , PARAMETER :: N_AZCOEFFS = 10 ! No. of azimuth emissivity coefficients
   INTEGER , PARAMETER :: N_HARMONICS = 3 ! No. of harmonics considered in the trignometric parameterisation
   REAL(fp), PARAMETER :: AZCOEFF(N_AZCOEFFS, N_STOKES, N_HARMONICS) = RESHAPE( &
-       ! COS(phi) and SIN(phi) coefficients  
+       ! COS(phi) and SIN(phi) coefficients
     (/ 1.318143E-02_fp,-1.660586E-04_fp,-7.102244E-03_fp, 8.771616E-05_fp,-3.418311E-03_fp, &
        3.784895E-05_fp, 5.763184E-05_fp,-6.290578E-07_fp, 1.839451E-03_fp,-1.856317E-05_fp, &
        6.459324E-03_fp,-7.570050E-05_fp,-3.777932E-03_fp, 4.270676E-05_fp,-1.247285E-03_fp, &
@@ -133,7 +133,7 @@ MODULE MWwaterCoeff_FASTEM4
       -5.745778E-06_fp,-2.942056E-05_fp, 1.889216E-07_fp,-9.058433E-04_fp,-1.136992E-06_fp, &
       -5.854263E-04_fp, 5.546263E-06_fp, 2.485058E-04_fp,-1.531698E-06_fp, 1.243394E-04_fp, &
       -1.575561E-06_fp,-2.437488E-06_fp, 2.986237E-08_fp,-5.555700E-05_fp, 6.076001E-07_fp, &
-       ! COS(2*phi) and SIN(2*phi) coefficients  
+       ! COS(2*phi) and SIN(2*phi) coefficients
        4.605486E-03_fp, 5.781246E-05_fp,-2.746737E-03_fp,-4.690045E-05_fp, 1.512049E-04_fp, &
       -7.411844E-09_fp,-3.476559E-06_fp, 1.466902E-07_fp,-6.472364E-05_fp,-1.776898E-06_fp, &
       -1.863094E-02_fp, 2.768660E-04_fp, 7.624930E-03_fp,-1.397481E-04_fp, 3.550912E-03_fp, &
@@ -142,13 +142,13 @@ MODULE MWwaterCoeff_FASTEM4
       -2.715428E-05_fp,-6.912266E-05_fp, 7.852767E-07_fp, 5.337096E-04_fp, 6.585635E-06_fp, &
        6.042016E-03_fp,-1.135219E-04_fp,-2.231061E-03_fp, 5.729232E-05_fp,-1.543391E-03_fp, &
        2.288614E-05_fp, 2.828443E-05_fp,-4.384802E-07_fp, 7.080137E-04_fp,-9.827192E-06_fp, &
-       ! COS(3*phi) and SIN(3*phi) coefficients  
+       ! COS(3*phi) and SIN(3*phi) coefficients
        1.205735E-03_fp,-1.748276E-05_fp,-6.002919E-04_fp, 1.174144E-05_fp,-1.735732E-04_fp, &
-       2.148296E-06_fp, 2.955853E-06_fp,-3.609258E-08_fp, 9.669164E-05_fp,-1.282544E-06_fp, & 
+       2.148296E-06_fp, 2.955853E-06_fp,-3.609258E-08_fp, 9.669164E-05_fp,-1.282544E-06_fp, &
       -7.610401E-04_fp, 1.293120E-05_fp, 3.796897E-04_fp,-5.562741E-06_fp, 8.865672E-05_fp, &
       -1.313724E-06_fp, 7.009076E-08_fp, 2.426378E-08_fp,-8.192732E-05_fp, 5.333771E-07_fp, &
       -1.834561E-03_fp, 2.896784E-05_fp, 7.613927E-04_fp,-1.367783E-05_fp, 4.887281E-04_fp, &
-      -5.810380E-06_fp,-9.568319E-06_fp, 1.207029E-07_fp,-2.210790E-04_fp, 2.159904E-06_fp, &      
+      -5.810380E-06_fp,-9.568319E-06_fp, 1.207029E-07_fp,-2.210790E-04_fp, 2.159904E-06_fp, &
       -2.054959E-04_fp, 1.806305E-07_fp, 1.144686E-04_fp, 4.638982E-07_fp, 3.581176E-05_fp, &
       -3.870976E-07_fp,-6.861957E-07_fp, 6.989780E-09_fp,-1.526136E-05_fp, 1.887424E-07_fp /), &
     (/N_AZCOEFFS, N_STOKES, N_HARMONICS/) )
@@ -161,29 +161,29 @@ CONTAINS
     INTEGER :: version
 
     version = 4
-    
+
     ! Load the foam coverage coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%FCCoeff, FCCOEFF, Version=version)
 
     ! Load the foam reflectivity coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%FRCoeff, FRCOEFF, Version=version)
-    
+
     ! Load the reflection correction coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%RCCoeff, RCCOEFF, Version=version)
-        
+
     ! Load the azimuth emissivity coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%AZCoeff, AZCOEFF, Version=version)
-        
+
     ! Load the small-scale correction coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%SSCCoeff, SSCCOEFF, Version=version)
-    
+
     ! Load the large-scale correction coefficients
     CALL FitCoeff_SetValue(MWwaterCoeff%LSCCoeff, LSCCOEFF, Version=version)
-    
+
     ! Flag the structure as valid
     CALL MWwaterCoeff_Create(MWwaterCoeff)
     MWwaterCoeff%Version = version
-    
+
   END SUBROUTINE MWwaterCoeff_LoadCoeffs
 
 
@@ -191,5 +191,5 @@ CONTAINS
     CHARACTER(*), INTENT(OUT) :: Id
     Id = MODULE_VERSION_ID
   END SUBROUTINE MWwaterCoeff_LoadVersion
-  
+
 END MODULE MWwaterCoeff_FASTEM4

--- a/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM5.f90
+++ b/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM5.f90
@@ -26,7 +26,7 @@ MODULE MWwaterCoeff_FASTEM5
   ! -----------------
   ! Module parameters
   ! -----------------
-  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = &
+  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = ' '
 
   ! No. of Stokes components
   INTEGER , PARAMETER :: N_STOKES = 4

--- a/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM6.f90
+++ b/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_CreateFile/MWwaterCoeff_FASTEM6.f90
@@ -24,7 +24,7 @@ MODULE MWwaterCoeff_FASTEM6
   ! -----------------
   ! Module parameters
   ! -----------------
-  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = &
+  CHARACTER(*), PARAMETER :: MODULE_VERSION_ID = ' '
 
   ! No. of Stokes components
   INTEGER , PARAMETER :: N_STOKES = 4

--- a/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_Define.f90
+++ b/src/Coefficients/EmisCoeff/MW_Water/MWwaterCoeff_Define.f90
@@ -45,6 +45,7 @@ MODULE MWwaterCoeff_Define
   PUBLIC :: MWwaterCoeff_Info
   PUBLIC :: MWwaterCoeff_ReadFile
   PUBLIC :: MWwaterCoeff_WriteFile
+  PUBLIC :: MWwaterCoeff_Equal
 
 
   ! ---------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -406,6 +406,13 @@ add_test(NAME test_hypsometric_eq
          COMMAND $<TARGET_FILE:hypsometric_eq>)
 set_tests_properties(test_hypsometric_eq PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
 
+# test_MWwater_io
+add_executable(MWwater_IO mains/unit/input_output/test_MWwater/test_MWwater_io.f90)
+target_link_libraries(MWwater_IO PRIVATE crtm)
+add_test(NAME test_MWwater_io
+         COMMAND $<TARGET_FILE:MWwater_IO>)
+set_tests_properties(test_MWwater_io PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
+
 #=================================================================================
 #forward and k_matrix regression tests
 foreach(regtype IN LISTS regression_types)
@@ -499,6 +506,7 @@ CloudCoeff/Little_Endian/CloudCoeff.bin
 CloudCoeff/netCDF/CloudCoeff.nc4
 CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2022.nc4
 EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
+EmisCoeff/MW_Water/Little_Endian/FASTEM4.MWwater.EmisCoeff.bin
 EmisCoeff/IR_Ice/SEcategory/Little_Endian/NPOESS.IRice.EmisCoeff.bin
 EmisCoeff/IR_Ice/SEcategory/netCDF/NPOESS.IRice.EmisCoeff.nc4
 EmisCoeff/IR_Land/SEcategory/Little_Endian/NPOESS.IRland.EmisCoeff.bin

--- a/test/mains/unit/input_output/test_MWwater/test_MWwater_io.f90
+++ b/test/mains/unit/input_output/test_MWwater/test_MWwater_io.f90
@@ -1,0 +1,126 @@
+!-------------------------------------------------------
+!
+! Description:
+!       Test replacement module for MW water emissivity FASTEM
+!
+!       Date: 2024-10-07        Author: Cheng Dang
+
+! MODIFICATION HISTORY:
+! =====================
+!
+!-------------------------------------------------------
+
+PROGRAM test_MWwater_io
+
+  ! ====================================================
+  ! **** ENVIRONMENT SETUP FOR RTM USAGE ****
+  !
+
+  ! Module usage
+  USE UnitTest_Define, ONLY: UnitTest_type,   &
+                             UnitTest_Init,   &
+                             UnitTest_Setup,  &
+                             UnitTest_Assert, &
+                             UnitTest_Passed
+  ! ...Infrared surface emissivities
+  USE CRTM_MWwaterCoeff  , ONLY: CRTM_MWwaterCoeff_Load, &
+                                 CRTM_MWwaterCoeff_Load_FASTEM, &
+                                 MWwaterC
+  USE MWwaterCoeff_Define, ONLY: MWwaterCoeff_type, &
+                                 MWwaterCoeff_Destroy, &
+                                 MWwaterCoeff_Equal
+  USE Message_Handler    , ONLY: SUCCESS, Display_Message
+
+  ! Disable all implicit typing
+  IMPLICIT NONE
+
+  ! Data dictionary:
+  LOGICAL,      PARAMETER :: Quiet = .TRUE.
+  CHARACTER(*), PARAMETER :: Program_Name = 'test_MWwater_io'
+  CHARACTER(*), PARAMETER :: File_Path = './testinput/'
+  CHARACTER(*), PARAMETER :: File_FASTEM6   = 'FASTEM6.MWwater.EmisCoeff.bin'
+  CHARACTER(*), PARAMETER :: File_FASTEM5   = 'FASTEM5.MWwater.EmisCoeff.bin'
+  CHARACTER(*), PARAMETER :: File_FASTEM4   = 'FASTEM4.MWwater.EmisCoeff.bin'
+  CHARACTER(*), PARAMETER :: Scheme_FASTEM6 = 'FASTEM6'
+  CHARACTER(*), PARAMETER :: Scheme_FASTEM5 = 'FASTEM5'
+  CHARACTER(*), PARAMETER :: Scheme_FASTEM4 = 'FASTEM4'
+
+  TYPE(MWwaterCoeff_type) :: MWwaterC_LUT, MWwaterC_NEW
+  CHARACTER(2000)         :: info
+  INTEGER                 :: err_stat
+  TYPE(UnitTest_type)     :: ioTest
+  LOGICAL                 :: testPassed, is_equal
+
+  ! Initialize Unit test:
+  CALL UnitTest_Init(ioTest, .TRUE.)
+  CALL UnitTest_Setup(ioTest, 'MWwater_Coeff_IO_Test', Program_Name, .TRUE.)
+
+  ! Load the default emissivity coefficient look-up table:
+
+  ! FASTEM 6
+  WRITE(*,*) 'CRTM_MWwaterCoeff_Load ...LOADING: ', File_FASTEM6
+  err_stat = CRTM_MWwaterCoeff_Load(&
+                  TRIM(TRIM(File_Path)//File_FASTEM6), &
+                  Quiet = .TRUE.)
+  IF ( err_stat /= SUCCESS ) THEN
+    CALL Display_Message( 'CRTM_MWwaterCoeff_Load' ,'Error loading MWwaterCoeff data', err_stat )
+    STOP 1
+  END IF
+  MWwaterC_LUT = MWwaterC
+  CALL MWwaterCoeff_Destroy (MWwaterC)
+
+  WRITE(*,*) 'CRTM_MWwaterCoeff_Load_FASTEM ...LOADING: ', Scheme_FASTEM6
+  err_stat = CRTM_MWwaterCoeff_Load_FASTEM( &
+                     Scheme_FASTEM6, &
+                     Quiet = .TRUE.)
+  IF ( err_stat /= SUCCESS ) THEN
+   CALL Display_Message( 'CRTM_MWwaterCoeff_Load_FASTEM' ,'Error loading MWwaterCoeff data', err_stat )
+   STOP 1
+  END IF
+  MWwaterC_NEW = MWwaterC
+  CALL MWwaterCoeff_Destroy (MWwaterC)
+
+  is_equal = MWwaterCoeff_Equal(MWwaterC_LUT, MWwaterC_NEW)
+  IF ( .NOT. is_equal ) THEN
+    CALL Display_Message( 'MWwaterCoeff_Equal' ,'MWwaterCoeff are different', err_stat )
+    STOP 1
+  END IF
+  CALL MWwaterCoeff_Destroy (MWwaterC_LUT)
+  CALL MWwaterCoeff_Destroy (MWwaterC_NEW)
+
+  ! FASTEM 5 - not supported by CRTM_MWwaterCoeff_Load_FASTEM
+
+  ! FASTEM 4
+  WRITE(*,*) 'CRTM_MWwaterCoeff_Load ...LOADING: ', File_FASTEM4
+  err_stat = CRTM_MWwaterCoeff_Load(&
+                  TRIM(TRIM(File_Path)//File_FASTEM4), &
+                  Quiet = .TRUE.)
+  IF ( err_stat /= SUCCESS ) THEN
+    CALL Display_Message( 'CRTM_MWwaterCoeff_Load' ,'Error loading MWwaterCoeff data', err_stat )
+    STOP 1
+  END IF
+  MWwaterC_LUT = MWwaterC
+  CALL MWwaterCoeff_Destroy (MWwaterC)
+
+  WRITE(*,*) 'CRTM_MWwaterCoeff_Load_FASTEM ...LOADING: ', Scheme_FASTEM4
+  err_stat = CRTM_MWwaterCoeff_Load_FASTEM( &
+                     Scheme_FASTEM4, &
+                     Quiet = .TRUE.)
+  IF ( err_stat /= SUCCESS ) THEN
+    CALL Display_Message( 'CRTM_MWwaterCoeff_Load_FASTEM' ,'Error loading MWwaterCoeff data', err_stat )
+    STOP 1
+  END IF
+  MWwaterC_NEW = MWwaterC
+  CALL MWwaterCoeff_Destroy (MWwaterC)
+
+  is_equal = MWwaterCoeff_Equal(MWwaterC_LUT, MWwaterC_NEW)
+  IF ( .NOT. is_equal ) THEN
+    CALL Display_Message( 'MWwaterCoeff_Equal' ,'MWwaterCoeff are different', err_stat )
+    STOP 1
+  END IF
+  CALL MWwaterCoeff_Destroy (MWwaterC_LUT)
+  CALL MWwaterCoeff_Destroy (MWwaterC_NEW)
+
+  STOP 0
+
+END PROGRAM test_MWwater_io


### PR DESCRIPTION
## Description

- This PR adds a new module (`CRTM_MWwaterCoeff_Load_FASTEM`) to load `MWwater_Coeff` directly from the existing MWwaterCoeff generation packages (`EmisCoeff/MW_Water/MWwaterCoeff_CreateFile`). 
- With FASTEM6 (default) and FASTEM4, no LUTs are required to initialize CRTM.
- With FASTEM5, users still need the corresponding Binary LUTs (`FASTEM5.MWwater.EmisCoeff.bin, MWwaterLUT.bin`). The initialization module (`CRTM_MWwaterCoeff_Load`) is currently commented out in `CRTM_LifeCycle.F90`. Users who wish to use this scheme should contact the CRTM team directly.
- One unit test is added to demonstrate modules `CRTM_MWwaterCoeff_Load` and `CRTM_MWwaterCoeff_Load_FASTEM` are equivalent  for FASTEM6 and FASTEM4. This test may be deleted after the new loading method is fully tested.

## Issue(s) addressed
This PR is part of the CRTM surface emissivity code sprint. 

## Dependencies
None

## Impact
- CRTM uses FASTEM6 by default (no arguments are needed); No binary table is needed.
- To use FASTEM4, set `MWwaterCoeff_Scheme = FASTEM4` in CRTM_Init(); No binary table is needed. 
- To use FASTEM 5, contact the CRTM team direct for additional support.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
