### PR TITLE
Adding a slash for coefficient path

### DIFF
--- a/src/Coefficients/CRTM_SpcCoeff.f90
+++ b/src/Coefficients/CRTM_SpcCoeff.f90
@@ -2,7 +2,7 @@
 ! CRTM_SpcCoeff
 !
 ! Module containing the shared CRTM spectral coefficients (SpcCoeff)
-! and their load/destruction routines. 
+! and their load/destruction routines.
 !
 ! PUBLIC DATA:
 !       SC:  Data structure array containing the spectral coefficient
@@ -46,7 +46,7 @@ MODULE CRTM_SpcCoeff
                                    LC_POLARIZATION         , &
                                    CONST_MIXED_POLARIZATION, &
                                    PRA_POLARIZATION        , &
-                                   POLARIZATION_TYPE_NAME 
+                                   POLARIZATION_TYPE_NAME
   USE SpcCoeff_Define      , ONLY: SpcCoeff_type               , &
                                    SpcCoeff_Associated         , &
                                    SpcCoeff_Destroy            , &
@@ -56,7 +56,7 @@ MODULE CRTM_SpcCoeff
                                    SpcCoeff_IsInfraredSensor   , &
                                    SpcCoeff_IsVisibleSensor    , &
                                    SpcCoeff_IsUltravioletSensor
-  USE SpcCoeff_IO          , ONLY: SpcCoeff_ReadFile 
+  USE SpcCoeff_IO          , ONLY: SpcCoeff_ReadFile
   USE CRTM_Parameters      , ONLY: CRTM_Set_Max_nChannels  , &
                                    CRTM_Reset_Max_nChannels
   ! Disable all implicit typing
@@ -76,32 +76,32 @@ MODULE CRTM_SpcCoeff
   PUBLIC :: CRTM_SpcCoeff_IsLoaded
   ! Flag and sensor check procedures passed through from SpcCoeff_Define
   PUBLIC :: SpcCoeff_IsSolar
-  PUBLIC :: SpcCoeff_IsZeeman  
-  PUBLIC :: SpcCoeff_IsMicrowaveSensor  
-  PUBLIC :: SpcCoeff_IsInfraredSensor   
-  PUBLIC :: SpcCoeff_IsVisibleSensor    
+  PUBLIC :: SpcCoeff_IsZeeman
+  PUBLIC :: SpcCoeff_IsMicrowaveSensor
+  PUBLIC :: SpcCoeff_IsInfraredSensor
+  PUBLIC :: SpcCoeff_IsVisibleSensor
   PUBLIC :: SpcCoeff_IsUltravioletSensor
   ! Polarisation flag parameters passed through from SensorInfo_Parameters
-  PUBLIC :: N_POLARIZATION_TYPES   
-  PUBLIC :: INVALID_POLARIZATION   
-  PUBLIC :: UNPOLARIZED            
-  PUBLIC :: INTENSITY              
-  PUBLIC :: FIRST_STOKES_COMPONENT 
+  PUBLIC :: N_POLARIZATION_TYPES
+  PUBLIC :: INVALID_POLARIZATION
+  PUBLIC :: UNPOLARIZED
+  PUBLIC :: INTENSITY
+  PUBLIC :: FIRST_STOKES_COMPONENT
   PUBLIC :: SECOND_STOKES_COMPONENT
-  PUBLIC :: THIRD_STOKES_COMPONENT 
+  PUBLIC :: THIRD_STOKES_COMPONENT
   PUBLIC :: FOURTH_STOKES_COMPONENT
-  PUBLIC :: VL_POLARIZATION        
-  PUBLIC :: HL_POLARIZATION        
-  PUBLIC :: plus45L_POLARIZATION   
-  PUBLIC :: minus45L_POLARIZATION  
-  PUBLIC :: VL_MIXED_POLARIZATION  
-  PUBLIC :: HL_MIXED_POLARIZATION  
-  PUBLIC :: RC_POLARIZATION        
-  PUBLIC :: LC_POLARIZATION  
+  PUBLIC :: VL_POLARIZATION
+  PUBLIC :: HL_POLARIZATION
+  PUBLIC :: plus45L_POLARIZATION
+  PUBLIC :: minus45L_POLARIZATION
+  PUBLIC :: VL_MIXED_POLARIZATION
+  PUBLIC :: HL_MIXED_POLARIZATION
+  PUBLIC :: RC_POLARIZATION
+  PUBLIC :: LC_POLARIZATION
   PUBLIC :: CONST_MIXED_POLARIZATION
   PUBLIC :: PRA_POLARIZATION
   PUBLIC :: POLARIZATION_TYPE_NAME
