### PR TITLE
Add a download-only option to the Get_CRTM_Binary_Files script

### DIFF
--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -6,7 +6,6 @@
 foldername="fix_REL-3.1.1.2"
 checksum=58e0a5c698a438a31dc4914fcda39846
 filename="${foldername}.tgz"
-echo "$filename"
 download_url=https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename
 
 usage() {

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -9,6 +9,31 @@ filename="${foldername}.tgz"
 echo "$filename"
 download_url=https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename
 
+usage() {
+    echo "Usage: $0 [-h] [-d TARBALL_PATH]" 1>&2
+    echo "   Call without flags to download the coefficients and extract to a default location." 1>&2
+    echo "   -h: show help" 1>&2
+    echo "   -d: download tarball to specified location without extracting." 1>&2
+}
+
+DOWNLOAD_ONLY_PATH=""
+while getopts "hd:" opt; do
+  case "$opt" in
+    h)
+      usage
+      exit 0
+      ;;
+    d)
+      DOWNLOAD_ONLY_PATH=$OPTARG
+      ;;
+  esac
+done
+
+if [ -n "${DOWNLOAD_ONLY_PATH}" ]; then
+    echo "Downloading coefficients ${foldername} to file \"${DOWNLOAD_ONLY_PATH}\" and exiting."
+    wget --no-verbose $download_url -O "${DOWNLOAD_ONLY_PATH}"
+    exit 0
+fi
 
 # Check if the fix directory already exists, indicating that no download is needed.
 if [ -d "fix/" ]; then #fix directory exists

--- a/Get_CRTM_Binary_Files.sh
+++ b/Get_CRTM_Binary_Files.sh
@@ -9,7 +9,7 @@ filename="${foldername}.tgz"
 download_url=https://bin.ssec.wisc.edu/pub/s4/CRTM/$filename
 
 usage() {
-    echo "Usage: $0 [-h] [-d TARBALL_PATH]" 1>&2
+    echo "Usage: $0 [-h] [-d TARBALL_PATH/filename.tgz]" 1>&2
     echo "   Call without flags to download the coefficients and extract to a default location." 1>&2
     echo "   -h: show help" 1>&2
     echo "   -d: download tarball to specified location without extracting." 1>&2


### PR DESCRIPTION
This change adds a "download-only" flag to the Get_CRTM_Binary_Files script. This will be used by CI scripts to speed up configuration and reduce load on the bin.ssec.wisc.edu file servers. Currently each CI run downloads the coefficients several times. I felt it was preferred to have this option so that the CRTM repo remains the source of truth for the coefficients download location, thus any change to the preferred source or version of CRTM coefficients will be immediately available in our tests.

Here are three example invocations demonstrating the new features and continued function of the original feature.
```
# Show help
eparker@macbook:~/git/jcsda/crtmv3$  ./Get_CRTM_Binary_Files.sh -h
Usage: ./Get_CRTM_Binary_Files.sh [-h] [-d TARBALL_PATH]
   Call without flags to download the coefficients and extract to a default location.
   -h: show help
   -d: download tarball to specified location without extracting.


# Download tarball only.
eparker@macbook:~/git/jcsda/crtmv3$  ./Get_CRTM_Binary_Files.sh -d tarball_1.tgz
Downloading coefficients fix_REL-3.1.1.2 to file "tarball_1.tgz" and exiting.
2024-12-04 13:31:43 URL:https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.1.1.2.tgz [7852108208/7852108208] -> "tarball_1.tgz" [2]


# Invoke without flags to download and extract.
eparker@macbook:~/git/jcsda/crtmv3$ ./Get_CRTM_Binary_Files.sh
Downloading fix_REL-3.1.1.2.tgz (7 GB tar file)
--2024-12-04 11:44:11--  https://bin.ssec.wisc.edu/pub/s4/CRTM/fix_REL-3.1.1.2.tgz
Resolving bin.ssec.wisc.edu (bin.ssec.wisc.edu)... 144.92.1.6
Connecting to bin.ssec.wisc.edu (bin.ssec.wisc.edu)|144.92.1.6|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7852108208 (7.3G) [application/x-gzip]
Saving to: ‘fix_REL-3.1.1.2.tgz’

fix_REL-3.1.1.2.tgz          1%[>                                        ]  97.99M  5.77MB/s    eta 19m 55s
```