### PR TITLE
Update check for n_Phase_Element in aerosol and cloud LUTs

### DIFF
--- a/src/CRTM_Adjoint_Module.f90
+++ b/src/CRTM_Adjoint_Module.f90
@@ -308,7 +308,7 @@ CONTAINS
     Options      ) &  ! Optional FWD input,  M
   RESULT( Error_Status )
     USE CRTM_AerosolCoeff,        ONLY: AeroC
-    USE CRTM_CloudCoeff,          ONLY: CloudC 
+    USE CRTM_CloudCoeff,          ONLY: CloudC
     ! Arguments
     TYPE(CRTM_Atmosphere_type)       , INTENT(IN)     :: Atmosphere(:)      ! M
     TYPE(CRTM_Surface_type)          , INTENT(IN)     :: Surface(:)         ! M
@@ -401,7 +401,7 @@ CONTAINS
     ! PROFILE LOOPS
     ! ------------
 
-!JR First loop just checks validity of Atmosphere(m) contents    
+!JR First loop just checks validity of Atmosphere(m) contents
 !$OMP PARALLEL DO PRIVATE (m, Opt, AncillaryInput) SCHEDULE (runtime)
     Profile_Loop2: DO m = 1, n_Profiles
       ! Check the optional Options structure argument
@@ -422,7 +422,7 @@ CONTAINS
       CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
       RETURN
     END IF
-      
+
     IF (enable_timing) THEN
       CALL SYSTEM_CLOCK (count=count_end)
       elapsed = REAL (count_end - count_start) / REAL (count_rate)
@@ -452,7 +452,7 @@ CONTAINS
       INTEGER, INTENT(in) :: m               ! profile index
       TYPE(CRTM_Options_type), INTENT(IN) :: Opt
       TYPE(CRTM_AncillaryInput_type), INTENT(IN) :: AncillaryInput
-   
+
       ! Local variables
       INTEGER :: Error_Status
       CHARACTER(256) :: Message
@@ -533,7 +533,7 @@ CONTAINS
       CALL CRTM_Surface_NonVariableCopy( Surface(m), Surface_AD(m) )
 
       IF( Opt%n_Stokes > 0 ) RTV%n_Stokes = Opt%n_Stokes
-      AtmOptics%n_Stokes = RTV%n_Stokes    
+      AtmOptics%n_Stokes = RTV%n_Stokes
       ! ...Assign the option specific SfcOptics input
       SfcOptics%n_Stokes = RTV%n_Stokes
       SfcOptics_AD%n_Stokes = RTV%n_Stokes
@@ -618,7 +618,7 @@ CONTAINS
         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
         RETURN
       END IF
-      ! Calculate cloud water density 
+      ! Calculate cloud water density
       CALL Calculate_Cloud_Water_Density(Atm)
 
       ! ...Similarly extend a copy of the input adjoint atmosphere
@@ -626,16 +626,32 @@ CONTAINS
 
       ! Calculate the height and water density
       !CALL Calculate_Cloud_Water_Density(Atm, Atm_AD)
-      Atm_AD%Height = Atm%Height      
+      Atm_AD%Height = Atm%Height
 
