### PR TITLE
Feature/pst mwsurfem

### DIFF
--- a/src/SfcOptics/CRTM_MW_Water_SfcOptics.f90
+++ b/src/SfcOptics/CRTM_MW_Water_SfcOptics.f90
@@ -212,7 +212,7 @@ CONTAINS
            Source_Azimuth_Angle = Source_Azimuth_Angle, &
            Sensor_Azimuth_Angle = Sensor_Azimuth_Angle  )
 
-
+    
     ! Compute the surface optical parameters
     IF( SfcOptics%Use_New_MWSSEM ) THEN
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -429,6 +429,13 @@ add_test(NAME test_MWwater_io
          COMMAND $<TARGET_FILE:MWwater_IO>)
 set_tests_properties(test_MWwater_io PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
 
+# test_MWSurfEM
+add_executable(test_MWSurfEM mains/unit/Unit_Test/test_MWSurfEM.f90)
+target_link_libraries(test_MWSurfEM PRIVATE crtm)
+add_test(NAME test_MWSurfEM
+         COMMAND $<TARGET_FILE:test_MWSurfEM>)
+set_tests_properties(test_MWSurfEM PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
+
 #=================================================================================
 #forward and k_matrix regression tests
 foreach(regtype IN LISTS regression_types)

--- a/test/mains/unit/Unit_Test/test_Hypsometric.f90
+++ b/test/mains/unit/Unit_Test/test_Hypsometric.f90
@@ -1,5 +1,5 @@
 !
-! test_TL.f90
+! test_Hypsometric.f90
 !
 ! Program to test the CRTM hypsometric equation module.
 !

--- a/test/mains/unit/Unit_Test/test_MWSurfEM.f90
+++ b/test/mains/unit/Unit_Test/test_MWSurfEM.f90
@@ -1,0 +1,329 @@
+!
+! test_MWSurfEM.f90
+!
+! Program to provide a (relatively) simple example of how
+! to test the CRTM MW surface emissivity functions.
+!
+! Copyright Patrick Stegmann, 2025
+!
+PROGRAM test_MWSurfEM
+
+  ! ============================================================================
+  ! **** ENVIRONMENT SETUP FOR RTM USAGE ****
+  !
+  ! Module usage
+  USE CRTM_Module
+  USE UnitTest_Define, ONLY: UnitTest_IsEqualWithin
+  ! Disable all implicit typing
+  IMPLICIT NONE
+  ! ============================================================================
+
+
+  ! ----------
+  ! Parameters
+  ! ----------
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME   = 'test_MWSurfEM'
+  CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = './testinput/'
+  CHARACTER(*), PARAMETER :: RESULTS_PATH = './results/unit/'
+
+  ! ============================================================================
+  ! 0. **** SOME SET UP PARAMETERS FOR THIS EXAMPLE ****
+  !
+  ! Profile dimensions...
+  INTEGER, PARAMETER :: N_PROFILES  = 2
+  INTEGER, PARAMETER :: N_LAYERS    = 92
+  INTEGER, PARAMETER :: N_ABSORBERS = 2
+  INTEGER, PARAMETER :: N_CLOUDS    = 0
+  INTEGER, PARAMETER :: N_AEROSOLS  = 0
+  ! ...but only ONE Sensor at a time
+  INTEGER, PARAMETER :: N_SENSORS = 1
+
+  ! Test GeometryInfo angles. The test scan angle is based
+  ! on the default Re (earth radius) and h (satellite height)
+  REAL(fp), PARAMETER :: ZENITH_ANGLE = 30.0_fp
+  REAL(fp), PARAMETER :: SCAN_ANGLE   = 26.37293341421_fp
+  ! ============================================================================
+
+
+  ! ---------
+  ! Variables
+  ! ---------
+  CHARACTER(256) :: Message
+  CHARACTER(256) :: Version
+  CHARACTER(256) :: Sensor_Id
+  INTEGER :: Error_Status
+  INTEGER :: Allocate_Status
+  INTEGER :: n_Channels
+  INTEGER :: l, m
+  INTEGER :: testresult
+  ! Declarations for Jacobian comparisons
+  INTEGER :: n_la, n_ma
+  INTEGER :: n_ls, n_ms
+  CHARACTER(256) :: atmk_File, sfck_File
+  REAL(fp) :: Perturbation
+  REAL(fp) :: Ratio
+  REAL(fp), PARAMETER :: TOLERANCE = 0.1_fp
+
+
+  ! ============================================================================
+  ! 1. **** DEFINE THE CRTM INTERFACE STRUCTURES ****
+  !
+  TYPE(CRTM_ChannelInfo_type)             :: ChannelInfo(N_SENSORS)
+  TYPE(CRTM_Geometry_type)                :: Geometry(N_PROFILES)
+
+  ! Define the FORWARD variables
+  TYPE(CRTM_Atmosphere_type)              :: Atm(N_PROFILES)
+  TYPE(CRTM_Surface_type)                 :: Sfc(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution(:,:)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_Perturb(:,:)
+
+  ! Define the Tangent-Linear variables
+  TYPE(CRTM_Atmosphere_type) :: Atmosphere_TL(N_PROFILES)
+  !TYPE(CRTM_Atmosphere_type) :: Perturbation
+  TYPE(CRTM_Surface_type)    :: Surface_TL(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_TL(:,:)
+  ! ============================================================================
+
+
+
+  ! Program header
+  ! --------------
+  CALL CRTM_Version( Version )
+  CALL Program_Message( PROGRAM_NAME, &
+    'Program to provide a (relatively) simple example of how '//&
+    'to call the CRTM K-Matrix function.', &
+    'CRTM Version: '//TRIM(Version) )
+
+
+  ! Get sensor id from user
+  ! -----------------------
+  !WRITE( *,'(/5x,"Enter sensor id [hirs4_n18, amsua_metop-a, or mhs_n18]: ")',ADVANCE='NO' )
+  !READ( *,'(a)' ) Sensor_Id
+  Sensor_Id = 'amsua_metop-a'
+  Sensor_Id = ADJUSTL(Sensor_Id)
+  WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id)
+
+
+  ! ============================================================================
+  ! 2. **** INITIALIZE THE CRTM ****
+  !
+  ! 2a. This initializes the CRTM for the sensors
+  !     predefined in the example SENSOR_ID parameter.
+  !     NOTE: The coefficient data file path is hard-
+  !           wired for this example.
+  ! --------------------------------------------------
+  WRITE( *,'(/5x,"Initializing the CRTM...")' )
+  Error_Status = CRTM_Init( (/Sensor_Id/), &  ! Input... must be an array, hence the (/../)
+                            ChannelInfo  , &  ! Output
+                            File_Path=COEFFICIENTS_PATH )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error initializing CRTM'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 2b. Determine the total number of channels
+  !     for which the CRTM was initialized
+  ! ------------------------------------------
+  n_Channels = SUM(CRTM_ChannelInfo_n_Channels(ChannelInfo))
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 3. **** ALLOCATE STRUCTURE ARRAYS ****
+  !
+  ! 3a. Allocate the ARRAYS
+  ! -----------------------
+  ! Note that only those structure arrays with a channel
+  ! dimension are allocated here because we've parameterized
+  ! the number of profiles in the N_PROFILES parameter.
+  !
+  ! Users can make the number of profiles dynamic also, but
+  ! then the INPUT arrays (Atmosphere, Surface) will also have to be allocated.
+  ALLOCATE( RTSolution( n_Channels, N_PROFILES ), &
+            RTSolution_Perturb( n_Channels, N_PROFILES ), &
+            RTSolution_TL( n_Channels, N_PROFILES ), &
+            STAT = Allocate_Status )
+  IF ( Allocate_Status /= 0 ) THEN
+    Message = 'Error allocating structure arrays'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! 3b. Allocate the STRUCTURES
+  ! ---------------------------
+  ! The input FORWARD structure
+  CALL CRTM_Atmosphere_Create( Atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atm)) ) THEN
+    Message = 'Error allocating CRTM Atmosphere structure'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+
+  ! The input TL structure
+  CALL CRTM_Atmosphere_Create( Atmosphere_TL, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atmosphere_TL)) ) THEN
+    Message = 'Error allocating CRTM Atmosphere_TL structure'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 4. **** ASSIGN INPUT DATA ****
+  !
+  ! Fill the Atmosphere structure array.
+  ! NOTE: This is an example program for illustrative purposes only.
+  !       Typically, one would not assign the data as shown below,
+  !       but rather read it from file
+
+  ! 4a. Atmosphere and Surface input
+  ! --------------------------------
+  CALL Load_Atm_Data()
+  CALL Load_Sfc_Data()
+
+
+  ! 4b. GeometryInfo input
+  ! ----------------------
+  ! All profiles are given the same value
+  !  The Sensor_Scan_Angle is optional.
+  CALL CRTM_Geometry_SetValue( Geometry, &
+                               Sensor_Zenith_Angle = ZENITH_ANGLE, &
+                               Sensor_Scan_Angle   = SCAN_ANGLE )
+  ! ============================================================================
+
+  
+
+
+  ! ============================================================================
+  ! 5. **** INITIALIZE THE TL ARGUMENTS ****
+  !
+  ! 5a. Zero the LT INPUT structures
+  ! ---------------------------------------
+  CALL CRTM_Atmosphere_Zero( Atmosphere_TL )
+  CALL CRTM_Surface_Zero( Surface_TL )
+  !Atmosphere_TL(1)%Temperature = Perturbation
+  Perturbation = Atm(1)%Temperature(92)*0.1_fp
+  !Atmosphere_TL = Atm 
+  !Surface_TL = Sfc 
+  Atmosphere_TL(1)%Temperature(92) = Perturbation
+
+
+  ! ============================================================================
+
+
+
+
+  ! ============================================================================
+  ! 6. **** CALL THE CRTM TANGENT-LINEAR MODEL ****
+  !
+  Error_Status = CRTM_Tangent_Linear( Atm , &
+                                    Sfc , &
+                                    Atmosphere_TL , &
+                                    Surface_TL , &
+                                    Geometry , &
+                                    ChannelInfo , &
+                                    RTSolution , &
+                                    RTSolution_TL  )
+  IF ( Error_Status /= SUCCESS ) THEN
+   Message = 'Error in CRTM Tangent-linear Model'
+   CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+   STOP 1
+  END IF
+
+  WRITE(*,*) 'Tangent-linear Result: ', RTSolution_TL(5,1)%Radiance
+
+  ! ============================================================================
+
+
+
+  ! ============================================================================
+  ! 6. **** CALL THE CRTM FORWARD MODEL ****
+  !
+  Error_Status = CRTM_Forward( Atm         , &
+                                Sfc         , &
+                                Geometry    , &
+                                ChannelInfo , &
+                                RTSolution  )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error in CRTM Forward Model'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+  Atm(1)%Temperature(92) = Atm(1)%Temperature(92) + Perturbation
+
+  ! ============================================================================
+  ! 6. **** CALL THE PERTURBED CRTM FORWARD MODEL ****
+  !
+  Error_Status = CRTM_Forward( Atm         , &
+                                Sfc         , &
+                                Geometry    , &
+                                ChannelInfo , &
+                                RTSolution_Perturb  )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error in perturbed CRTM Forward Model'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+  WRITE(*,*) 'Nonlinear Perturbation: ', ( RTSolution_Perturb(5,1)%Radiance - RTSolution(5,1)%Radiance )
+  Ratio = ( RTSolution_Perturb(5,1)%Radiance - RTSolution(5,1)%Radiance ) &
+               / RTSolution_TL(5,1)%Radiance
+  WRITE(*,*) 'Ratio: ', Ratio
+
+  ! ============================================================================
+  ! 8. **** DESTROY THE CRTM ****
+  !
+  WRITE( *, '( /5x, "Destroying the CRTM..." )' )
+  Error_Status = CRTM_Destroy( ChannelInfo )
+  IF ( Error_Status /= SUCCESS ) THEN
+    Message = 'Error destroying CRTM'
+    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    STOP 1
+  END IF
+  ! ============================================================================
+
+
+
+
+  
+
+  ! ============================================================================
+  ! 10. **** CLEAN UP ****
+  !
+  ! 10a. Deallocate the structures.
+  !      These are the explicitly allocated structures.
+  !      Note that in some cases other structures, such as the Sfc
+  !      and RTSolution structures, will also be allocated and thus
+  !      should also be deallocated here.
+  ! ---------------------------------------------------------------
+  CALL CRTM_Atmosphere_Destroy(Atmosphere_TL)
+  CALL CRTM_Atmosphere_Destroy(Atm)
+
+  ! 10b. Deallocate the arrays
+  ! --------------------------
+  DEALLOCATE(RTSolution, RTSolution_TL, &
+             STAT = Allocate_Status)
+  ! ============================================================================
+  IF(ONE - Ratio < TOLERANCE) THEN
+    testresult = 0
+    STOP 0
+  ELSE
+    testresult = 1
+    STOP 1
+  END IF
+ 
+CONTAINS
+
+  INCLUDE 'Load_Atm_Data.inc'
+  INCLUDE 'Load_Sfc_Data.inc'
+
+END PROGRAM test_MWSurfEM

