### PR TITLE
Fix README release info and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-CRTM REL-3.1.1
+CRTM REL-3.1.2
 ====================
 
-[![Build Status](https://app.travis-ci.com/JCSDA-internal/crtm.svg?token=r6aaq9P13fHcTi8yBgdM&branch=develop)](https://app.travis-ci.com/JCSDA-internal/crtm)
+[![Build Status](https://app.travis-ci.com/JCSDA/CRTMv3.svg?branch=develop)](https://app.travis-ci.com/JCSDA/CRTMv3)
 
 Preamble
 --------
@@ -12,10 +12,10 @@ v3.1.2 released July 11, 2025
 v3.1.1 released August 12, 2024
 v3.1.0 (alpha) Released October 31, 2023
 v3.0.0 Released March, 2023  
-v2.4.1-alpha Released on April 1, 2021 (internal realease only)
+v2.4.1-alpha Released on April 1, 2021 (internal release only)
 v2.4.0 Released on October 23, 2020
 
-This is an experimental release of CRTM v3.0, some features may not be fully functional. Contact crtm-support@googlegroups.com.  
+This is a v3.x release of CRTM, some features may not be fully functional. Contact crtm-support@googlegroups.com.
 v3.x features will be rolled out in incremental updates. 
 
 Basic requirements:  
@@ -68,9 +68,8 @@ The CRTM repository directory structure looks (something) like:
   ├── NOTES
   ├── README.md 
   ├── Get_CRTM_Binary_Files.sh  
-  ├── <b>configuration/</b>
-  ├── <b>documentation/</b>
-  ├── <b>fix/</b>
+  ├── <b>cmake/</b>
+  ├── <b>scripts/</b>
   │   ├── AerosolCoeff/
   │   ├── CloudCoeff/
   │   ├── EmisCoeff/
@@ -105,7 +104,7 @@ The CRTM repository directory structure looks (something) like:
   │   ├── Validation/
   │   ├── Zeeman/
   └── <b>test/</b>
-      └── Main/
+      └── mains/
 </pre>
 
 In the above list, the directories highlighted in bold (bold in markdown), are the key directories of interest to the casual developer.
@@ -153,12 +152,12 @@ cmake -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=./
 ```
 this would make a debug build of CRTM, static library (`libcrtm.a`) and set the optional install location to `<build>/install/.` (or something similar, search for `libcrtm.*` and `*.mod`).  Custom Install only happens if you issue the `make install` command. 
 
-The first time you run `cmake`, it will check for a `fix/` directory one level above (or `FIX_FILE_PATH` CMake variable), and if it does't find it, it will download the binary files (according to `test/CMakeLists.txt` file information), and store them in `<build>/test_data/**`.  
+The first time you run `cmake`, it will check for a `fix/` directory one level above (or `FIX_FILE_PATH` CMake variable), and if it doesn't find it, it will download the binary files (according to `test/CMakeLists.txt` file information), and store them in `<build>/test_data/**`.
 
 Linking to the library
 ----------------------
 
-Let's assume the above install was moved into "/home/username/CRTMv3/", to use the library in this structure in your own application, the usual environment variables would need to be be modified something like:
+Let's assume the above install was moved into "/home/username/CRTMv3/", to use the library in this structure in your own application, the usual environment variables would need to be modified something like:
 
 <pre>
 libroot="/home/username/CRTMv3/"
@@ -189,11 +188,10 @@ nvfortran also works on WSL, but has a more involved install process -- if you'r
 Known Issues
 ------------
 
-(1) Any "Transmitance Coefficient" generation codes included in src/ are not functional.  Contact CRTM support above for details.  
+(1) Any "Transmittance Coefficient" generation codes included in src/ are not functional.  Contact CRTM support above for details.
 (2) No testing was done on PGI, XLF, or other less common compilers.  Feedback from users suggest that there's no major concerns though.  Please contact us with specifics.  Tested on GCC v5 and higher, and ifort v18 and higher.  Some specific compiler versions have issues, contact support if you run into problems.
 
   
-
 
 
 


### PR DESCRIPTION
  Summary:

  - Align README release banner and v3.x wording with v3.1.2.
  - Update the build status badge to point to the CRTMv3 repo.
  - Refresh the repo layout snapshot and fix a few typos.
