### PR TITLE
Bug fix in crtm_compiler_flags.cmake: use correct crtm compiler identification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.20)
 
 project(crtm VERSION 3.1.2 LANGUAGES Fortran)
 

--- a/cmake/crtm_compiler_flags.cmake
+++ b/cmake/crtm_compiler_flags.cmake
@@ -21,7 +21,7 @@ elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" )
   include( compiler_flags_IntelLLVM_Fortran )
 
 elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" )
-    include( compiler_flags_Intel_Fortran )
+  include( compiler_flags_Intel_Fortran )
 
 elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "PGI" OR CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" )
   include( compiler_flags_NVHPC_Fortran )

--- a/cmake/crtm_compiler_flags.cmake
+++ b/cmake/crtm_compiler_flags.cmake
@@ -14,25 +14,22 @@ set(CMAKE_FORTRAN_STANDARD 08)
 set(CMAKE_FORTRAN_STANDARD_REQUIRED ON)
 set(CMAKE_FORTRAN_EXTENSIONS OFF)
 
-if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
+if( CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" )
   include( compiler_flags_GNU_Fortran )
 
-elseif( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
-  if( CMAKE_Fortran_COMPILER MATCHES ".*ifx.*" )
-    message(STATUS "Detected Intel ifx (LLVM-based) Fortran compiler")
-    include( compiler_flags_IntelLLVM_Fortran )  # <-- new file for ifx
-  else()
-    message(STATUS "Detected Intel ifort (classic) Fortran compiler")
-    include( compiler_flags_Intel_Fortran )
-  endif()
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" )
+  include( compiler_flags_IntelLLVM_Fortran )
 
-elseif( CMAKE_Fortran_COMPILER_ID MATCHES "PGI" OR CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" )
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" )
+    include( compiler_flags_Intel_Fortran )
+
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "PGI" OR CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" )
   include( compiler_flags_NVHPC_Fortran )
 
-elseif( CMAKE_Fortran_COMPILER_ID MATCHES "XL" )
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "XL" )
   include( compiler_flags_XL_Fortran )
 
-elseif( CMAKE_Fortran_COMPILER_ID MATCHES "Cray" )
+elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" )
   include( compiler_flags_Cray_Fortran )
 
 else()


### PR DESCRIPTION
## Description

The way crtm decides between ifx and ifort compiler flags is not using the cmake standard compiler identification strings, and it causes problems with spack where the spack compiler **wrapper** is called `ifx` no matter what the actual compiler is (`ifort`, `ifx`).

This PR fixes it.

See https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html for a list of compiler identification strings.

Note that this requires cmake@3.20 at the minimum, which was released in 2021. spack-stack is somewhere north of cmake@3.30 at the time of writing.

## Issue(s) addressed

None created

## Dependencies

None

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
    - I haven't, edited the file in GitHub onine