--- a/test/mains/unit/Unit_Test/test_MWSurfEM.f90
+++ b/test/mains/unit/Unit_Test/test_MWSurfEM.f90
@@ -12,8 +12,29 @@ PROGRAM test_MWSurfEM
   ! **** ENVIRONMENT SETUP FOR RTM USAGE ****
   !
   ! Module usage
-  USE CRTM_Module
-  USE UnitTest_Define, ONLY: UnitTest_IsEqualWithin
+  USE UnitTest_Define, ONLY: UnitTest_type,   &
+                             UnitTest_Init,   &
+                             UnitTest_Setup,  &
+                             UnitTest_Assert, &
+                             UnitTest_Passed
+  USE Type_Kinds,               ONLY: fp
+  USE CRTM_Surface_Define, ONLY: CRTM_Surface_type
+  USE SpcCoeff_Define, ONLY: SpcCoeff_type
+  USE CRTM_Geometry_Define, ONLY: CRTM_Geometry_type
+  USE CRTM_GeometryInfo_Define, ONLY: CRTM_GeometryInfo_type, &
+                                      CRTM_GeometryInfo_SetValue, &
+                                      CRTM_GeometryInfo_Destroy
+  USE CRTM_SpcCoeff
+  USE Message_Handler, ONLY: SUCCESS, Display_Message
+  !USE CRTM_MW_Water_SfcOptics, ONLY: iVar_type, &
+  !                                   Compute_MW_Water_SfcOptics
+  USE CRTM_SfcOptics_Define, ONLY: CRTM_SfcOptics_type, &
+                                   CRTM_SfcOptics_Create, &
+                                   CRTM_SfcOptics_Destroy
+  USE CRTM_MWwaterCoeff, ONLY: CRTM_MWwaterCoeff_Load_FASTEM
+  USE CRTM_SfcOptics, ONLY: iVar_type, &
+                            CRTM_Compute_SfcOptics
+
   ! Disable all implicit typing
   IMPLICIT NONE
   ! ============================================================================
