### PR TITLE
enabling the Emissivity Coefficient NetCDF test utility

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -416,6 +416,13 @@ add_test(NAME test_TauCoeff_IO_NC
          COMMAND $<TARGET_FILE:TauCoeff_IO_NC>)
 set_tests_properties(test_TauCoeff_IO_NC PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
 
+#./mains/unit/input_output/test_EmisCoeff_NC/test_emis_coeff_io_nc.f90
+add_executable(EmisCoeff_IO_NC mains/unit/input_output/test_EmisCoeff_NC/test_emis_coeff_io_nc.f90)
+target_link_libraries(EmisCoeff_IO_NC PRIVATE crtm)
+add_test(NAME test_EmisCoeff_IO_NC
+         COMMAND $<TARGET_FILE:EmisCoeff_IO_NC>)
+set_tests_properties(test_EmisCoeff_IO_NC PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
+
 #(CD) AerosolCoeff I/O test
 add_executable(AerosolCoeff_IO mains/unit/input_output/test_AerosolCoeff/test_aerosol_coeff_io.f90)
 target_link_libraries(AerosolCoeff_IO PRIVATE crtm)


### PR DESCRIPTION
## Description

This enables the IR emissivity coefficient test for netcdf files:
```
11: Test command: /home/ben/CRTM/CRTMv3/build/bin/EmisCoeff_IO_NC
11: Working Directory: /home/ben/CRTM/CRTMv3/build/test
11: Environment variables:
11:  OMP_NUM_THREADS=1
11: Test timeout computed to be: 1500
11:
11:  (INIT) UnitTest::Init:
11:
11:    --------------
11:    (SETUP) UnitTest::Setup:  Emi_Coeff_IO_Test; CALLER: Test_Emi_Coeff_io_nc
11:  HELLO, THIS IS A TEST CODE TO INSPECT EmisCoeff files in netCDF format.
11:  test_emi_coeff_io_nc
11:  The following optional EmisCoeff files are investigated:
11:  ...loading: NPOESS.IRland.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#1 PASSED. Test#1 PASSED.
11:  ...loading: Nalli.IRwater.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#2 PASSED. Test#2 PASSED.
11:  ...loading: NPOESS.IRsnow.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#3 PASSED. Test#3 PASSED.
11:  ...loading: NPOESS.IRice.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#4 PASSED. Test#4 PASSED.
11:  ...loading: NPOESS.VISland.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#5 PASSED. Test#5 PASSED.
11:  ...loading: NPOESS.VISwater.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#6 PASSED. Test#6 PASSED.
11:  ...loading: NPOESS.VISsnow.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#7 PASSED. Test#7 PASSED.
11:  ...loading: NPOESS.VISice.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#8 PASSED. Test#8 PASSED.
11:  The following optional EmisCoeff files are investigated:
11:  ...loading: Nalli2.IRwater.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#9 PASSED. Test#9 PASSED.
11:  ...loading: Nalli.IRsnow.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#10 PASSED. Test#10 PASSED.
11:  ...loading: Nalli2.IRsnow.EmisCoeff.nc4
11:      (TEST) UnitTest::Assert: Test#11 PASSED. Test#11 PASSED.
11: STOP 0
1/1 Test #11: test_EmisCoeff_IO_NC .............   Passed    0.08 sec
```
