### PR TITLE
Change check run "pull_request" trigger to "pull_request_target"

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -14,6 +14,12 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Debug secret availability
+        run: |
+          echo "event=${{ github.event_name }}"
+          echo "actor=${{ github.actor }}"
+          echo "from_fork=${{ github.event.pull_request.head.repo.fork || 'n/a' }}"
+          echo "has_key=${{ secrets.CI_APP_PRIVATE_KEY != '' }}"
 
       - name: Generate CI App token
         id: generate-token

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -1,7 +1,7 @@
 name: start-jedi-ci
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
      - 'master'
      - 'main'
@@ -13,13 +13,11 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+    # Checks in this environment must be approved by reviewers configured in "Settings" -> "Environments".
+    environment: fork_pull_secrets
+
     steps:
-      - name: Debug secret availability
-        run: |
-          echo "event=${{ github.event_name }}"
-          echo "actor=${{ github.actor }}"
-          echo "from_fork=${{ github.event.pull_request.head.repo.fork || 'n/a' }}"
-          echo "has_key=${{ secrets.CI_APP_PRIVATE_KEY != '' }}"
 
       - name: Generate CI App token
         id: generate-token
@@ -28,7 +26,7 @@ jobs:
           # Owner is specified to scope the token to the org install
           # otherwise the token will be scoped to the repository.
           app-id: 321361
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY_FORK }}
           owner: JCSDA
 
       - name: checkout repository

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -13,10 +13,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
-    # Checks in this environment must be approved by reviewers configured in "Settings" -> "Environments".
-    environment: fork_pull_secrets
-
     steps:
 
       - name: Generate CI App token
@@ -26,7 +22,7 @@ jobs:
           # Owner is specified to scope the token to the org install
           # otherwise the token will be scoped to the repository.
           app-id: 321361
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY_FORK }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: JCSDA
 
       - name: checkout repository

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -293,7 +293,12 @@ add_executable(test_check_crtm_random  mains/application/check_crtm_random_profi
 target_link_libraries(test_check_crtm_random PRIVATE crtm)
 add_test(NAME test_check_crtm_random
          COMMAND test_check_crtm_random)
-set_tests_properties(test_check_crtm_random PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
+set_tests_properties(
+    test_check_crtm_random
+	PROPERTIES
+	    ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}"
+		LABELS tier2
+)
 
 
 add_executable(Unit_TL_TEST mains/unit/Unit_Test/test_TL.f90)


### PR DESCRIPTION
Change check run "pull_request" trigger to "pull_request_target". This will allow pull requests from forks to execute in the correct CI environment with access to the secret keys needed to launch the test on EC2.

I also changed the configuration on this repo to require approval for PR check-runs on pulls from members outside our organization. This will prevent people from issuing "PWN Requests" to harvest our tasty AWS secrets.

One other security note here; the credentials at risk here are very limited in scope (because they were issued with risk management in mind) The AWS credentials only allow for CI launching (and that is rate-limited by budget controls). The git credentials allow read-only access to repos required for the test.