@@ -25,6 +46,7 @@ PROGRAM test_MWSurfEM
   CHARACTER(*), PARAMETER :: PROGRAM_NAME   = 'test_MWSurfEM'
   CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = './testinput/'
   CHARACTER(*), PARAMETER :: RESULTS_PATH = './results/unit/'
+  LOGICAL,      PARAMETER :: Quiet = .TRUE.
 
   ! ============================================================================
   ! 0. **** SOME SET UP PARAMETERS FOR THIS EXAMPLE ****
@@ -50,141 +72,76 @@ PROGRAM test_MWSurfEM
   ! ---------
   CHARACTER(256) :: Message
   CHARACTER(256) :: Version
-  CHARACTER(256) :: Sensor_Id
+  CHARACTER(256), DIMENSION(1) :: Sensor_Id
   INTEGER :: Error_Status
   INTEGER :: Allocate_Status
   INTEGER :: n_Channels
+  INTEGER :: SensorIndex
+  INTEGER :: ChannelIndex
   INTEGER :: l, m
   INTEGER :: testresult
-  ! Declarations for Jacobian comparisons
-  INTEGER :: n_la, n_ma
-  INTEGER :: n_ls, n_ms
-  CHARACTER(256) :: atmk_File, sfck_File
-  REAL(fp) :: Perturbation
-  REAL(fp) :: Ratio
-  REAL(fp), PARAMETER :: TOLERANCE = 0.1_fp
+  TYPE(UnitTest_type) :: ioTest
+  LOGICAL :: testPassed
 
 
   ! ============================================================================
   ! 1. **** DEFINE THE CRTM INTERFACE STRUCTURES ****
   !
