### PR TITLE
Add/use BUILD_TESTING and FIX_FILE_PATH to CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,10 @@ export(EXPORT ${PROJECT_NAME}-config
 # Additional settings for test and build type (unchanged from original)
 set(CRTM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_subdirectory(test)
 include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 # Summary (unchanged from original)
 message(STATUS "Configuration summary")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(crtm VERSION 3.1.1 LANGUAGES Fortran)
 
 option(OPENMP "Build crtm with OpenMP support" ON)
+option(FIX_FILE_PATH "Path to fix files (default: fix/)" OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ But after a clean clone of the development repository, none of the links to sour
 
 Configuration
 -------------
-At present, the `fix/` directory is provided through ftp using the Get_CRTM_Binary_Files.sh script to obtain and unpack the dataset. 
-If this directory doesn't exist during the `cmake` step, then cmake will download and install into `build/test_data/fix_REL-3.1.1.x/fix/`...
+By default, the `fix/` directory is provided through ftp using the Get_CRTM_Binary_Files.sh script to obtain and unpack the dataset. 
+If this directory doesn't exist during the `cmake` step, then cmake will download and install into `build/test_data/fix_REL-3.1.1.x/fix/`.
+The path to an existing fix file installation can be specified using the `FIX_FILE_PATH` option (see CMake variables summary below).
 
 The fix/ directory (as of v3.1.1) contains most of the netCDF SpcCoeff and TauCoeff files, as part of our ongoing effort to transition toward netCDF-only CRTM.  We expect to deprecate the binary formats in v3.2.x 
 
@@ -141,6 +142,8 @@ The CMake variables of interest are:
 `-DCMAKE_BUILD_TYPE = RELEASE / DEBUG / RELWITHDEBINFO`  (default is `RELEASE` if not specified)
 `-DBUILD_SHARED_LIBS = ON / OFF`   (build shared lib (`<build>/lib/libcrtm.so`) or static lib (`<build>/lib/libcrtm.a`) --  default is `ON` if not specified)
 `-DCMAKE_INSTALL_PREFIX=<path-to-install>` (You have to run `make install` to install the libcrtm* into your desired directory `<build>/path-to-install`).
+`-DFIX_FILE_PATH=<path-to-fix-files>` (default is `fix/`, populated by Get_CRTM_Binary_Files.sh if needed)
+`-DBUILD_TESTING = ON / OFF` (enables/disabled testing under `test/`; default is ON)
 
 
 example:
@@ -149,7 +152,7 @@ cmake -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=./
 ```
 this would make a debug build of CRTM, static library (`libcrtm.a`) and set the optional install location to `<build>/install/.` (or something similar, search for `libcrtm.*` and `*.mod`).  Custom Install only happens if you issue the `make install` command. 
 
-The first time you run `cmake`, it will check for a `fix/` directory one level above, and if it does't find it, it will download the binary files (according to `test/CMakeLists.txt` file information), and store them in `<build>/test_data/**`.  
+The first time you run `cmake`, it will check for a `fix/` directory one level above (or `FIX_FILE_PATH` CMake variable), and if it does't find it, it will download the binary files (according to `test/CMakeLists.txt` file information), and store them in `<build>/test_data/**`.  
 
 Linking to the library
 ----------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,23 +44,24 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/results/forward)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/results/unit)
 
 
-if( DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES})
-  set(LOCAL_PATH_JEDI_TESTFILES "$ENV{LOCAL_PATH_JEDI_TESTFILES}")
-endif()
-
 if ( DEFINED ENV{CRTM_TEST_ROOT})
   set(CRTM_TEST_ROOT "$ENV{CRTM_TEST_ROOT}")
 else()
   set(CRTM_TEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-
+if(NOT FIX_FILE_PATH)
+  if( DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES})
+    set(FIX_FILE_PATH "$ENV{LOCAL_PATH_JEDI_TESTFILES}/fix")
+  else()
+    set(FIX_FILE_PATH ${CMAKE_SOURCE_DIR}/fix)
+  endif()
+endif()
 
 # If local path to testfiles is defined don't download 
-IF(EXISTS  ${CMAKE_SOURCE_DIR}/fix)
-  set( CRTM_COEFFS_PATH ${CMAKE_SOURCE_DIR} )
-  message(STATUS "use LOCAL_PATH_JEDI_TESTFILES: ${CRTM_COEFFS_PATH}/fix")
-  message("Using existing local fix directory instead of downloading.")
+IF(EXISTS  ${FIX_FILE_PATH})
+  get_filename_component(CRTM_COEFFS_PATH "${FIX_FILE_PATH}/.." ABSOLUTE)
+  message(STATUS "Using existing fix files: ${CRTM_COEFFS_PATH}/fix")
   set( CRTM_COEFFS_BRANCH "" )
 
 else() # Download CRTM coefficients


### PR DESCRIPTION
## Description

This PR:
 - makes build testing optional using the CTest standard BUILD_TESTING variable, and
 - adds an option to point to an existing fix files installation (default is current behavior).

## Issue(s) addressed

Fixes #211

## Dependencies

none

## Impact

No expected impact to current CMake behavior. Will facilitate customizing CMake behavior in spack-stack.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR (186/186 tests passing)
