### PR TITLE
Add jedi-ci to CRTMv3

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -23,7 +23,7 @@ jobs:
           # otherwise the token will be scoped to the repository.
           app-id: 321361
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: JCSDA-internal
 
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -1,0 +1,50 @@
+name: start-jedi-ci
+
+on:
+  pull_request:
+    branches:
+     - 'master'
+     - 'main'
+     - 'develop'
+
+jobs:
+  launch-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+
+      - name: Generate CI App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          # Owner is specified to scope the token to the org install
+          # otherwise the token will be scoped to the repository.
+          app-id: 321361
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: target_repository
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # This role only has the permission to write to our lfs archive s3 bucket path.
+          role-to-assume: arn:aws:iam::747101682576:role/service-role/jedi-ci-action-runner-backend-GitHubActionsIAMRole-HkHdJRVEFw3x
+          aws-region: us-east-2
+
+      - name: Run JEDI CI
+        uses: JCSDA-internal/jedi-ci@feature/downstream-trim
+        with:
+          container_version: latest
+          unittest_tag: crtm
+          target_project_name: crtm
+          simple_bundle_dependencies: oops ioda ioda-data saber vader gsw oasim soca ufo fv3-jedi fv3-jedi-lm fv3-jedi-data mpas mpas-jedi mpas-jedi-data
+          test_script: run_tests_simple.sh
+          target_repo_dir: target_repository
+          bundle_branch: develop
+          jedi_ci_token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run JEDI CI
-        uses: JCSDA-internal/jedi-ci@feature/downstream-trim
+        uses: JCSDA-internal/jedi-ci@develop
         with:
           container_version: latest
           target_project_name: crtm

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -41,9 +41,9 @@ jobs:
         uses: JCSDA-internal/jedi-ci@feature/downstream-trim
         with:
           container_version: latest
-          unittest_tag: crtm
           target_project_name: crtm
-          integration_test_dependencies: ioda oops gsw ufo-data ufo
+          test_dependencies: ioda oops gsw ufo-data ufo
+          test_strategy: INTEGRATION
           test_script: run_tests.sh
           bundle_repository: https://github.com/JCSDA/jedi-bundle.git
           target_repo_dir: target_repository

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -23,7 +23,7 @@ jobs:
           # otherwise the token will be scoped to the repository.
           app-id: 321361
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          owner: JCSDA-internal
+          owner: JCSDA
 
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -43,8 +43,9 @@ jobs:
           container_version: latest
           unittest_tag: crtm
           target_project_name: crtm
-          simple_bundle_dependencies: oops ioda ioda-data saber vader gsw oasim soca ufo fv3-jedi fv3-jedi-lm fv3-jedi-data mpas mpas-jedi mpas-jedi-data
-          test_script: run_tests_simple.sh
+          integration_test_dependencies: ioda oops gsw ufo-data ufo
+          test_script: run_tests.sh
+          bundle_repository: https://github.com/JCSDA/jedi-bundle.git
           target_repo_dir: target_repository
           bundle_branch: develop
           jedi_ci_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Add jedi-ci to CRTMv3 using the new jedi-ci GitHub action.

As a side note. I'd like to point out that CRTMv3 was the straw that broke the camel's back for the old CI. I knew CI needed an overhaul as soon as the paint was dry, but the deep technical debt resulting in the total infeasibility of supporting CRTM was the final motivation I needed to fix it. Issue 165 in jcsda-internal/CI has been sitting like a rock in my shoe for almost 6 months and I'm just gald to see the finish line.

## Issue(s) addressed

Issue: https://github.com/JCSDA-internal/jedi-ci/issues/26 - jedi-ci-action rollout continued: models and new integrations
Resolves: https://github.com/JCSDA-internal/CI/issues/165 - Add CI testing to CRTM

## Checklist

- [x] I have performed a self-review of my own code
- n/a I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