-  
+
 
   ! -----------------
   ! Module parameters
@@ -133,7 +133,7 @@ CONTAINS
 !       Error_Status = CRTM_Load_SpcCoeff( &
 !                        Sensor_ID                            , &
 !                        File_Path         = File_Path        , &
-!                        netCDF            = netCDF           , &   
+!                        netCDF            = netCDF           , &
 !                        Quiet             = Quiet            , &
 !                        Process_ID        = Process_ID       , &
 !                        Output_Process_ID = Output_Process_ID  )
@@ -189,7 +189,7 @@ CONTAINS
 !       Output_Process_ID:  Set this argument to the MPI process ID in which
 !                           all INFORMATION messages are to be output. If
 !                           the passed Process_ID value agrees with this value
-!                           the INFORMATION messages are output. 
+!                           the INFORMATION messages are output.
 !                           This argument is ignored if the Quiet argument
 !                           is set.
 !                           UNITS:      None
@@ -216,7 +216,7 @@ CONTAINS
   FUNCTION CRTM_SpcCoeff_Load( &
     Sensor_ID        , &  ! Input
     File_Path        , &  ! Optional input
-    netCDF           , &  ! Optional input 
+    netCDF           , &  ! Optional input
     Quiet            , &  ! Optional input
     Process_ID       , &  ! Optional input
     Output_Process_ID) &  ! Optional input
@@ -225,9 +225,9 @@ CONTAINS
     CHARACTER(*),           INTENT(IN)  :: Sensor_ID(:)
     CHARACTER(*), OPTIONAL, INTENT(IN)  :: File_Path
     LOGICAL     , OPTIONAL, INTENT(IN)  :: netCDF
-    LOGICAL     , OPTIONAL, INTENT(IN)  :: Quiet             
-    INTEGER     , OPTIONAL, INTENT(IN)  :: Process_ID        
-    INTEGER     , OPTIONAL, INTENT(IN)  :: Output_Process_ID 
+    LOGICAL     , OPTIONAL, INTENT(IN)  :: Quiet
+    INTEGER     , OPTIONAL, INTENT(IN)  :: Process_ID
+    INTEGER     , OPTIONAL, INTENT(IN)  :: Output_Process_ID
     ! Function result
     INTEGER :: err_stat
     ! Local parameters
@@ -240,7 +240,7 @@ CONTAINS
     INTEGER :: alloc_stat
     INTEGER :: n, n_sensors
 
-    ! Setup 
+    ! Setup
     err_stat = SUCCESS
     ! ...Check the File_Path argument
     IF ( PRESENT(File_Path) ) THEN
@@ -262,7 +262,7 @@ CONTAINS
       pid_msg = ''
     END IF
 
-    
+
     ! Allocate the SpcCoeff shared data structure array
     n_sensors = SIZE(Sensor_ID)
     ALLOCATE( SC(n_sensors), STAT = alloc_stat )
@@ -275,10 +275,10 @@ CONTAINS
 
     ! Read the SpcCoeff data files
     DO n = 1, n_Sensors
-      spccoeff_file = TRIM(ADJUSTL(path))//TRIM(ADJUSTL(Sensor_ID(n)))//'.SpcCoeff.bin'
+      spccoeff_file = TRIM(ADJUSTL(path)) // '/' // TRIM(ADJUSTL(Sensor_ID(n))) // '.SpcCoeff.bin'
       IF( PRESENT(netCDF) ) THEN
         IF( netCDF ) THEN
-          spccoeff_file = TRIM(ADJUSTL(path))//TRIM(ADJUSTL(Sensor_ID(n)))//'.SpcCoeff.nc'
+          spccoeff_file = TRIM(ADJUSTL(path)) // '/' // TRIM(ADJUSTL(Sensor_ID(n))) // '.SpcCoeff.nc'
         END IF
       END IF
       err_stat = SpcCoeff_ReadFile( &


### PR DESCRIPTION
## Description

This PR adds a slash for the coefficient path.

## Issue(s) addressed

Resolves https://github.com/JCSDA/CRTMv3/issues/251

## Dependencies

None

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