-  TYPE(CRTM_ChannelInfo_type)             :: ChannelInfo(N_SENSORS)
-  TYPE(CRTM_Geometry_type)                :: Geometry(N_PROFILES)
-
+  TYPE(CRTM_GeometryInfo_type), DIMENSION(N_PROFILES) :: GeometryInfo(N_PROFILES)
+  TYPE(iVar_type)                         :: iVar
   ! Define the FORWARD variables
-  TYPE(CRTM_Atmosphere_type)              :: Atm(N_PROFILES)
   TYPE(CRTM_Surface_type)                 :: Sfc(N_PROFILES)
-  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution(:,:)
-  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_Perturb(:,:)
+  TYPE(CRTM_SfcOptics_type)               :: SfcOptics
 
-  ! Define the Tangent-Linear variables
-  TYPE(CRTM_Atmosphere_type) :: Atmosphere_TL(N_PROFILES)
-  !TYPE(CRTM_Atmosphere_type) :: Perturbation
-  TYPE(CRTM_Surface_type)    :: Surface_TL(N_PROFILES)
-  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_TL(:,:)
   ! ============================================================================
-
-
-
-  ! Program header
-  ! --------------
-  CALL CRTM_Version( Version )
-  CALL Program_Message( PROGRAM_NAME, &
-    'Program to provide a (relatively) simple example of how '//&
-    'to call the CRTM K-Matrix function.', &
-    'CRTM Version: '//TRIM(Version) )
-
+  ! Initialize Unit test:
+  CALL UnitTest_Init(ioTest, .TRUE.)
+  CALL UnitTest_Setup(ioTest, 'test_MWSurfEM', Program_Name, .TRUE.)
 
   ! Get sensor id from user
   ! -----------------------
+  SensorIndex = 1 ! Number of sensors
   !WRITE( *,'(/5x,"Enter sensor id [hirs4_n18, amsua_metop-a, or mhs_n18]: ")',ADVANCE='NO' )
   !READ( *,'(a)' ) Sensor_Id
-  Sensor_Id = 'amsua_metop-a'
-  Sensor_Id = ADJUSTL(Sensor_Id)
-  WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id)
+  Sensor_Id = (/'atms_npp'/)
+  Sensor_Id = ADJUSTL(Sensor_Id(SensorIndex))
+  WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id(SensorIndex))
 
+  ! Load the instrument spectral coefficients
+  ! -----------------------
+  Error_Status = 3
+  Error_Status = CRTM_SpcCoeff_Load( &
+                                    Sensor_ID         = Sensor_Id        , &
+                                    File_Path         = COEFFICIENTS_PATH, &
+                                    netCDF            = .FALSE.           , &
+                                    Quiet             = Quiet          )
+  CALL UnitTest_Assert(ioTest, (Error_Status==SUCCESS) )
+  testPassed = UnitTest_Passed(ioTest)
 
-  ! ============================================================================
-  ! 2. **** INITIALIZE THE CRTM ****
-  !
-  ! 2a. This initializes the CRTM for the sensors
-  !     predefined in the example SENSOR_ID parameter.
-  !     NOTE: The coefficient data file path is hard-
-  !           wired for this example.
-  ! --------------------------------------------------
-  WRITE( *,'(/5x,"Initializing the CRTM...")' )
-  Error_Status = CRTM_Init( (/Sensor_Id/), &  ! Input... must be an array, hence the (/../)
-                            ChannelInfo  , &  ! Output
-                            File_Path=COEFFICIENTS_PATH )
   IF ( Error_Status /= SUCCESS ) THEN
-    Message = 'Error initializing CRTM'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
+    CALL Display_Message( 'CRTM_Load_SpcCoeff' ,'Error loading SpcCoeff data', Error_Status )
     STOP 1
