### PR TITLE
merge release/REL-3.1.3 back into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(crtm VERSION 3.1.2 LANGUAGES Fortran)
+project(crtm VERSION 3.1.3 LANGUAGES Fortran)
 
 option(OPENMP "Build crtm with OpenMP support" ON)
 option(FIX_FILE_PATH "Path to fix files (default: fix/)" OFF)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CRTM REL-3.1.2
+CRTM REL-3.1.3
 ====================
 
 [![Build Status](https://app.travis-ci.com/JCSDA/CRTMv3.svg?branch=develop)](https://app.travis-ci.com/JCSDA/CRTMv3)
@@ -6,8 +6,9 @@ CRTM REL-3.1.2
 Preamble
 --------
 
-CRTM v3.1.2 release (`REL-3.1.2`)
+CRTM v3.1.3 release (`REL-3.1.3`)
 
+v3.1.3 released February 10, 2025 
 v3.1.2 released July 11, 2025
 v3.1.1 released August 12, 2024
 v3.1.0 (alpha) Released October 31, 2023
@@ -57,7 +58,7 @@ Contents
 
 Configuration, building, and testing the library
 ================================================  
-JCSDA CRTM v3.1.2 Build Instructions
+JCSDA CRTM v3.1.3 Build Instructions
 
 The CRTM repository directory structure looks (something) like:
 
@@ -119,7 +120,7 @@ By default, the `fix/` directory is provided through ftp using the Get_CRTM_Bina
 If this directory doesn't exist during the `cmake` step, then cmake will download and install into `build/test_data/fix_REL-3.1.2.x/fix/`.
 The path to an existing fix file installation can be specified using the `FIX_FILE_PATH` option (see CMake variables summary below).
 
-The fix/ directory (as of v3.1.2) contains most of the netCDF SpcCoeff and TauCoeff files, as part of our ongoing effort to transition toward netCDF-only CRTM.  We expect to deprecate the binary formats in v3.2.x, but code to read / convert binary format will continue.  
+The fix/ directory (as of v3.1.x) contains most of the netCDF SpcCoeff and TauCoeff files, as part of our ongoing effort to transition toward netCDF-only CRTM.  We expect to deprecate the binary formats in v3.2.x, but code to read / convert binary format will continue.  
 
 As of CRTM v3.0.0, we no longer support legacy build system using autotools. (i.e., configure/make).  Only cmake / ecbuild (a cmake wrapper, but not required) is supported.   Many standalone Makefiles, make.dependencies, etc. have been removed, but not entirely.  Cleanup occurs as we work our way through the repository updating other things.  
 

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -3,5 +3,5 @@
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
 
-set( ${PROJECT_NAME}_VERSION_STR  "3.1.2" )
+set( ${PROJECT_NAME}_VERSION_STR  "3.1.3" )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 cmake_minimum_required (VERSION 3.12)
-project("CRTM_Tests" VERSION 3.1.2 LANGUAGES Fortran C)
+project("CRTM_Tests" VERSION 3.1.3 LANGUAGES Fortran C)
 
 enable_testing ()
 


### PR DESCRIPTION
Just a minor PR to ensure that `develop` is in line with `release/REL-3.1.3`