### PR TITLE
Fix jedi-ci config

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           container_version: latest
           target_project_name: crtm
-          test_dependencies: ioda oops gsw ufo-data ufo
-          test_strategy: INTEGRATION
+          test_dependencies: ioda ioda-data oops gsw ufo ufo-data
+          test_strategy: ALL
           test_script: run_tests.sh
           bundle_repository: https://github.com/JCSDA/jedi-bundle.git
           target_repo_dir: target_repository


### PR DESCRIPTION
Necessary for #297 to pass tests. Changes to this config must be submitted in order for CI actions to use them. This is because we use the `pull_request_target` event type which is necessary to maintain safety in a public repository.
