### PR TITLE
remove test_check_crtm_random to fix some slowness in CI

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -281,13 +281,6 @@ add_test(NAME test_check_crtm
          COMMAND test_check_crtm)
 set_tests_properties(test_check_crtm PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
 
-add_executable(test_check_crtm_random  mains/application/check_crtm_random_profiles.F90)
-target_link_libraries(test_check_crtm_random PRIVATE crtm)
-add_test(NAME test_check_crtm_random
-         COMMAND test_check_crtm_random)
-set_tests_properties(test_check_crtm_random PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}")
-
-
 add_executable(Unit_TL_TEST mains/unit/Unit_Test/test_TL.f90)
 target_link_libraries(Unit_TL_TEST PRIVATE crtm)
 add_test(NAME test_Unit_TL_TEST


### PR DESCRIPTION
Simply removes the test_check_crtm_random ctests per EAP comments regarding slowness in CI.