-  END IF
+  END IF  
+
+  Error_Status = CRTM_MWwaterCoeff_Load_FASTEM( &
+                        'FASTEM6',             &
+                        Quiet             = Quiet            )
 
   ! 2b. Determine the total number of channels
   !     for which the CRTM was initialized
   ! ------------------------------------------
-  n_Channels = SUM(CRTM_ChannelInfo_n_Channels(ChannelInfo))
+  ChannelIndex = 1 ! Channel number
+  n_Channels = SC(SensorIndex)%n_Channels
   ! ============================================================================
-
-
-
-
-  ! ============================================================================
-  ! 3. **** ALLOCATE STRUCTURE ARRAYS ****
-  !
-  ! 3a. Allocate the ARRAYS
-  ! -----------------------
-  ! Note that only those structure arrays with a channel
-  ! dimension are allocated here because we've parameterized
-  ! the number of profiles in the N_PROFILES parameter.
-  !
-  ! Users can make the number of profiles dynamic also, but
-  ! then the INPUT arrays (Atmosphere, Surface) will also have to be allocated.
-  ALLOCATE( RTSolution( n_Channels, N_PROFILES ), &
-            RTSolution_Perturb( n_Channels, N_PROFILES ), &
-            RTSolution_TL( n_Channels, N_PROFILES ), &
-            STAT = Allocate_Status )
-  IF ( Allocate_Status /= 0 ) THEN
-    Message = 'Error allocating structure arrays'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-
-  ! 3b. Allocate the STRUCTURES
-  ! ---------------------------
-  ! The input FORWARD structure
-  CALL CRTM_Atmosphere_Create( Atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
-  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atm)) ) THEN
-    Message = 'Error allocating CRTM Atmosphere structure'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-
-  ! The input TL structure
-  CALL CRTM_Atmosphere_Create( Atmosphere_TL, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
-  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atmosphere_TL)) ) THEN
-    Message = 'Error allocating CRTM Atmosphere_TL structure'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-  ! ============================================================================
-
-
+  WRITE(*,*) "Channels: ", n_Channels
 
 
   ! ============================================================================
   ! 4. **** ASSIGN INPUT DATA ****
   !
-  ! Fill the Atmosphere structure array.
-  ! NOTE: This is an example program for illustrative purposes only.
-  !       Typically, one would not assign the data as shown below,
-  !       but rather read it from file
 
-  ! 4a. Atmosphere and Surface input
+  ! 4a. Surface input
   ! --------------------------------
-  CALL Load_Atm_Data()
   CALL Load_Sfc_Data()
 
 
@@ -192,138 +149,90 @@ PROGRAM test_MWSurfEM
   ! ----------------------
   ! All profiles are given the same value
   !  The Sensor_Scan_Angle is optional.
-  CALL CRTM_Geometry_SetValue( Geometry, &
-                               Sensor_Zenith_Angle = ZENITH_ANGLE, &
-                               Sensor_Scan_Angle   = SCAN_ANGLE )
+  CALL CRTM_GeometryInfo_SetValue( GeometryInfo, &
+                                   Source_Azimuth_Angle = 0._fp, &
+                                   Sensor_Azimuth_Angle = 0._fp, &
+                                   Sensor_Scan_Angle   = SCAN_ANGLE, & 
+                                   Sensor_Zenith_Angle = ZENITH_ANGLE )
   ! ============================================================================
 
-  
+  CALL CRTM_SfcOptics_Create(SfcOptics, 1, 1)
 
+  !Error_Status = Compute_MW_Water_SfcOptics( &
+  !  Sfc(1)     , &  ! Input
+  !  GeometryInfo(1), &  ! Input
+  !  SensorIndex , &  ! Input
+  !  ChannelIndex, &  ! Input
+  !  SfcOptics   , &  ! Output
+  !  iVar        )
 
-  ! ============================================================================
-  ! 5. **** INITIALIZE THE TL ARGUMENTS ****
-  !
-  ! 5a. Zero the LT INPUT structures
-  ! ---------------------------------------
-  CALL CRTM_Atmosphere_Zero( Atmosphere_TL )
-  CALL CRTM_Surface_Zero( Surface_TL )
-  !Atmosphere_TL(1)%Temperature = Perturbation
-  Perturbation = Atm(1)%Temperature(92)*0.1_fp
-  !Atmosphere_TL = Atm 
-  !Surface_TL = Sfc 
-  Atmosphere_TL(1)%Temperature(92) = Perturbation
+  Error_Status = CRTM_Compute_SfcOptics( &
+                                        Sfc(1)     , &  ! Input
+                                        GeometryInfo(1), &  ! Input
+                                        SensorIndex , &  ! Input
+                                        ChannelIndex, &  ! Input
+                                        SfcOptics   , &  ! Output
+                                        iVar        )
 
+  WRITE(*,*) "SfcOptics: ", SfcOptics%Emissivity(1,1)
 
-  ! ============================================================================
+  ! 5. Cleanup
+  CALL CRTM_SfcOptics_Destroy(SfcOptics)
+  CALL CRTM_GeometryInfo_Destroy(GeometryInfo)
 
