### PR TITLE
Fix to FitCoeff_Define.f90

### DIFF
--- a/src/Coefficients/FitCoeff/FitCoeff_Define.f90
+++ b/src/Coefficients/FitCoeff/FitCoeff_Define.f90
@@ -144,7 +144,7 @@ MODULE FitCoeff_Define
     INTEGER(Long) :: Release = FITCOEFF_RELEASE
     INTEGER(Long) :: Version = FITCOEFF_VERSION
     ! Dimensions
-    INTEGER(Long) :: Dimensions(1) = 0
+    INTEGER(Long) :: Dimensions(:) = 0
     ! Data
     REAL(Double), ALLOCATABLE :: C(:)
   END TYPE FitCoeff_1D_type
@@ -158,7 +158,7 @@ MODULE FitCoeff_Define
     INTEGER(Long) :: Release = FITCOEFF_RELEASE
     INTEGER(Long) :: Version = FITCOEFF_VERSION
     ! Dimensions
-    INTEGER(Long) :: Dimensions(2) = 0
+    INTEGER(Long) :: Dimensions(:) = 0
     ! Data
     REAL(Double), ALLOCATABLE :: C(:,:)
   END TYPE FitCoeff_2D_type
@@ -172,7 +172,7 @@ MODULE FitCoeff_Define
     INTEGER(Long) :: Release = FITCOEFF_RELEASE
     INTEGER(Long) :: Version = FITCOEFF_VERSION
     ! Dimensions
-    INTEGER(Long) :: Dimensions(3) = 0
+    INTEGER(Long) :: Dimensions(:) = 0
     ! Data
     REAL(Double), ALLOCATABLE :: C(:,:,:)
   END TYPE FitCoeff_3D_type


### PR DESCRIPTION
## Description
Per issue https://github.com/JCSDA/CRTMv3/issues/192#issuecomment-2620195886  
reported with fix by @ADCollard 

Fix Fortran array temporary creation in `FitCoeff_Create` subroutines

This PR addresses compiler warnings about creating unnecessary array temporaries for the `dimensions` argument in `FitCoeff_*D_Create` calls. It changes the subroutine dummy arguments from:

`  INTEGER, INTENT(IN) :: dimensions(1)`

to:

`  INTEGER, INTENT(IN) :: dimensions(:)`

for 1D, 2D, and 3D routines. This prevents the compiler from generating array temporaries when passing array sections or slices, without altering the internal logic.
