### PR TITLE
Replace system tar command with cmake built-in tar function

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,8 @@ else() # Download CRTM coefficients
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
     message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
+    # Use the built-in tar feature to work around an issue on Orion with the
+    # system tar command. See: https://github.com/JCSDA/spack-stack/issues/1355
     execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${UNTAR_DEST}
                     ${CMAKE_COMMAND} -E tar xzf ${DOWNLOAD_DEST}
                     RESULT_VARIABLE result

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,7 +99,8 @@ else() # Download CRTM coefficients
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
     message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
-    execute_process(COMMAND tar -xzf ${DOWNLOAD_DEST} -C ${UNTAR_DEST}
+    execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${UNTAR_DEST}
+                    ${CMAKE_COMMAND} -E tar xzf ${DOWNLOAD_DEST}
                     RESULT_VARIABLE result
                     OUTPUT_QUIET ERROR_QUIET)
     if(NOT result EQUAL 0)


### PR DESCRIPTION
## Description

This PR changes the CRTM test CMake configuration to use the builtin cmake tar feature instead of the system tar command to unpack the downloaded test files. This change is desired to work around an issue with the latest spack-stack Intel build on Orion as described in: jcsda/spack-stack/issues/1355.

## Issue(s) addressed

Resolves jcsda/spack-stack/issues/1355

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None - this is a cmake configuration only change which uses a different means for upacking a downloaded tar file.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
    - Built and Intel spack-stack environment on Orion using the latest develop branches, then built and tested jedi-bundle using that environment. The jedi-bundle build completed successfully and there were 7 ctest failures that match up with known test failures (and not related to this change).