-
-
-
-  ! ============================================================================
-  ! 6. **** CALL THE CRTM TANGENT-LINEAR MODEL ****
-  !
-  Error_Status = CRTM_Tangent_Linear( Atm , &
-                                    Sfc , &
-                                    Atmosphere_TL , &
-                                    Surface_TL , &
-                                    Geometry , &
-                                    ChannelInfo , &
-                                    RTSolution , &
-                                    RTSolution_TL  )
-  IF ( Error_Status /= SUCCESS ) THEN
-   Message = 'Error in CRTM Tangent-linear Model'
-   CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-   STOP 1
-  END IF
-
-  WRITE(*,*) 'Tangent-linear Result: ', RTSolution_TL(5,1)%Radiance
-
-  ! ============================================================================
-
-
-
-  ! ============================================================================
-  ! 6. **** CALL THE CRTM FORWARD MODEL ****
-  !
-  Error_Status = CRTM_Forward( Atm         , &
-                                Sfc         , &
-                                Geometry    , &
-                                ChannelInfo , &
-                                RTSolution  )
-  IF ( Error_Status /= SUCCESS ) THEN
-    Message = 'Error in CRTM Forward Model'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-  ! ============================================================================
-
-  Atm(1)%Temperature(92) = Atm(1)%Temperature(92) + Perturbation
-
-  ! ============================================================================
-  ! 6. **** CALL THE PERTURBED CRTM FORWARD MODEL ****
-  !
-  Error_Status = CRTM_Forward( Atm         , &
-                                Sfc         , &
-                                Geometry    , &
-                                ChannelInfo , &
-                                RTSolution_Perturb  )
-  IF ( Error_Status /= SUCCESS ) THEN
-    Message = 'Error in perturbed CRTM Forward Model'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-  ! ============================================================================
-
-  WRITE(*,*) 'Nonlinear Perturbation: ', ( RTSolution_Perturb(5,1)%Radiance - RTSolution(5,1)%Radiance )
-  Ratio = ( RTSolution_Perturb(5,1)%Radiance - RTSolution(5,1)%Radiance ) &
-               / RTSolution_TL(5,1)%Radiance
-  WRITE(*,*) 'Ratio: ', Ratio
-
-  ! ============================================================================
-  ! 8. **** DESTROY THE CRTM ****
-  !
-  WRITE( *, '( /5x, "Destroying the CRTM..." )' )
-  Error_Status = CRTM_Destroy( ChannelInfo )
-  IF ( Error_Status /= SUCCESS ) THEN
-    Message = 'Error destroying CRTM'
-    CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
-    STOP 1
-  END IF
-  ! ============================================================================
-
-
-
-
-  
-
-  ! ============================================================================
-  ! 10. **** CLEAN UP ****
-  !
-  ! 10a. Deallocate the structures.
-  !      These are the explicitly allocated structures.
-  !      Note that in some cases other structures, such as the Sfc
-  !      and RTSolution structures, will also be allocated and thus
-  !      should also be deallocated here.
-  ! ---------------------------------------------------------------
-  CALL CRTM_Atmosphere_Destroy(Atmosphere_TL)
-  CALL CRTM_Atmosphere_Destroy(Atm)
-
-  ! 10b. Deallocate the arrays
-  ! --------------------------
-  DEALLOCATE(RTSolution, RTSolution_TL, &
-             STAT = Allocate_Status)
-  ! ============================================================================
-  IF(ONE - Ratio < TOLERANCE) THEN
-    testresult = 0
-    STOP 0
-  ELSE
-    testresult = 1
-    STOP 1
-  END IF
- 
 CONTAINS
 