-      IF( (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) .or. &
-         (RTV%n_Stokes > 1.and.CloudC%N_PHASE_ELEMENTS < 6) ) THEN
-        Error_Status = FAILURE
-        WRITE( Message,'("N_PHASE_ELEMENTS NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
-        CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
-        RETURN
+      ! Check n_Stokes and number of phase elements
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. &
+           (RTV%n_Stokes > 1 .AND. CloudC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD LUT NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
       END IF
 
+      IF ( CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (RTV%n_Stokes > 1 .AND. AeroC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF AEROSOL LUT NOT RIGHT ",i0)' ) AeroC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) ) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD AND AEROSOL LUTS DO NOT MATCH")' )
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
       ! Prepare the atmospheric optics structures
       ! ...Allocate the atmospheric optics structures based on Atm extension
       CALL CRTM_AtmOptics_Create( AtmOptics, &
@@ -694,7 +710,7 @@ CONTAINS
 
       ! Setup for fractional cloud coverage
       IF ( CRTM_Atmosphere_IsFractional(cloud_coverage_flag) ) THEN
-      
+
         ! Compute cloudcover
         Error_Status = CloudCover%Compute_CloudCover(atm, Overlap = opt%Overlap_Id)
         IF ( Error_Status /= SUCCESS ) THEN
@@ -832,7 +848,7 @@ CONTAINS
           ln = ln + 1
           AtmOptics%n_Stokes = RTV%n_Stokes
           AtmOptics_AD%n_Stokes = RTV%n_Stokes
-          
+
           ! ...Assign sensor+channel information to output
           RTSolution(ln,m)%Sensor_Id        = ChannelInfo(n)%Sensor_Id
           RTSolution(ln,m)%WMO_Satellite_Id = ChannelInfo(n)%WMO_Satellite_Id
@@ -1031,10 +1047,10 @@ CONTAINS
             END IF
           END IF
 
-!  non scattering case, this condition may be changed for future surface reflectance 
+!  non scattering case, this condition may be changed for future surface reflectance
   IF( .not.RTSolution(ln,m)%Scattering_FLAG .or. .not.AtmOptics%Include_Scattering ) RTV%n_Azi = 0
 !!!          IF( .not. RTV%Scattering_RT ) RTV%n_Azi = 0
-          
+
           ! Fourier component loop for azimuth angles (VIS).
           ! mth_Azi = 0 is for an azimuth-averaged value (IR, MW)
           ! ...Initialise radiance
@@ -1057,8 +1073,8 @@ CONTAINS
 !  Clear_sky case uses Emission_Module.f90 without atmospheric scatterings right now.
                IF( ks == 1 ) &
                RTSolution_Clear_AD%Radiance = (ONE - CloudCover%Total_Cloud_Cover) * RTSolution_AD(ln,m)%Stokes(ks)
-               RTSolution_AD(ln,m)%Stokes(ks) = CloudCover%Total_Cloud_Cover * RTSolution_AD(ln,m)%Stokes(ks)          
-              END DO          
+               RTSolution_AD(ln,m)%Stokes(ks) = CloudCover%Total_Cloud_Cover * RTSolution_AD(ln,m)%Stokes(ks)
+              END DO
               END IF
             END IF
 
@@ -1136,29 +1152,29 @@ CONTAINS
               r_cloudy(ks) = RTSolution(ln,m)%Stokes(ks)  ! Save the 100% cloudy radiance
               RTSolution(ln,m)%Stokes(ks) = &
                   ((ONE - CloudCover%Total_Cloud_Cover) * RTSolution_Clear%Stokes(ks)) + &
-                  (CloudCover%Total_Cloud_Cover * RTSolution(ln,m)%Stokes(ks))              
+                  (CloudCover%Total_Cloud_Cover * RTSolution(ln,m)%Stokes(ks))
               END DO
               RTSolution(ln,m)%Radiance = RTSolution(ln,m)%Stokes(1)
               END IF
               ! ...Save the cloud cover in the output structure
               RTSolution(ln,m)%Total_Cloud_Cover = CloudCover%Total_Cloud_Cover
             END IF
- 
+
             ! The radiance post-processing
             CALL Post_Process_RTSolution(Opt, RTSolution(ln,m), &
                                          NLTE_Predictor, &
                                          ChannelIndex, SensorIndex, &
-                                         compute_antenna_correction, GeometryInfo)  
-                                        
+                                         compute_antenna_correction, GeometryInfo)
+
             IF  ( SC(SensorIndex)%Is_Active_Sensor .AND. AtmOptics%Include_Scattering) THEN
                 CALL CRTM_Compute_Reflectivity(Atm             , & ! Input
                                                AtmOptics       , & ! Input
                                                GeometryInfo    , & ! Input
                                                SensorIndex     , & ! Input
                                                ChannelIndex    , & ! Input
-                                               RTSolution(ln,m))   ! Input/Output                        
+                                               RTSolution(ln,m))   ! Input/Output
             ENDIF
- 
+
         IF ( SpcCoeff_IsInfraredSensor( SC(SensorIndex) ) .OR. &
                SpcCoeff_IsMicrowaveSensor( SC(SensorIndex) ) ) THEN
             ! Perform clear-sky post and pre-processing
@@ -1192,7 +1208,7 @@ CONTAINS
 
      END IF
          ! The adjoint of the clear sky radiative transfer for fractionally cloudy atmospheres
-          IF ( CRTM_Atmosphere_IsFractional(cloud_coverage_flag).and.RTV%mth_Azi==0 ) THEN 
+          IF ( CRTM_Atmosphere_IsFractional(cloud_coverage_flag).and.RTV%mth_Azi==0 ) THEN
                 RTV_Clear%mth_Azi = RTV%mth_Azi
                 SfcOptics_Clear%mth_Azi = SfcOptics%mth_Azi
                 Error_Status = CRTM_Compute_RTSolution_AD( &
@@ -1218,7 +1234,7 @@ CONTAINS
                   RETURN
                 END IF
               END IF
-      
+
               ! The adjoint of the radiative transfer
               Error_Status = CRTM_Compute_RTSolution_AD( &
                                Atm                , &  ! FWD Input
@@ -1243,13 +1259,13 @@ CONTAINS
                 CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
                 RETURN
               END IF
-              
+
               ! Compute the adjoint for active sensors
               ! It is prefered to keep the adjoint for active sensors here, thoguh it
               ! may not be in the reverse order for TL code
               IF  ( SC(SensorIndex)%Is_Active_Sensor .AND. AtmOptics%Include_Scattering) THEN
                  CALL CRTM_Compute_Reflectivity_AD(Atm       , & ! Input
-                                                   AtmOptics   , &  ! Input 
+                                                   AtmOptics   , &  ! Input
                                                    RTSolution(ln,m), & ! Input
                                                    GeometryInfo    , & ! Input
                                                    SensorIndex , &  ! Input
@@ -1266,7 +1282,7 @@ CONTAINS
        IF ( CRTM_Atmosphere_IsFractional(cloud_coverage_flag) ) THEN
               RTSolution(ln,m)%R_Clear           = RTSolution_Clear%Radiance
               RTSolution(ln,m)%Tb_Clear          = RTSolution_Clear%Brightness_Temperature
-              
+
          IF( CloudCover%Total_Cloud_Cover > ZERO) THEN
             IF( RTV%n_Stokes == 1 ) THEN
                 CloudCover_AD%Total_Cloud_Cover = CloudCover_AD%Total_Cloud_Cover &
@@ -1280,10 +1296,10 @@ CONTAINS
                    * RTSolution_AD(ln,m)%Stokes(ks)/CloudCover%Total_Cloud_Cover
                 END DO
             END IF
-         END IF   
+         END IF
        END IF
       END IF
- 
+
           ! ###################################################
           ! TEMPORARY FIX : SENSOR-DEPENDENT AZIMUTH ANGLE LOOP
           ! ###################################################
@@ -1421,7 +1437,7 @@ CONTAINS
         ! ...Clear sky atmosphere
 
         Error_Status = CRTM_Atmosphere_ClearSkyCopy_AD(Atm, Atm_Clear_AD, Atm_AD)
-  
+
         IF ( Error_Status /= SUCCESS ) THEN
           Error_status = FAILURE
           WRITE( Message,'("Error copying CLEAR SKY adjoint Atmosphere structure for profile #",i0)' ) m
@@ -1439,7 +1455,7 @@ CONTAINS
           RETURN
         END IF
       END IF
-          
+
       ! Adjoint of the atmosphere layer addition
       Error_Status = CRTM_Atmosphere_AddLayers_AD( Atmosphere(m), Atm_AD, Atmosphere_AD(m) )
 
@@ -1470,7 +1486,7 @@ CONTAINS
     CALL ASvar_Destroy( ASvar )
     CALL RTV_Destroy( RTV )
 
-    END FUNCTION profile_solution 
+    END FUNCTION profile_solution
     ! ----------------------------------------------------------------
     ! Local subroutine to post-process the FORWARD radiance, as it is
     ! the same for all-sky and fractional clear-sky cases.
@@ -1564,5 +1580,5 @@ CONTAINS
 
 
   END FUNCTION CRTM_Adjoint
-  
+
 END MODULE CRTM_Adjoint_Module

--- a/src/CRTM_Forward_Module.f90
+++ b/src/CRTM_Forward_Module.f90
@@ -598,10 +598,27 @@ CONTAINS
          RETURN
       END IF
 
-      IF( (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) .OR. &
-           (RTV(1)%n_Stokes > 1.AND.CloudC%N_PHASE_ELEMENTS < 6) ) THEN
+      ! Check n_Stokes and number of phase elements
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. CloudC%N_PHASE_ELEMENTS < 6 )) THEN
          Error_Status = FAILURE
-         WRITE( Message,'("N_PHASE_ELEMENTS NOT RIGHT FW ",i0)' ) CloudC%N_PHASE_ELEMENTS
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD LUT NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+
+      IF ( CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. AeroC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF AEROSOL LUT NOT RIGHT ",i0)' ) AeroC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) ) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD AND AEROSOL LUTS DO NOT MATCH")' )
          CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
          RETURN
       END IF

--- a/src/CRTM_K_Matrix_Module.f90
+++ b/src/CRTM_K_Matrix_Module.f90
@@ -707,14 +707,31 @@ CONTAINS
         RETURN
       END IF
 
-      IF( (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) .or. &
-         (RTV(1)%n_Stokes > 1.and.CloudC%N_PHASE_ELEMENTS < 6) ) THEN
-        Error_Status = FAILURE
-
-        WRITE( Message,'("N_PHASE_ELEMENTS NOT RIGHT FW ",i0)' ) CloudC%N_PHASE_ELEMENTS
-        CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
-        RETURN
+      ! Check n_Stokes and number of phase elements
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. CloudC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD LUT NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
       END IF
+
+      IF ( CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. AeroC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF AEROSOL LUT NOT RIGHT ",i0)' ) AeroC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) ) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD AND AEROSOL LUTS DO NOT MATCH")' )
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+      
       ! Calculate cloud water density
       CALL Calculate_Cloud_Water_Density(Atm)
 
@@ -1083,7 +1100,7 @@ CONTAINS
               ! (2) If aerosol/cloud and MieParameter < 0.01_fp, AtmOptics(nt)%n_Legendre_Terms == 4
               !     Follow the legacy code, make sure RTSolution(ln,m)%n_Full_Streams == 6 for visible channels
               ! Rayleigh phase function has 0, 1, 2 components.
-              IF( AtmOptics(nt)%n_Legendre_Terms <= 4 ) THEN                
+              IF( AtmOptics(nt)%n_Legendre_Terms <= 4 ) THEN
                 AtmOptics(nt)%n_Legendre_Terms = 4
                 AtmOptics_K(nt)%n_Legendre_Terms = AtmOptics(nt)%n_Legendre_Terms
                 RTSolution(ln,m)%Scattering_FLAG = .TRUE.
@@ -1326,7 +1343,7 @@ CONTAINS
                                                  RTSolution(ln,m))   ! Input/Output
               ENDIF
               !=============================
-           
+
 
            IF ( SpcCoeff_IsInfraredSensor( SC(SensorIndex) ) .OR. &
                SpcCoeff_IsMicrowaveSensor( SC(SensorIndex) ) ) THEN
@@ -1418,8 +1435,8 @@ CONTAINS
                 END IF
                 ! Calculate the adjoint for the active sensor reflectivity
                 IF  ( SC(SensorIndex)%Is_Active_Sensor .AND. AtmOptics(nt)%Include_Scattering) THEN
-                    CALL CRTM_Compute_Reflectivity_AD(Atm             , &  ! Input 
-                                                      AtmOptics(nt)   , &  ! Input 
+                    CALL CRTM_Compute_Reflectivity_AD(Atm             , &  ! Input
+                                                      AtmOptics(nt)   , &  ! Input
                                                       RTSolution(ln,m), & ! Input
                                                       GeometryInfo    , & ! Input
                                                       SensorIndex     , &  ! Input

--- a/src/CRTM_Tangent_Linear_Module.f90
+++ b/src/CRTM_Tangent_Linear_Module.f90
@@ -657,10 +657,10 @@ CONTAINS
         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
         RETURN
       END IF
-  
-      Atm_TL%Height = Atm%Height 
-   
-      ! ...Check the total number of Atm layers
+
+      Atm_TL%Height = Atm%Height
+
+      ! Check the total number of Atm layers
       IF ( Atm%n_Layers > MAX_N_LAYERS .OR. Atm_TL%n_Layers > MAX_N_LAYERS) THEN
         Error_Status = FAILURE
         WRITE( Message,'("Added layers [",i0,"] cause total [",i0,"] to exceed the ",&
@@ -670,13 +670,29 @@ CONTAINS
         RETURN
       END IF
 
-      IF( (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) .or. &
-         (RTV(1)%n_Stokes > 1.and.CloudC%N_PHASE_ELEMENTS < 6) ) THEN
-        Error_Status = FAILURE
+      ! Check n_Stokes and number of phase elements
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. CloudC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD LUT NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
 
-        WRITE( Message,'("N_PHASE_ELEMENTS NOT RIGHT FW ",i0)' ) CloudC%N_PHASE_ELEMENTS
-        CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
-        RETURN
+      IF ( CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (RTV(1)%n_Stokes > 1 .AND. AeroC%N_PHASE_ELEMENTS < 6 )) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF AEROSOL LUT NOT RIGHT ",i0)' ) AeroC%N_PHASE_ELEMENTS
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
+      END IF
+
+      IF ( CRTM_CloudCoeff_IsLoaded() .AND. CRTM_AerosolCoeff_IsLoaded() .AND. &
+           (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) ) THEN
+         Error_Status = FAILURE
+         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD AND AEROSOL LUTS DO NOT MATCH")' )
+         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
+         RETURN
       END IF
 
 !$OMP PARALLEL DO NUM_THREADS(n_channel_threads) PRIVATE(Message)
@@ -1339,7 +1355,7 @@ CONTAINS
                                              SensorIndex     , & ! Input
                                              ChannelIndex    , & ! Input
                                              RTSolution(ln,m))   ! Input/Output
-                                             
+
               CALL CRTM_Compute_Reflectivity_TL(Atm                 , & ! Input
                                                 AtmOptics(nt)       , & ! Input
                                                 AtmOptics_TL(nt)    , & ! Input


### PR DESCRIPTION
## Description

Per issue (https://github.com/JCSDA/CRTMv3/issues/192), fix the if statement for n_Phase_Element.

In CRTMv3. if one load cloud or aerosol table only, CRTM stops and report an error. This is because the following code block implemented in CRTMV3 Forward , Adjoint, TL, and K-matrix models. The purpose of this code block is to ensure the right number of stokes are set for CRTM calculation, but the current version neglects the cases when only one of the tables are loaded. By default, AeroC%N_PHASE_ELEMENTS = 0 and CloudC%N_PHASE_ELEMENTS = 0, while in CRTM tables, these numbers are either 1 or 6. For profiles with no cloud and no aerosol, CRTM runs fine.

```
      IF( (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) .or. &
         (RTV%n_Stokes > 1.and.CloudC%N_PHASE_ELEMENTS < 6) ) THEN
        Error_Status = FAILURE
        WRITE( Message,'("N_PHASE_ELEMENTS NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
        CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
        RETURN
      END IF
```

In this PR, we updated this code block so users can choose to load cloud or aerosol table only.
```
      ! Check n_Stokes and number of phase elements
      IF ( CRTM_CloudCoeff_IsLoaded() .AND. &
           (RTV%n_Stokes > 1 .AND. CloudC%N_PHASE_ELEMENTS < 6 )) THEN
         Error_Status = FAILURE
         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD LUT NOT RIGHT ",i0)' ) CloudC%N_PHASE_ELEMENTS
         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
         RETURN
      END IF

      IF ( CRTM_AerosolCoeff_IsLoaded() .AND. &
           (RTV%n_Stokes > 1 .AND. AeroC%N_PHASE_ELEMENTS < 6 )) THEN
         Error_Status = FAILURE
         WRITE( Message,'("N_PHASE_ELEMENTS OF AEROSOL LUT NOT RIGHT ",i0)' ) AeroC%N_PHASE_ELEMENTS
         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
         RETURN
      END IF

      IF ( CRTM_CloudCoeff_IsLoaded() .AND. CRTM_AerosolCoeff_IsLoaded() .AND. &
           (CloudC%N_PHASE_ELEMENTS /= AeroC%N_PHASE_ELEMENTS) ) THEN
         Error_Status = FAILURE
         WRITE( Message,'("N_PHASE_ELEMENTS OF CLOUD AND AEROSOL LUTS DO NOT MATCH")' )
         CALL Display_Message( ROUTINE_NAME, Message, Error_Status )
         RETURN
      END IF
```

## Issue(s) addressed

Part of issue https://github.com/JCSDA/CRTMv3/issues/192

## Dependencies

None

## Impact

Users no longer need to load both cloud and aerosol LUTs for CRTMv3 calculations

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
