### PR TITLE
Download crtm coefficient once and use it by crtm, ufo, fv3-jedi and mpas-jedi

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,7 @@ else() # Download CRTM coefficients
 endif()
 
   set (CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
-  message(STATUS "Set the file path to be seen at ${CRTM_TESTFILES_PATH} ")
+  message(STATUS "Downloaded CRTM files are placed at ${CRTM_TESTFILES_PATH} ")
   set_property (GLOBAL PROPERTY CRTM_TESTFILES_PATH ${CRTM_TESTFILES_PATH})
 
 # Create list of sensor ids for testing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,7 @@ else() # Download CRTM coefficients
 endif()
 
   set (CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
-  message(STATUS "Set the file path to be seen by UFO at ${CRTM_TESTFILES_PATH} ")
+  message(STATUS "Set the file path to be seen at ${CRTM_TESTFILES_PATH} ")
   set_property (GLOBAL PROPERTY CRTM_TESTFILES_PATH ${CRTM_TESTFILES_PATH})
 
 # Create list of sensor ids for testing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,9 +122,9 @@ else() # Download CRTM coefficients
   endif()
 endif()
 
-  set (UFO_CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
-  message(STATUS "Set the file path to be seen by UFO at ${UFO_CRTM_TESTFILES_PATH} ")
-  set_property (GLOBAL PROPERTY UFO_CRTM_TESTFILES_PATH ${UFO_CRTM_TESTFILES_PATH})
+  set (CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
+  message(STATUS "Set the file path to be seen by UFO at ${CRTM_TESTFILES_PATH} ")
+  set_property (GLOBAL PROPERTY CRTM_TESTFILES_PATH ${CRTM_TESTFILES_PATH})
 
 # Create list of sensor ids for testing
 list( APPEND Simple_Sensor_Ids

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,7 @@ else() # Download CRTM coefficients
   set( CRTM_COEFFS_BRANCH_PREFIX "" )  #preserves the structure of the paths that have been used in jedi previously vs the local path above
   set( CRTM_COEFFS_BRANCH "fix_REL-3.1.2.0" )
 
-  set(CRTM_COEFFS_PATH ${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION})
+  set(CRTM_COEFFS_PATH ${CMAKE_SOURCE_DIR}/test-data-release)
   file(MAKE_DIRECTORY ${CRTM_COEFFS_PATH})
 
   set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
@@ -103,7 +103,7 @@ else() # Download CRTM coefficients
   # -- UNTAR -- 
   
   # Define the directory to untar into
-  set(UNTAR_DEST "${CMAKE_BINARY_DIR}/test_data/${PROJECT_VERSION}")
+  set(UNTAR_DEST "${CMAKE_SOURCE_DIR}/test-data-release")
     message(STATUS "Checking if ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH} already exists...")
   # Only untar if the CHECK_PATH does not exist
   if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
@@ -122,7 +122,9 @@ else() # Download CRTM coefficients
   endif()
 endif()
 
-
+  set (UFO_CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
+  message(STATUS "Set the file path to be seen by UFO at ${UFO_CRTM_TESTFILES_PATH} ")
+  set_property (GLOBAL PROPERTY UFO_CRTM_TESTFILES_PATH ${UFO_CRTM_TESTFILES_PATH})
 
 # Create list of sensor ids for testing
 list( APPEND Simple_Sensor_Ids


### PR DESCRIPTION

## Description

CRTM coefficient is downloaded twice when building using jedi-bundle, once by crtm module and then by ufo and saved in two different locations. Changing the download location to be in jedi-bundle and then used as a symlink in the build directory for testing, reduces the download of coefficient to only once.

## Issue(s) addressed

Resolves #https://github.com/JCSDA-internal/ufo/issues/4085

## Dependencies

List the other PRs that this PR is dependent on:
build-group=https://github.com/JCSDA-internal/ufo/pull/4123
- [ ] https://github.com/JCSDA-internal/ufo/pull/4123

## Impact

Expected impact on downstream repositories:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