-  INCLUDE 'Load_Atm_Data.inc'
-  INCLUDE 'Load_Sfc_Data.inc'
+  SUBROUTINE Load_Sfc_Data()
+    
+    
+    ! 4a.0 Surface type definitions for default SfcOptics definitions
+    !      For IR and VIS, this is the NPOESS reflectivities.
+    ! ---------------------------------------------------------------
+    INTEGER, PARAMETER :: TUNDRA_SURFACE_TYPE         = 10  ! NPOESS Land surface type for IR/VIS Land SfcOptics
+    INTEGER, PARAMETER :: SCRUB_SURFACE_TYPE          =  7  ! NPOESS Land surface type for IR/VIS Land SfcOptics
+    INTEGER, PARAMETER :: COARSE_SOIL_TYPE            =  1  ! Soil type                for MW land SfcOptics
+    INTEGER, PARAMETER :: GROUNDCOVER_VEGETATION_TYPE =  7  ! Vegetation type          for MW Land SfcOptics
+    INTEGER, PARAMETER :: BARE_SOIL_VEGETATION_TYPE   = 11  ! Vegetation type          for MW Land SfcOptics
+    INTEGER, PARAMETER :: SEA_WATER_TYPE              =  1  ! Water type               for all SfcOptics
+    INTEGER, PARAMETER :: FRESH_SNOW_TYPE             =  2  ! NPOESS Snow type         for IR/VIS SfcOptics
+    INTEGER, PARAMETER :: FRESH_ICE_TYPE              =  1  ! NPOESS Ice type          for IR/VIS SfcOptics
+
+
+
+    ! 4a.1 Profile #1
+    ! ---------------
+    ! ...Land surface characteristics
+    !sfc(1)%Land_Coverage     = 0.1_fp
+    !sfc(1)%Land_Type         = TUNDRA_SURFACE_TYPE
+    !sfc(1)%Land_Temperature  = 272.0_fp
+    !sfc(1)%Lai               = 0.17_fp
+    !sfc(1)%Soil_Type         = COARSE_SOIL_TYPE
+    !sfc(1)%Vegetation_Type   = GROUNDCOVER_VEGETATION_TYPE
+    ! ...Water surface characteristics
+    sfc(1)%Water_Coverage    = 1.0_fp !0.5_fp
+    sfc(1)%Water_Type        = SEA_WATER_TYPE
+    sfc(1)%Water_Temperature = 275.0_fp
+    ! ...Snow coverage characteristics
+    !sfc(1)%Snow_Coverage    = 0.25_fp
+    !sfc(1)%Snow_Type        = FRESH_SNOW_TYPE
+    !sfc(1)%Snow_Temperature = 265.0_fp
+    ! ...Ice surface characteristics
+    !sfc(1)%Ice_Coverage    = 0.15_fp
+    !sfc(1)%Ice_Type        = FRESH_ICE_TYPE
+    !sfc(1)%Ice_Temperature = 269.0_fp
+
+
+
+    ! 4a.2 Profile #2
+    ! ---------------
+    ! Surface data
+    sfc(2)%Land_Coverage    = 1.0_fp
+    sfc(2)%Land_Type        = SCRUB_SURFACE_TYPE
+    sfc(2)%Land_Temperature = 318.0_fp
+    sfc(2)%Lai              = 0.65_fp
+    sfc(2)%Soil_Type        = COARSE_SOIL_TYPE
+    sfc(2)%Vegetation_Type  = BARE_SOIL_VEGETATION_TYPE
+
+  END SUBROUTINE Load_Sfc_Data
 
 END PROGRAM test_MWSurfEM

--- a/test/mains/unit/Unit_Test/test_MWSurfEM.f90
+++ b/test/mains/unit/Unit_Test/test_MWSurfEM.f90
@@ -78,9 +78,9 @@ PROGRAM test_MWSurfEM
   INTEGER :: n_Channels
   INTEGER :: SensorIndex
   INTEGER :: ChannelIndex
-  INTEGER :: l, m
+  INTEGER :: ii
   INTEGER :: testresult
-  TYPE(UnitTest_type) :: ioTest
+  TYPE(UnitTest_type) :: emTest
   LOGICAL :: testPassed
 
 
@@ -95,8 +95,8 @@ PROGRAM test_MWSurfEM
 
   ! ============================================================================
   ! Initialize Unit test:
-  CALL UnitTest_Init(ioTest, .TRUE.)
-  CALL UnitTest_Setup(ioTest, 'test_MWSurfEM', Program_Name, .TRUE.)
+  CALL UnitTest_Init(emTest, .TRUE.)
+  CALL UnitTest_Setup(emTest, 'test_MWSurfEM', Program_Name, .TRUE.)
 
   ! Get sensor id from user
   ! -----------------------
@@ -115,18 +115,12 @@ PROGRAM test_MWSurfEM
                                     File_Path         = COEFFICIENTS_PATH, &
                                     netCDF            = .FALSE.           , &
                                     Quiet             = Quiet          )
-  CALL UnitTest_Assert(ioTest, (Error_Status==SUCCESS) )
-  testPassed = UnitTest_Passed(ioTest)
-
-  IF ( Error_Status /= SUCCESS ) THEN
-    CALL Display_Message( 'CRTM_Load_SpcCoeff' ,'Error loading SpcCoeff data', Error_Status )
-    STOP 1
-  END IF  
+  CALL UnitTest_Assert(emTest, (Error_Status==SUCCESS) )
 
   Error_Status = CRTM_MWwaterCoeff_Load_FASTEM( &
                         'FASTEM6',             &
                         Quiet             = Quiet            )
-
+  CALL UnitTest_Assert(emTest, (Error_Status==SUCCESS) )
   ! 2b. Determine the total number of channels
   !     for which the CRTM was initialized
   ! ------------------------------------------
@@ -156,7 +150,9 @@ PROGRAM test_MWSurfEM
                                    Sensor_Zenith_Angle = ZENITH_ANGLE )
   ! ============================================================================
 
-  CALL CRTM_SfcOptics_Create(SfcOptics, 1, 1)
+  CALL CRTM_SfcOptics_Create(SfcOptics, &
+                              1, & ! n_Angles
+                              1)   ! n_Stokes
 
   !Error_Status = Compute_MW_Water_SfcOptics( &
   !  Sfc(1)     , &  ! Input
@@ -166,19 +162,29 @@ PROGRAM test_MWSurfEM
   !  SfcOptics   , &  ! Output
   !  iVar        )
 
