### PR TITLE
updated SpcCoeff_Define Inspect and SpcCoeff_Edit.f90

### DIFF
--- a/src/Coefficients/SpcCoeff/SpcCoeff_Define.f90
+++ b/src/Coefficients/SpcCoeff/SpcCoeff_Define.f90
@@ -414,11 +414,13 @@ CONTAINS
         WRITE(*,'(5x,"Channel ",i0,": ",a)') SpcCoeff%Sensor_Channel(n), &
                                              POLARIZATION_TYPE_NAME(SpcCoeff%Polarization(n))
       END DO
-      WRITE(*,*) "Fixed Polarization Angle: "
-      DO n = 1, SpcCoeff%n_Channels
-        WRITE(*,'(3x,"Channel ",i0,": ")') SpcCoeff%Sensor_Channel(n)
-        WRITE(*,'(es22.15)') SpcCoeff%PolAngle(n)
-      END DO
+      IF (SpcCoeff%Version > 3) THEN ! See SpcCoeff_Binary_IO.f90
+         WRITE(*,*) "Fixed Polarization Angle: "
+         DO n = 1, SpcCoeff%n_Channels
+            WRITE(*,'(3x,"Channel ",i0,": ")') SpcCoeff%Sensor_Channel(n)
+            WRITE(*,'(es22.15)') SpcCoeff%PolAngle(n)
+         END DO
+      END IF
     END IF
     WRITE(*,'(3x,"Channel_Flag               :")')
     WRITE(*,'(3(1x,b32.32,:))') SpcCoeff%Channel_Flag

--- a/src/Coefficients/SpcCoeff/SpcCoeff_Edit/SpcCoeff_Edit.f90
+++ b/src/Coefficients/SpcCoeff/SpcCoeff_Edit/SpcCoeff_Edit.f90
@@ -50,7 +50,7 @@ PROGRAM SpcCoeff_Edit
   TYPE(SpcCoeff_type) :: sc
   CHARACTER(256) :: sensor_id
   INTEGER :: wmo_sensor_id, wmo_satellite_id
-  INTEGER :: version
+  INTEGER :: version, n_args
 
   ! Output program header
   CALL Program_Message( PROGRAM_NAME, &
@@ -59,14 +59,19 @@ PROGRAM SpcCoeff_Edit
                         '$Revision$' )
 
   ! Get the filename
-  WRITE( *,FMT='(/5x,"Enter the Binary SpcCoeff filename: ")',ADVANCE='NO' )
-  READ( *,'(a)' ) filename
+  n_args = COMMAND_ARGUMENT_COUNT()
+  IF ( n_args > 0 ) THEN
+     CALL GET_COMMAND_ARGUMENT(1, filename)
+  ELSE
+     WRITE( *,FMT='(/5x,"Enter the SpcCoeff filename: ")',ADVANCE='NO' )
+     READ( *,'(a)' ) filename
+  END IF
   filename = ADJUSTL(filename)
   IF ( .NOT. File_Exists( TRIM(filename) ) ) THEN
-    msg = 'File '//TRIM(filename)//' not found.'
-    CALL Display_Message( PROGRAM_NAME, msg, FAILURE ); STOP
+     msg = 'File '//TRIM(filename)//' not found.'
+     CALL Display_Message( PROGRAM_NAME, msg, FAILURE ); STOP
   END IF
-
+  
   ! Read the binary data file
   err_stat = SpcCoeff_Binary_ReadFile( filename, sc )
   IF ( err_stat /= SUCCESS ) THEN


### PR DESCRIPTION
Pull Request: Minor Improvements to SpcCoeff Display and CLI Handling
This PR includes two minor changes to the SpcCoeff module:

Guard Fixed Polarization Angle Output
In SpcCoeff_Define.f90, added a conditional to only print the Fixed Polarization Angle section if Version > 3, preventing unintended output for older-format files.

Enable Command-Line Input in SpcCoeff_Edit
In SpcCoeff_Edit.f90, updated the program to accept the SpcCoeff filename as a command-line argument. Interactive input is still supported if no argument is given, improving usability in scripting or batch workflows.

These changes are backwards-compatible and improve clarity and automation.