### PR TITLE
minor update to README.md to include information about WSL / Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Preamble
 
 CRTM v3.1.2 release (`REL-3.1.2`)
 
-v3.1.2 released June 11, 2025
+v3.1.2 released July 11, 2025
 v3.1.1 released August 12, 2024
 v3.1.0 (alpha) Released October 31, 2023
 v3.0.0 Released March, 2023  
@@ -171,6 +171,19 @@ LIBS="-lcrtm ${LIBS}"
 **Feedback and Contact Information**
 
 CRTM SUPPORT: visit https://forums.jcsda.org/ or visit https://github.com/JCSDA/CRTMv3 and post an issue (be sure to assign someone from the team).
+
+System-specific notes
+---------------------
+WSL / Ubuntu installation:
+  sudo apt update && sudo apt upgrade
+  sudo apt install cmake
+  sudo apt install gcc   (probably installed already)
+  sudo apt install gfortran
+  sudo apt install libnetcdff-dev
+  
+Then continue with the build steps per above.  You can find your number of processors by 'cat /proc/cpuinfo' and then the -j ## values for make and ctest should be: number_processors-1  e.g., make -j31 if you have 32 processors.
+
+nvfortran also works on WSL, but has a more involved install process -- if you're using nvfortran, please visit https://github.com/JCSDA/CRTMv3 and create an issue. 
 
 
 Known Issues


### PR DESCRIPTION
## Summary

This PR updates `README.md` to improve clarity and support for users building CRTM under WSL environments.

## Changes

- Corrects the release date for `v3.1.2` from June 11, 2025 to July 11, 2025.
- Adds a new "System-specific notes" section with guidance for WSL/Ubuntu users:
  - Installation commands for required packages: `cmake`, `gcc`, `gfortran`, `libnetcdff-dev`
  - Notes on how to determine the number of processors for use with `make -j` and `ctest -j`
  - Mention of `nvfortran` support on WSL with a pointer to GitHub Issues for further help

