### PR TITLE
Fix for surface emissivity jacobian

### DIFF
--- a/src/RTSolution/CRTM_RTSolution_Define.f90
+++ b/src/RTSolution/CRTM_RTSolution_Define.f90
@@ -527,7 +527,7 @@ CONTAINS
     WRITE(fid,fmt) "Brightness Temperature        : ", RTSolution%Brightness_Temperature
     WRITE(fid,fmt) "Solar Irradiance              : ", RTSolution%Solar_Irradiance
     WRITE(fid,fmt) "Reflectance                   : ", RTSolution%Reflectance
-    !WRITE(fid,fmt) "Stokes                        : ", RTSolution%n_Stokes
+    !WRITE(fid,fmt) "Stokes                        : ", RTSolution%Stokes
     IF ( CRTM_RTSolution_Associated(RTSolution) ) THEN
       WRITE(fid,'(3x,"n_Layers : ",i0)') RTSolution%n_Layers
       WRITE(fid,'(3x,"Upwelling Overcast Radiance :")')

--- a/src/RTSolution/CRTM_RTSolution_Define.f90
+++ b/src/RTSolution/CRTM_RTSolution_Define.f90
@@ -441,7 +441,7 @@ CONTAINS
     RTSolution%Brightness_Temperature  = ZERO
     RTSolution%Solar_Irradiance        = ZERO
     RTSolution%Reflectance             = ZERO
-    RTSolution%Stokes  = ZERO
+    RTSolution%Stokes                  = ZERO
 
     ! Zero out the array data components
     IF ( CRTM_RTSolution_Associated(RTSolution) ) THEN
@@ -527,7 +527,7 @@ CONTAINS
     WRITE(fid,fmt) "Brightness Temperature        : ", RTSolution%Brightness_Temperature
     WRITE(fid,fmt) "Solar Irradiance              : ", RTSolution%Solar_Irradiance
     WRITE(fid,fmt) "Reflectance                   : ", RTSolution%Reflectance
-    WRITE(fid,fmt) "Stokes                        : ", RTSolution%Stokes
+    !WRITE(fid,fmt) "Stokes                        : ", RTSolution%n_Stokes
     IF ( CRTM_RTSolution_Associated(RTSolution) ) THEN
       WRITE(fid,'(3x,"n_Layers : ",i0)') RTSolution%n_Layers
       WRITE(fid,'(3x,"Upwelling Overcast Radiance :")')

--- a/src/RTSolution/Common_RTSolution.f90
+++ b/src/RTSolution/Common_RTSolution.f90
@@ -1723,9 +1723,13 @@ CONTAINS
     ! -----------------------------------------
     ! Populate the SfcOptics_AD structure based
     ! on FORWARD model SfcOptics Compute_Switch
-    ! -----------------------------------------
+    ! -----------------------------------------  
+
     IF ( SfcOptics%Compute ) THEN
-      Error_Status = CRTM_Compute_SfcOptics_AD( &
+      
+        RTSolution_AD%Surface_Emissivity = SfcOptics_AD%Emissivity(SfcOptics_AD%Index_Sat_Ang,1)
+        
+        Error_Status = CRTM_Compute_SfcOptics_AD( &
                        Surface     , & ! Input
                        SfcOptics   , & ! Input
                        SfcOptics_AD, & ! Input

--- a/test/mains/regression/k_matrix/test_ClearSky/test_ClearSky.f90
+++ b/test/mains/regression/k_matrix/test_ClearSky/test_ClearSky.f90
@@ -144,6 +144,7 @@ PROGRAM test_ClearSky
     CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
     STOP 1
   END IF
+  
 
   ! 3b. Allocate the STRUCTURES
   ! ---------------------------
@@ -251,6 +252,7 @@ PROGRAM test_ClearSky
       CALL CRTM_RTSolution_Inspect(RTSolution(l,m))
       ! K-MATRIX output
       WRITE( *, '(/3x,"K-MATRIX OUTPUT")')
+      CALL CRTM_RTSolution_Inspect(RTSolution_K(l,m))
       CALL CRTM_Surface_Inspect(Surface_K(l,m))
       CALL CRTM_Atmosphere_Inspect(Atmosphere_K(l,m))
     END DO


### PR DESCRIPTION
## Description

Fix for surface emissivity Jacobian bug per described in issue #204 

## Issue(s) addressed
Resolves #204 

## Other note
Comment out the following data logging in Scalar_Inspect( RTSolution, Unit )
`!WRITE(fid,fmt) "Stokes                        : ", RTSolution%Stokes`
Because (1) `Stokes` is not a scalar variable (2) AD implementation of stokes are not completed. Will address this in a separate issue and PR.
This does not impact the scalar calculation of CRTM

## Dependencies
None

## Impact
Change to value `RTSolution_K%Emissivity`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