-  Error_Status = CRTM_Compute_SfcOptics( &
-                                        Sfc(1)     , &  ! Input
-                                        GeometryInfo(1), &  ! Input
-                                        SensorIndex , &  ! Input
-                                        ChannelIndex, &  ! Input
-                                        SfcOptics   , &  ! Output
-                                        iVar        )
+  ChannelLoop: DO ChannelIndex = 1, n_Channels
+    Error_Status = CRTM_Compute_SfcOptics( &
+                                          Sfc(1)     , &  ! Input
+                                          GeometryInfo(1), &  ! Input
+                                          SensorIndex , &  ! Input
+                                          ChannelIndex, &  ! Input
+                                          SfcOptics   , &  ! Output
+                                          iVar        )
+    WRITE(*,*) "Channel: ", ChannelIndex, " Emissivity: ", SfcOptics%Emissivity
+  END DO ChannelLoop
 
-  WRITE(*,*) "SfcOptics: ", SfcOptics%Emissivity(1,1)
+  CALL UnitTest_Assert(emTest, (Error_Status==SUCCESS) )
 
   ! 5. Cleanup
   CALL CRTM_SfcOptics_Destroy(SfcOptics)
   CALL CRTM_GeometryInfo_Destroy(GeometryInfo)
+
+  testPassed = UnitTest_Passed(emTest)
+  IF(testPassed) THEN
+    STOP 0
+  ELSE
+    STOP 1
+  END IF
 
 CONTAINS
 
@@ -202,24 +208,24 @@ CONTAINS
     ! 4a.1 Profile #1
     ! ---------------
     ! ...Land surface characteristics
-    !sfc(1)%Land_Coverage     = 0.1_fp
-    !sfc(1)%Land_Type         = TUNDRA_SURFACE_TYPE
-    !sfc(1)%Land_Temperature  = 272.0_fp
-    !sfc(1)%Lai               = 0.17_fp
-    !sfc(1)%Soil_Type         = COARSE_SOIL_TYPE
-    !sfc(1)%Vegetation_Type   = GROUNDCOVER_VEGETATION_TYPE
+    sfc(1)%Land_Coverage     = 0.1_fp
+    sfc(1)%Land_Type         = TUNDRA_SURFACE_TYPE
+    sfc(1)%Land_Temperature  = 272.0_fp
+    sfc(1)%Lai               = 0.17_fp
+    sfc(1)%Soil_Type         = COARSE_SOIL_TYPE
+    sfc(1)%Vegetation_Type   = GROUNDCOVER_VEGETATION_TYPE
     ! ...Water surface characteristics
-    sfc(1)%Water_Coverage    = 1.0_fp !0.5_fp
+    sfc(1)%Water_Coverage    = 0.5_fp
     sfc(1)%Water_Type        = SEA_WATER_TYPE
     sfc(1)%Water_Temperature = 275.0_fp
     ! ...Snow coverage characteristics
-    !sfc(1)%Snow_Coverage    = 0.25_fp
-    !sfc(1)%Snow_Type        = FRESH_SNOW_TYPE
-    !sfc(1)%Snow_Temperature = 265.0_fp
+    sfc(1)%Snow_Coverage    = 0.25_fp
+    sfc(1)%Snow_Type        = FRESH_SNOW_TYPE
+    sfc(1)%Snow_Temperature = 265.0_fp
     ! ...Ice surface characteristics
-    !sfc(1)%Ice_Coverage    = 0.15_fp
-    !sfc(1)%Ice_Type        = FRESH_ICE_TYPE
-    !sfc(1)%Ice_Temperature = 269.0_fp
+    sfc(1)%Ice_Coverage    = 0.15_fp
+    sfc(1)%Ice_Type        = FRESH_ICE_TYPE
+    sfc(1)%Ice_Temperature = 269.0_fp
 
 
 

--- a/test/mains/unit/Unit_Test/test_TL.f90
+++ b/test/mains/unit/Unit_Test/test_TL.f90
@@ -106,7 +106,7 @@ PROGRAM test_TL
   ! -----------------------
   !WRITE( *,'(/5x,"Enter sensor id [hirs4_n18, amsua_metop-a, or mhs_n18]: ")',ADVANCE='NO' )
   !READ( *,'(a)' ) Sensor_Id
-  Sensor_Id = 'amsua_metop-a'
+  Sensor_Id = 'atms_n21'
   Sensor_Id = ADJUSTL(Sensor_Id)
   WRITE( *,'(//5x,"Running CRTM for ",a," sensor...")' ) TRIM(Sensor_Id)
 


### PR DESCRIPTION
## Description

This PR adds a new unit test `test_MWSurfEM` that tests the `CRTM_SfcOptics, ONLY: CRTM_Compute_SfcOptics` function for all 22 channels of `atms_npp`.
The test is a preliminary for future MW surface emissivity code changes.
### Output:
- The unit test is successful if `Error_Status==SUCCESS` is asserted for all included function calls, most importantly for `CRTM_Compute_SfcOptics`.
- The test prints one `SfcOptics%Emissivity` for each `ChannelIndex`.

## Issue(s) addressed

Resolves StegmannJCSDA/CRTMv3#1.

## Dependencies

- Requires `atms_npp` SpcCoeff coefficients in test data.

## Impact

Expected impact on downstream repositories:
- One additional unit test for all repositories that call `CRTMv3` unit tests during their build process.
- Increased test time: ca. +0.3 sec.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
