### PR TITLE
Revert "Fix for surface emissivity jacobian"

### DIFF
--- a/src/RTSolution/CRTM_RTSolution_Define.f90
+++ b/src/RTSolution/CRTM_RTSolution_Define.f90
@@ -441,7 +441,7 @@ CONTAINS
     RTSolution%Brightness_Temperature  = ZERO
     RTSolution%Solar_Irradiance        = ZERO
     RTSolution%Reflectance             = ZERO
-    RTSolution%Stokes                  = ZERO
+    RTSolution%Stokes  = ZERO
 
     ! Zero out the array data components
     IF ( CRTM_RTSolution_Associated(RTSolution) ) THEN
@@ -527,7 +527,7 @@ CONTAINS
     WRITE(fid,fmt) "Brightness Temperature        : ", RTSolution%Brightness_Temperature
     WRITE(fid,fmt) "Solar Irradiance              : ", RTSolution%Solar_Irradiance
     WRITE(fid,fmt) "Reflectance                   : ", RTSolution%Reflectance
-    !WRITE(fid,fmt) "Stokes                        : ", RTSolution%Stokes
+    WRITE(fid,fmt) "Stokes                        : ", RTSolution%Stokes
     IF ( CRTM_RTSolution_Associated(RTSolution) ) THEN
       WRITE(fid,'(3x,"n_Layers : ",i0)') RTSolution%n_Layers
       WRITE(fid,'(3x,"Upwelling Overcast Radiance :")')

--- a/src/RTSolution/Common_RTSolution.f90
+++ b/src/RTSolution/Common_RTSolution.f90
@@ -1723,13 +1723,9 @@ CONTAINS
     ! -----------------------------------------
     ! Populate the SfcOptics_AD structure based
     ! on FORWARD model SfcOptics Compute_Switch
-    ! -----------------------------------------  
-
+    ! -----------------------------------------
     IF ( SfcOptics%Compute ) THEN
-      
-        RTSolution_AD%Surface_Emissivity = SfcOptics_AD%Emissivity(SfcOptics_AD%Index_Sat_Ang,1)
-        
-        Error_Status = CRTM_Compute_SfcOptics_AD( &
+      Error_Status = CRTM_Compute_SfcOptics_AD( &
                        Surface     , & ! Input
                        SfcOptics   , & ! Input
                        SfcOptics_AD, & ! Input

--- a/test/mains/regression/k_matrix/test_ClearSky/test_ClearSky.f90
+++ b/test/mains/regression/k_matrix/test_ClearSky/test_ClearSky.f90
@@ -144,7 +144,6 @@ PROGRAM test_ClearSky
     CALL Display_Message( PROGRAM_NAME, Message, FAILURE )
     STOP 1
   END IF
-  
 
   ! 3b. Allocate the STRUCTURES
   ! ---------------------------
@@ -252,7 +251,6 @@ PROGRAM test_ClearSky
       CALL CRTM_RTSolution_Inspect(RTSolution(l,m))
       ! K-MATRIX output
       WRITE( *, '(/3x,"K-MATRIX OUTPUT")')
-      CALL CRTM_RTSolution_Inspect(RTSolution_K(l,m))
       CALL CRTM_Surface_Inspect(Surface_K(l,m))
       CALL CRTM_Atmosphere_Inspect(Atmosphere_K(l,m))
     END DO


### PR DESCRIPTION
Reverts JCSDA/CRTMv3#209

@BenjaminRuston @liujake This is a temporary reversion of the emissivity jacobian fix to allow for a coordinated merge with other repositories, to avoid CI failures.  This jacobian fix resulted in some values that were unexpected in JEDI/UFO.  We'll work with the various teams to get it fixed.


