### PR TITLE
GROUP_MW_O3 (Group_Index=7): scene-ozone ODPS component for MW sensors + TL/AD/K parity test

### DIFF
--- a/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
+++ b/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
@@ -75,6 +75,7 @@ MODULE ODPS_Predictor
   PUBLIC :: GROUP_1
   PUBLIC :: GROUP_2
   PUBLIC :: GROUP_3
+  PUBLIC :: GROUP_MW_O3
   PUBLIC :: ALLOW_OPTRAN
 
 
@@ -82,14 +83,18 @@ MODULE ODPS_Predictor
   ! Module parameters
   ! -----------------
   ! Dimensions of each predictor group.
-  INTEGER, PARAMETER  :: N_G = 3
-  INTEGER, PARAMETER  :: N_COMPONENTS_G(N_G)     = (/8,   5, 2/)
-  INTEGER, PARAMETER  :: N_ABSORBERS_G(N_G)      = (/6,   3, 1/)
-  INTEGER, PARAMETER  :: MAX_N_PREDICTORS_G(N_G) = (/18, 15, 14/)
+  ! Group 7 is the MW+ozone variant of group 3 (indexes 4 - 6 are Zeeman);
+  ! entries 4 - 6 in the dimension tables are placeholders (Zeeman has its
+  ! own predictor module and never reaches these tables).
+  INTEGER, PARAMETER  :: N_G = 7
+  INTEGER, PARAMETER  :: N_COMPONENTS_G(N_G)     = (/8,   5, 2, 0, 0, 0, 3/)
+  INTEGER, PARAMETER  :: N_ABSORBERS_G(N_G)      = (/6,   3, 1, 0, 0, 0, 2/)
+  INTEGER, PARAMETER  :: MAX_N_PREDICTORS_G(N_G) = (/18, 15, 14, 0, 0, 0, 14/)
   ! Group index (note, group indexes 4 - 6 are reserved for Zeeman sub-algorithms
   INTEGER, PARAMETER :: GROUP_1 = 1
   INTEGER, PARAMETER :: GROUP_2 = 2
   INTEGER, PARAMETER :: GROUP_3 = 3
+  INTEGER, PARAMETER :: GROUP_MW_O3 = 7   ! MW with a scene-ozone component
 
   ! Number of predictors for each component
   INTEGER, PARAMETER :: N_PREDICTORS_G1(8) = (/ &
@@ -114,6 +119,11 @@ MODULE ODPS_Predictor
   INTEGER, PARAMETER :: N_PREDICTORS_G3(2) = (/ &
                      7, &  ! dry gas
                     14 /)  ! water vapor line and continua
+
+  INTEGER, PARAMETER :: N_PREDICTORS_G7(3) = (/ &
+                     7, &  ! effective dry gas (climatological trace gases folded in)
+                    14, &  ! water vapor line and continua
+                    11 /)  ! ozone (same formulation as the IR ozone component)
 
 
   ! Component IDs
@@ -145,6 +155,7 @@ MODULE ODPS_Predictor
   ! MW sensor Component indexes
   INTEGER, PARAMETER :: COMP_DRY_MW = 1
   INTEGER, PARAMETER :: COMP_WET_MW = 2
+  INTEGER, PARAMETER :: COMP_OZO_MW = 3   ! GROUP_MW_O3 only
 
   ! Component index to component ID mapping
   INTEGER, PARAMETER :: COMPONENT_ID_MAP_G1(8) = (/ &
@@ -168,6 +179,11 @@ MODULE ODPS_Predictor
                                   EDRY_ComID, &
                                    WET_ComID /)
 
+  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G7(3) = (/ &
+                                  EDRY_ComID, &
+                                   WET_ComID, &
+                                   OZO_ComID /)
+
   ! Absorber IDs (HITRAN)
   INTEGER, PARAMETER ::   H2O_ID =  1
   INTEGER, PARAMETER ::   CO2_ID =  2
@@ -185,6 +201,7 @@ MODULE ODPS_Predictor
   INTEGER,  PARAMETER :: ABS_CH4_IR = 6
 
   INTEGER,  PARAMETER :: ABS_H2O_MW = 1
+  INTEGER,  PARAMETER :: ABS_O3_MW  = 2   ! GROUP_MW_O3 only
 
   ! Absorber index to absorber ID mapping
   INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G1(6) = (/ &
@@ -202,6 +219,10 @@ MODULE ODPS_Predictor
 
   INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G3(1) = (/ &
                                            H2O_ID /)
+
+  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G7(2) = (/ &
+                                           H2O_ID, &
+                                           O3_ID /)
   ! Literal constants
   REAL(fp), PARAMETER :: ZERO      = 0.0_fp
   REAL(fp), PARAMETER :: ONE       = 1.0_fp
@@ -766,7 +787,7 @@ CONTAINS
     SELECT CASE( Group_ID )
       CASE( GROUP_1, GROUP_2 )
          CALL ODPS_Compute_Predictor_IR()
-      CASE( GROUP_3 )
+      CASE( GROUP_3, GROUP_MW_O3 )
          CALL ODPS_Compute_Predictor_MW()
     END SELECT
 
@@ -1028,6 +1049,9 @@ CONTAINS
       REAL(fp) ::    H2O_S
       REAL(fp) ::    H2O_R4
       REAL(fp) ::    H2OdH2OTzp
+      REAL(fp) ::    O3
+      REAL(fp) ::    O3_A
+      REAL(fp) ::    O3_R
 
       Layer_Loop : DO k = 1, n_Layers
 
@@ -1057,7 +1081,11 @@ CONTAINS
        !#-------------------------------------------------------------------#
 
        ! set number of predictors
-        Predictor%n_CP = N_PREDICTORS_G3
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          Predictor%n_CP = N_PREDICTORS_G7
+        ELSE
+          Predictor%n_CP = N_PREDICTORS_G3
+        END IF
 
         !  ----------------------
         !   Fixed (Dry) predictors
@@ -1087,6 +1115,26 @@ CONTAINS
         Predictor%X(k, 12,COMP_WET_MW) = H2O_S*H2O_A
         Predictor%X(k, 13,COMP_WET_MW) = H2O_S*H2O_S
         Predictor%X(k, 14,COMP_WET_MW) = H2OdH2OTzp
+
+        !  -----------------------
+        !  Ozone predictors (GROUP_MW_O3 only; same formulation as IR)
+        !  -----------------------
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          O3   = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
+          Predictor%X(k, 1, COMP_OZO_MW)  = O3_A
+          Predictor%X(k, 2, COMP_OZO_MW)  = O3_A*DT
+          Predictor%X(k, 3, COMP_OZO_MW)  = O3_A*O3*GAzp(k,ABS_O3_MW)
+          Predictor%X(k, 4, COMP_OZO_MW)  = O3_A*O3_A
+          Predictor%X(k, 5, COMP_OZO_MW)  = O3_A*GAzp(k,ABS_O3_MW)
+          Predictor%X(k, 6, COMP_OZO_MW)  = O3_A*SQRT(SECANG(k)*GAzp(k,ABS_O3_MW))
+          Predictor%X(k, 7, COMP_OZO_MW)  = O3_R*DT
+          Predictor%X(k, 8, COMP_OZO_MW)  = O3_R
+          Predictor%X(k, 9, COMP_OZO_MW)  = O3_R*O3/GAzp(k,ABS_O3_MW)
+          Predictor%X(k,10, COMP_OZO_MW)  = SECANG(k)*GAzp(k,ABS_O3_MW)
+          Predictor%X(k,11, COMP_OZO_MW)  = (SECANG(k)*GAzp(k,ABS_O3_MW))**2
+        END IF
 
       END DO Layer_Loop
 
@@ -1276,7 +1324,7 @@ CONTAINS
     SELECT CASE( Group_ID )
       CASE( GROUP_1, GROUP_2 )
          CALL ODPS_Compute_Predictor_IR_TL()
-      CASE( GROUP_3 )
+      CASE( GROUP_3, GROUP_MW_O3 )
          CALL ODPS_Compute_Predictor_MW_TL()
     END SELECT
 
@@ -1603,6 +1651,9 @@ CONTAINS
       REAL(fp) ::    H2O_S,        H2O_S_TL
       REAL(fp) ::    H2O_R4,       H2O_R4_TL
       REAL(fp) ::    H2OdH2OTzp,   H2OdH2OTzp_TL
+      REAL(fp) ::    O3,           O3_TL
+      REAL(fp) ::    O3_A,         O3_A_TL
+      REAL(fp) ::    O3_R,         O3_R_TL
 
       Layer_Loop : DO k = 1, n_Layers
 
@@ -1650,7 +1701,11 @@ CONTAINS
        !#-------------------------------------------------------------------#
 
        ! set number of predictors
-        Predictor_TL%n_CP = N_PREDICTORS_G3
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          Predictor_TL%n_CP = N_PREDICTORS_G7
+        ELSE
+          Predictor_TL%n_CP = N_PREDICTORS_G3
+        END IF
 
         !  ----------------------
         !   Fixed (Dry) predictors
@@ -1681,6 +1736,36 @@ CONTAINS
         Predictor_TL%X(k, 12,COMP_WET_MW) = H2O_S_TL*H2O_A + H2O_S*H2O_A_TL
         Predictor_TL%X(k, 13,COMP_WET_MW) = TWO*H2O_S*H2O_S_TL
         Predictor_TL%X(k, 14,COMP_WET_MW) = H2OdH2OTzp_TL
+
+        !  -----------------------
+        !  Ozone predictors (GROUP_MW_O3 only)
+        !  -----------------------
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          O3      = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+          O3_TL   = Absorber_TL(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+          O3_A    = SECANG(k)*O3
+          O3_A_TL = SECANG(k)*O3_TL
+          O3_R    = SQRT( O3_A )
+          O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
+          Predictor_TL%X(k, 1, COMP_OZO_MW)  = O3_A_TL
+          Predictor_TL%X(k, 2, COMP_OZO_MW)  = O3_A_TL*DT + O3_A*DT_TL
+          Predictor_TL%X(k, 3, COMP_OZO_MW)  = O3_A_TL*O3*PAFV%GAzp(k,ABS_O3_MW) &
+                                             + O3_A*O3_TL*PAFV%GAzp(k,ABS_O3_MW) &
+                                             + O3_A*O3*GAzp_TL(k,ABS_O3_MW)
+          Predictor_TL%X(k, 4, COMP_OZO_MW)  = TWO*O3_A*O3_A_TL
+          Predictor_TL%X(k, 5, COMP_OZO_MW)  = O3_A_TL*PAFV%GAzp(k,ABS_O3_MW) &
+                                             + O3_A*GAzp_TL(k,ABS_O3_MW)
+          Predictor_TL%X(k, 6, COMP_OZO_MW)  = O3_A_TL*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_MW)) &
+                                             + O3_A*POINT_5*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_MW)) &
+                                              *GAzp_TL(k,ABS_O3_MW)
+          Predictor_TL%X(k, 7, COMP_OZO_MW)  = O3_R_TL*DT + O3_R*DT_TL
+          Predictor_TL%X(k, 8, COMP_OZO_MW)  = O3_R_TL
+          Predictor_TL%X(k, 9, COMP_OZO_MW)  = O3_R_TL*O3/PAFV%GAzp(k,ABS_O3_MW) &
+                                             + O3_R*O3_TL/PAFV%GAzp(k,ABS_O3_MW) &
+                                             - O3_R*O3*GAzp_TL(k,ABS_O3_MW)/PAFV%GAzp(k,ABS_O3_MW)**2
+          Predictor_TL%X(k,10, COMP_OZO_MW)  = SECANG(k)*GAzp_TL(k,ABS_O3_MW)
+          Predictor_TL%X(k,11, COMP_OZO_MW)  = TWO*SECANG(k)**2 * PAFV%GAzp(k,ABS_O3_MW)*GAzp_TL(k,ABS_O3_MW)
+        END IF
 
       END DO Layer_Loop
 
@@ -1857,7 +1942,7 @@ CONTAINS
     SELECT CASE( Group_ID )
       CASE( GROUP_1, GROUP_2 )
          CALL ODPS_Compute_Predictor_IR_AD()
-      CASE( GROUP_3 )
+      CASE( GROUP_3, GROUP_MW_O3 )
          CALL ODPS_Compute_Predictor_MW_AD()
     END SELECT
 
@@ -2475,6 +2560,9 @@ CONTAINS
       REAL(fp) :: H2O_S,        H2O_S_AD
       REAL(fp) :: H2O_R4,       H2O_R4_AD
       REAL(fp) :: H2OdH2OTzp,   H2OdH2OTzp_AD
+      REAL(fp) :: O3,           O3_AD
+      REAL(fp) :: O3_A,         O3_A_AD
+      REAL(fp) :: O3_R,         O3_R_AD
 
       DT_AD         = ZERO
       T_AD          = ZERO
@@ -2486,6 +2574,9 @@ CONTAINS
       H2O_S_AD      = ZERO
       H2O_R4_AD     = ZERO
       H2OdH2OTzp_AD = ZERO
+      O3_AD         = ZERO
+      O3_A_AD       = ZERO
+      O3_R_AD       = ZERO
 
       Layer_Loop : DO k = n_Layers, 1, -1
 
@@ -2510,12 +2601,22 @@ CONTAINS
         H2O_R4 = SQRT( H2O_R )
         H2OdH2OTzp = H2O/PAFV%GATzp(k, ABS_H2O_MW)
 
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          O3   = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
+        END IF
+
        !#-------------------------------------------------------------------#
        !#        -- Predictors --                                           #
        !#-------------------------------------------------------------------#
 
        ! set number of predictors
-        Predictor_AD%n_CP = N_PREDICTORS_G3
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+          Predictor_AD%n_CP = N_PREDICTORS_G7
+        ELSE
+          Predictor_AD%n_CP = N_PREDICTORS_G3
+        END IF
 
         !  ----------------------
         !   Fixed (Dry) predictors
@@ -2595,6 +2696,52 @@ CONTAINS
         Predictor_AD%X(k, 12,COMP_WET_MW) = ZERO
         Predictor_AD%X(k, 13,COMP_WET_MW) = ZERO
         Predictor_AD%X(k, 14,COMP_WET_MW) = ZERO
+
+        !  -----------------------
+        !  Ozone predictors (GROUP_MW_O3 only)
+        !  -----------------------
+        IF ( Group_ID == GROUP_MW_O3 ) THEN
+
+          O3_A_AD = O3_A_AD                                                       &
+                    + Predictor_AD%X(k, 1, COMP_OZO_MW)                           &
+                    + Predictor_AD%X(k, 2, COMP_OZO_MW)*DT                        &
+                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3*PAFV%GAzp(k,ABS_O3_MW) &
+                    + Predictor_AD%X(k, 4, COMP_OZO_MW)*TWO*O3_A                  &
+                    + Predictor_AD%X(k, 5, COMP_OZO_MW)*PAFV%GAzp(k,ABS_O3_MW)    &
+                    + Predictor_AD%X(k, 6, COMP_OZO_MW)*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_MW))
+
+          DT_AD   = DT_AD                                                         &
+                    + Predictor_AD%X(k, 2, COMP_OZO_MW)*O3_A                      &
+                    + Predictor_AD%X(k, 7, COMP_OZO_MW)*O3_R
+
+          O3_AD   = O3_AD                                                         &
+                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3_A*PAFV%GAzp(k,ABS_O3_MW) &
+                    + Predictor_AD%X(k, 9, COMP_OZO_MW)*O3_R/PAFV%GAzp(k,ABS_O3_MW)
+
+          GAzp_AD(k,ABS_O3_MW) = GAzp_AD(k,ABS_O3_MW)                             &
+                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3_A*O3                   &
+                    + Predictor_AD%X(k, 5, COMP_OZO_MW)*O3_A                      &
+                    + Predictor_AD%X(k, 6, COMP_OZO_MW)*POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_MW)) &
+                    - Predictor_AD%X(k, 9, COMP_OZO_MW)*O3_R*O3/PAFV%GAzp(k,ABS_O3_MW)**2 &
+                    + Predictor_AD%X(k,10, COMP_OZO_MW)*SECANG(k)                 &
+                    + Predictor_AD%X(k,11, COMP_OZO_MW)*TWO*SECANG(k)**2*PAFV%GAzp(k,ABS_O3_MW)
+
+          O3_R_AD = O3_R_AD                                                       &
+                    + Predictor_AD%X(k, 7, COMP_OZO_MW)*DT                        &
+                    + Predictor_AD%X(k, 8, COMP_OZO_MW)                           &
+                    + Predictor_AD%X(k, 9, COMP_OZO_MW)*O3/PAFV%GAzp(k,ABS_O3_MW)
+
+          Predictor_AD%X(k, 1:11, COMP_OZO_MW) = ZERO
+
+          O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
+          O3_AD   = O3_AD + O3_A_AD * SECANG(k)
+          O3_R_AD = ZERO
+          O3_A_AD = ZERO
+          Absorber_AD(k,ABS_O3_MW) = Absorber_AD(k,ABS_O3_MW)            &
+                                   + O3_AD / Ref_Absorber(k, ABS_O3_MW)
+          O3_AD   = ZERO
+
+        END IF
 
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
@@ -3263,6 +3410,8 @@ CONTAINS
          Component_ID = COMPONENT_ID_MAP_G2(Component_Index)
       CASE( GROUP_3 )
          Component_ID = COMPONENT_ID_MAP_G3(Component_Index)
+      CASE( GROUP_MW_O3 )
+         Component_ID = COMPONENT_ID_MAP_G7(Component_Index)
       CASE DEFAULT
          Component_ID = HUGE(Component_ID)  ! Entry not found: Hopefully induce code to fail 
     END SELECT
@@ -3280,6 +3429,8 @@ CONTAINS
           Absorber_ID = ABSORBER_ID_MAP_G2(Absorber_Index)
       CASE( GROUP_3 )
           Absorber_ID = ABSORBER_ID_MAP_G3(Absorber_Index)
+      CASE( GROUP_MW_O3 )
+          Absorber_ID = ABSORBER_ID_MAP_G7(Absorber_Index)
       CASE DEFAULT
           Absorber_ID = HUGE(Absorber_ID)  ! Entry not found: Hopefully induce code to fail 
       END SELECT
@@ -3289,7 +3440,8 @@ CONTAINS
   PURE FUNCTION ODPS_Get_Ozone_Component_ID(Group_Index) RESULT( Ozone_Component_ID )
     INTEGER, INTENT(IN) :: Group_Index
     INTEGER :: Ozone_Component_ID
-    IF( Group_Index == GROUP_1 .OR. Group_Index == GROUP_2)THEN
+    IF( Group_Index == GROUP_1 .OR. Group_Index == GROUP_2 .OR. &
+        Group_Index == GROUP_MW_O3 )THEN
       Ozone_Component_ID = OZO_ComID
     ELSE
       Ozone_Component_ID = -1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -650,6 +650,22 @@ else()
   message(STATUS "test_VectorRT_TLADK not registered (needs mwr_aws coeffs + CloudCoeff_Exp_Full6.nc).")
 endif()
 
+# test_MW_O3_TLAD: TL/AD/K parity for the MW scene-ozone ODPS component
+# (GROUP_MW_O3, Group_Index=7). Verifies TL-vs-central-FD for O3/H2O/T column
+# perturbations, the adjoint dot-product over T+H2O+O3, and K-vs-AD on the
+# most O3-sensitive channel. Self-adapting: against a 2-component group-3
+# TauCoeff (the stock testinput link) it asserts the O3 response is
+# identically zero (backward-compatibility control); against a group-7 file
+# it exercises the ozone predictor TL/AD/K blocks end-to-end.
+add_executable(test_MW_O3_TLAD mains/unit/Unit_Test/test_MW_O3_TLAD.f90)
+target_link_libraries(test_MW_O3_TLAD PRIVATE crtm)
+if(AWS_COEFFS_PRESENT)
+  add_test(NAME test_MW_O3_TLAD
+           COMMAND $<TARGET_FILE:test_MW_O3_TLAD>)
+else()
+  message(STATUS "test_MW_O3_TLAD not registered (needs mwr_aws coeffs).")
+endif()
+
 # test_Grazing_SfcOptics: regression test for the catastrophic-reflectivity
 # guard in the MW-water surface optics (CRTM_FastemX and CRTM_PARMIO). Drives
 # both backends directly at grazing zenith angles + 325 GHz (where the reflection

--- a/test/mains/unit/Unit_Test/test_MW_O3_TLAD.f90
+++ b/test/mains/unit/Unit_Test/test_MW_O3_TLAD.f90
@@ -1,0 +1,394 @@
+!
+! test_MW_O3_TLAD
+!
+! TL/AD/K parity check for the MW scene-ozone ODPS component
+! (GROUP_MW_O3, Group_Index = 7).
+!
+! The group-7 ozone predictor blocks in ODPS_Predictor.f90 are transcriptions
+! of the validated IR ozone formulation; the forward path has been verified
+! (zero-coefficient plumbing identity + synthetic single-channel isolation)
+! but no test exercises their TL/AD/K consistency. This test initializes
+! mwr_aws on a clear-sky ECMWF84 ocean column and verifies:
+!   1. TL vs central finite difference for column perturbations of
+!      O3 (relative), H2O (relative) and Temperature (additive) -- the O3
+!      check probes the new predictor block end-to-end.
+!   2. Adjoint dot-product  <dy,dy> == <x, AD(dy)>  with x spanning
+!      Temperature, H2O and O3 on every layer of every profile.
+!   3. K-Matrix vs Adjoint Jacobian equality (Temperature, H2O and O3
+!      columns) on the most O3-sensitive channel.
+!
+! The test adapts to the loaded TauCoeff: with a 2-component group-3 file
+! (no ozone absorber) the O3 response must be IDENTICALLY ZERO in both the
+! forward FD probe and the TL -- that run is the backward-compatibility
+! control. With a group-7 file the O3 TL must converge to the FD derivative.
+!
+! Exit: STOP 0 if every check passes, STOP 1 otherwise.
+!
+! CREATION HISTORY:
+!       Written by:     Benjamin Johnson, 15-Jul-2026
+!                       Setup and verification machinery adapted from
+!                       test_VectorRT_TLADK.
+!
+PROGRAM test_MW_O3_TLAD
+
+  USE CRTM_Module
+  IMPLICIT NONE
+
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME = 'test_MW_O3_TLAD'
+  CHARACTER(*), PARAMETER :: PATH   = './testinput/'
+  CHARACTER(*), PARAMETER :: SENSOR = 'mwr_aws'
+
+  ! Profile / column setup (ECMWF84 ocean column; clear sky)
+  INTEGER,  PARAMETER :: N_PROFILES  = 2
+  INTEGER,  PARAMETER :: N_LAYERS    = 100
+  INTEGER,  PARAMETER :: N_ABSORBERS = 6
+  INTEGER,  PARAMETER :: N_CLOUDS    = 0
+  INTEGER,  PARAMETER :: N_AEROSOLS  = 0
+  REAL(fp), PARAMETER :: ZENITH      = 53.0_fp
+  INTEGER,  PARAMETER :: IDX_H2O = 1, IDX_O3 = 3   ! ECMWF84 absorber slots
+
+  REAL(fp), PARAMETER :: TOL_FD   = 1.0e-3_fp     ! TL vs finite difference
+  REAL(fp), PARAMETER :: TOL_ADJ  = 1.0e-12_fp    ! adjoint dot-product
+  REAL(fp), PARAMETER :: TOL_K    = 1.0e-9_fp     ! K vs AD
+  ! Forward radiances are O(1e0..1e2) mW/(m2.sr.cm-1); a column FD response
+  ! below this is numerically indistinguishable from zero -> O3-blind file.
+  REAL(fp), PARAMETER :: FD_ZERO  = 1.0e-9_fp
+
+  ! Perturbation-variable selectors
+  INTEGER, PARAMETER :: VAR_T = 1, VAR_H2O = 2, VAR_O3 = 3
+
+  CHARACTER(256) :: Version
+  INTEGER :: Error_Status, Allocate_Status, n_Channels
+  INTEGER :: l, m
+  INTEGER :: ch_o3                 ! most O3-sensitive channel (0 if none)
+  LOGICAL :: o3_active             ! loaded file responds to scene O3
+  LOGICAL :: ok_fd_o3, ok_fd_h2o, ok_fd_t, ok_adj, ok_k
+
+  TYPE(CRTM_ChannelInfo_type) :: ChannelInfo(1)
+  TYPE(CRTM_Geometry_type)    :: Geometry(N_PROFILES)
+  TYPE(CRTM_Atmosphere_type)  :: Atm(N_PROFILES)
+  TYPE(CRTM_Surface_type)     :: Sfc(N_PROFILES)
+  TYPE(CRTM_Atmosphere_type)  :: Atm_TL(N_PROFILES), Atm_AD(N_PROFILES)
+  TYPE(CRTM_Surface_type)     :: Sfc_TL(N_PROFILES), Sfc_AD(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution(:,:), RTSolution_pert(:,:)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_TL(:,:), RTSolution_AD(:,:)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution_K(:,:)
+  TYPE(CRTM_Atmosphere_type), ALLOCATABLE :: Atm_K(:,:)
+  TYPE(CRTM_Surface_type),    ALLOCATABLE :: Sfc_K(:,:)
+
+  CALL CRTM_Version(Version)
+  WRITE(*,'(/5x,a)') 'MW scene-ozone (GROUP_MW_O3) TL/AD/K verification'
+  WRITE(*,'(5x,a/)') 'CRTM Version: '//TRIM(Version)
+
+  Error_Status = CRTM_Init( (/ SENSOR /), ChannelInfo, File_Path=PATH, Quiet=.TRUE. )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'CRTM_Init failed', FAILURE )
+    STOP 1
+  END IF
+  n_Channels = SUM(CRTM_ChannelInfo_n_Channels(ChannelInfo))
+  IF ( n_Channels < 1 ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'no channels loaded for '//SENSOR, FAILURE )
+    STOP 1
+  END IF
+
+  ALLOCATE( RTSolution(n_Channels,N_PROFILES), RTSolution_pert(n_Channels,N_PROFILES), &
+            RTSolution_TL(n_Channels,N_PROFILES), RTSolution_AD(n_Channels,N_PROFILES), &
+            RTSolution_K(n_Channels,N_PROFILES), &
+            Atm_K(n_Channels,N_PROFILES), Sfc_K(n_Channels,N_PROFILES), &
+            STAT=Allocate_Status )
+  IF ( Allocate_Status /= 0 ) THEN; WRITE(*,*) 'Alloc error'; STOP 1; END IF
+
+  CALL CRTM_RTSolution_Create( RTSolution,      N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTSolution_pert, N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTSolution_TL,   N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTSolution_AD,   N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTSolution_K,    N_LAYERS )
+
+  CALL CRTM_Atmosphere_Create( Atm,    N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  CALL CRTM_Atmosphere_Create( Atm_TL, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  CALL CRTM_Atmosphere_Create( Atm_AD, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  CALL CRTM_Atmosphere_Create( Atm_K,  N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(Atm)) ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'CRTM_Atmosphere_Create failed', FAILURE )
+    STOP 1
+  END IF
+
+  ! Base clear-sky column for every profile; second profile gets a scaled O3
+  ! column so both profiles contribute distinct ozone signals to the adjoint
+  ! dot-product.
+  CALL Load_ECMWF84_Atm_Data()         ! fills Atm(1) and Atm(2)
+  Atm(2)%Absorber(:,IDX_O3) = 1.3_fp * Atm(2)%Absorber(:,IDX_O3)
+
+  ! Congruent TL/AD/K input atmospheres
+  DO m = 1, N_PROFILES
+    Atm_TL(m)%Climatology = Atm(m)%Climatology
+    Atm_TL(m)%Absorber_ID = Atm(m)%Absorber_ID ; Atm_TL(m)%Absorber_Units = Atm(m)%Absorber_Units
+    Atm_AD(m)%Climatology = Atm(m)%Climatology
+    Atm_AD(m)%Absorber_ID = Atm(m)%Absorber_ID ; Atm_AD(m)%Absorber_Units = Atm(m)%Absorber_Units
+    DO l = 1, n_Channels
+      Atm_K(l,m)%Climatology = Atm(m)%Climatology
+      Atm_K(l,m)%Absorber_ID = Atm(m)%Absorber_ID ; Atm_K(l,m)%Absorber_Units = Atm(m)%Absorber_Units
+    END DO
+  END DO
+
+  ! Ocean surface + geometry
+  DO m = 1, N_PROFILES
+    Sfc(m)%Water_Coverage    = ONE
+    Sfc(m)%Water_Type        = 1
+    Sfc(m)%Water_Temperature = 290.0_fp
+    Sfc(m)%Wind_Speed        = 6.0_fp
+    Sfc(m)%Salinity          = 33.0_fp
+    CALL CRTM_Geometry_SetValue( Geometry(m), Sensor_Zenith_Angle = ZENITH )
+  END DO
+
+  ! --------------------------------------------------------------------------
+  ! Checks. check_fd(VAR_O3) also determines o3_active/ch_o3 from the forward
+  ! FD probe, so it must run first.
+  ! --------------------------------------------------------------------------
+  CALL check_fd ( VAR_O3 , ok_fd_o3  )
+  CALL check_fd ( VAR_H2O, ok_fd_h2o )
+  CALL check_fd ( VAR_T  , ok_fd_t   )
+  CALL check_adj( ok_adj )
+  CALL check_k  ( ok_k )
+
+  Error_Status = CRTM_Destroy( ChannelInfo )
+
+  WRITE(*,'(/5x,a)') '====================================================='
+  IF ( o3_active ) THEN
+    WRITE(*,'(5x,a)') 'TauCoeff mode : scene-O3 ACTIVE (group-7 ozone component)'
+  ELSE
+    WRITE(*,'(5x,a)') 'TauCoeff mode : O3-blind control (2-component MW file)'
+  END IF
+  WRITE(*,'(5x,"TL vs FD (O3 column)                  : ",a)') MERGE('PASS','FAIL',ok_fd_o3)
+  WRITE(*,'(5x,"TL vs FD (H2O column)                 : ",a)') MERGE('PASS','FAIL',ok_fd_h2o)
+  WRITE(*,'(5x,"TL vs FD (Temperature)                : ",a)') MERGE('PASS','FAIL',ok_fd_t)
+  WRITE(*,'(5x,"adjoint dot-product (T+H2O+O3)        : ",a)') MERGE('PASS','FAIL',ok_adj)
+  WRITE(*,'(5x,"K vs AD (T/H2O/O3 columns)            : ",a)') MERGE('PASS','FAIL',ok_k)
+  IF ( ok_fd_o3 .AND. ok_fd_h2o .AND. ok_fd_t .AND. ok_adj .AND. ok_k ) THEN
+    WRITE(*,'(5x,a)') 'ALL CHECKS PASSED'
+    STOP 0
+  ELSE
+    WRITE(*,'(5x,a)') 'CHECKS FAILED'
+    STOP 1
+  END IF
+
+CONTAINS
+
+  ! Apply a column perturbation of size eps to profile 1 of the forward state:
+  ! multiplicative (1+eps) on the absorber columns, additive eps [K] on T.
+  SUBROUTINE perturb( var, base, eps )
+    INTEGER,  INTENT(IN) :: var
+    REAL(fp), INTENT(IN) :: base(N_LAYERS)
+    REAL(fp), INTENT(IN) :: eps
+    SELECT CASE ( var )
+      CASE ( VAR_T )   ; Atm(1)%Temperature        = base + eps
+      CASE ( VAR_H2O ) ; Atm(1)%Absorber(:,IDX_H2O) = base * (ONE + eps)
+      CASE ( VAR_O3 )  ; Atm(1)%Absorber(:,IDX_O3)  = base * (ONE + eps)
+    END SELECT
+  END SUBROUTINE perturb
+
+  SUBROUTINE get_base( var, base )
+    INTEGER,  INTENT(IN)  :: var
+    REAL(fp), INTENT(OUT) :: base(N_LAYERS)
+    SELECT CASE ( var )
+      CASE ( VAR_T )   ; base = Atm(1)%Temperature
+      CASE ( VAR_H2O ) ; base = Atm(1)%Absorber(:,IDX_H2O)
+      CASE ( VAR_O3 )  ; base = Atm(1)%Absorber(:,IDX_O3)
+    END SELECT
+  END SUBROUTINE get_base
+
+  ! ----------------------------------------------------------------
+  ! Check 1 : TL vs central finite difference for a whole-column
+  !           perturbation of variable `var` on profile 1. The TL
+  !           direction matches the FD perturbation shape, so the
+  !           FD/TL ratio must -> 1.
+  ! ----------------------------------------------------------------
+  SUBROUTINE check_fd( var, ok )
+    INTEGER, INTENT(IN)  :: var
+    LOGICAL, INTENT(OUT) :: ok
+    CHARACTER(16) :: vname
+    REAL(fp) :: base(N_LAYERS), fd_all(n_Channels)
+    REAL(fp) :: tl, fd, Rp, Rm, ratio, best, eps, tl_max
+    INTEGER  :: ii, kk, ch
+
+    SELECT CASE ( var )
+      CASE ( VAR_T )   ; vname = 'Temperature'
+      CASE ( VAR_H2O ) ; vname = 'H2O column'
+      CASE ( VAR_O3 )  ; vname = 'O3 column'
+    END SELECT
+    CALL get_base( var, base )
+
+    ! TL along the same direction as the FD perturbation
+    CALL CRTM_Atmosphere_Zero( Atm_TL ) ; CALL CRTM_Surface_Zero( Sfc_TL )
+    SELECT CASE ( var )
+      CASE ( VAR_T )   ; Atm_TL(1)%Temperature        = ONE
+      CASE ( VAR_H2O ) ; Atm_TL(1)%Absorber(:,IDX_H2O) = base
+      CASE ( VAR_O3 )  ; Atm_TL(1)%Absorber(:,IDX_O3)  = base
+    END SELECT
+    Error_Status = CRTM_Tangent_Linear( Atm, Sfc, Atm_TL, Sfc_TL, Geometry, ChannelInfo, &
+                                        RTSolution, RTSolution_TL )
+    IF ( Error_Status /= SUCCESS ) THEN ; WRITE(*,*) 'TL fail' ; ok=.FALSE. ; RETURN ; END IF
+
+    ! Channel selection by FD probe (not max|TL|: a broken zero TL must not
+    ! hide itself).
+    eps = 1.0e-3_fp
+    CALL perturb( var, base, +eps )
+    Error_Status = CRTM_Forward( Atm, Sfc, Geometry, ChannelInfo, RTSolution_pert )
+    DO ii = 1, n_Channels ; fd_all(ii) = RTSolution_pert(ii,1)%Radiance ; END DO
+    CALL perturb( var, base, -eps )
+    Error_Status = CRTM_Forward( Atm, Sfc, Geometry, ChannelInfo, RTSolution_pert )
+    DO ii = 1, n_Channels
+      fd_all(ii) = ( fd_all(ii) - RTSolution_pert(ii,1)%Radiance ) / ( 2.0_fp*eps )
+    END DO
+    CALL perturb( var, base, ZERO )
+
+    ! O3 mode detection: an O3-blind (group-3) file must show ZERO forward
+    ! response AND zero TL to an O3 perturbation -- that is the
+    ! backward-compatibility contract.
+    IF ( var == VAR_O3 ) THEN
+      tl_max = ZERO
+      DO ii = 1, n_Channels
+        tl_max = MAX( tl_max, ABS(RTSolution_TL(ii,1)%Radiance) )
+      END DO
+      o3_active = ( MAXVAL(ABS(fd_all)) > FD_ZERO )
+      ch_o3 = MAXLOC( ABS(fd_all), DIM=1 )
+      IF ( .NOT. o3_active ) THEN
+        ok = ( tl_max <= FD_ZERO )
+        WRITE(*,'(/7x,"[FD] O3: no forward response (O3-blind file).  max|TL| = ",es11.4)') tl_max
+        WRITE(*,'(7x,"-> TL consistently zero : ",a)') MERGE('PASS','FAIL',ok)
+        ch_o3 = 0
+        RETURN
+      END IF
+    END IF
+
+    ch = MAXLOC( ABS(fd_all), DIM=1 )
+    tl = RTSolution_TL(ch,1)%Radiance
+    IF ( ABS(tl) <= TINY(ONE) ) THEN
+      WRITE(*,'(/7x,"[FD] d Radiance / d ",a,"   channel ",i0,": TL is ZERO but FD=",es13.6)') &
+            TRIM(vname), RTSolution(ch,1)%Sensor_Channel, fd_all(ch)
+      ok = .FALSE.
+      RETURN
+    END IF
+
+    best = HUGE(ONE)
+    WRITE(*,'(/7x,"[FD] d Radiance / d ",a,"   channel ",i0,"   TL=",es13.6)') &
+          TRIM(vname), RTSolution(ch,1)%Sensor_Channel, tl
+    DO kk = 4, 14
+      eps = 0.1_fp / (2.0_fp**kk)
+      CALL perturb( var, base, +eps )
+      Error_Status = CRTM_Forward( Atm, Sfc, Geometry, ChannelInfo, RTSolution_pert )
+      Rp = RTSolution_pert(ch,1)%Radiance
+      CALL perturb( var, base, -eps )
+      Error_Status = CRTM_Forward( Atm, Sfc, Geometry, ChannelInfo, RTSolution_pert )
+      Rm = RTSolution_pert(ch,1)%Radiance
+      CALL perturb( var, base, ZERO )
+      fd = ( Rp - Rm ) / ( 2.0_fp*eps )
+      ratio = fd / tl
+      IF ( ABS(ratio-ONE) < best ) best = ABS(ratio-ONE)
+      WRITE(*,'(9x,"eps=",es10.3,"  FD=",es16.9,"  FD/TL=",f14.10)') eps, fd, ratio
+    END DO
+    ok = ( best < TOL_FD )
+    WRITE(*,'(7x,"-> best |FD/TL - 1| = ",es11.4,"   ",a)') best, MERGE('PASS','FAIL',ok)
+  END SUBROUTINE check_fd
+
+  ! ----------------------------------------------------------------
+  ! Check 2 : adjoint dot-product  <dy,dy> == <x, AD(dy)>,
+  !           x spanning Temperature + H2O + O3 everywhere.
+  ! ----------------------------------------------------------------
+  SUBROUTINE check_adj( ok )
+    LOGICAL, INTENT(OUT) :: ok
+    REAL(fp) :: LHS, RHS, dy, rel_adj
+    INTEGER  :: ii, mm
+
+    CALL CRTM_Atmosphere_Zero( Atm_TL ) ; CALL CRTM_Surface_Zero( Sfc_TL )
+    DO mm = 1, N_PROFILES
+      DO ii = 1, N_LAYERS
+        Atm_TL(mm)%Temperature(ii)      = 0.5_fp * SIN( 0.7_fp*REAL(ii,fp) + 1.3_fp*REAL(mm,fp) )
+        Atm_TL(mm)%Absorber(ii,IDX_H2O) = 0.05_fp * Atm(mm)%Absorber(ii,IDX_H2O) &
+                                          * COS( 0.9_fp*REAL(ii,fp) + 0.4_fp*REAL(mm,fp) )
+        Atm_TL(mm)%Absorber(ii,IDX_O3)  = 0.05_fp * Atm(mm)%Absorber(ii,IDX_O3) &
+                                          * SIN( 1.1_fp*REAL(ii,fp) + 0.8_fp*REAL(mm,fp) )
+      END DO
+    END DO
+    Error_Status = CRTM_Tangent_Linear( Atm, Sfc, Atm_TL, Sfc_TL, Geometry, ChannelInfo, &
+                                        RTSolution, RTSolution_TL )
+    IF ( Error_Status /= SUCCESS ) THEN ; WRITE(*,*) 'TL fail' ; ok=.FALSE. ; RETURN ; END IF
+
+    LHS = ZERO
+    CALL CRTM_RTSolution_Zero( RTSolution_AD )
+    DO mm = 1, N_PROFILES
+      DO l = 1, n_Channels
+        dy = RTSolution_TL(l,mm)%Radiance
+        LHS = LHS + dy*dy
+        RTSolution_AD(l,mm)%Radiance = dy
+      END DO
+    END DO
+
+    CALL CRTM_Atmosphere_Zero( Atm_AD ) ; CALL CRTM_Surface_Zero( Sfc_AD )
+    Error_Status = CRTM_Adjoint( Atm, Sfc, RTSolution_AD, Geometry, ChannelInfo, &
+                                 Atm_AD, Sfc_AD, RTSolution )
+    IF ( Error_Status /= SUCCESS ) THEN ; WRITE(*,*) 'AD fail' ; ok=.FALSE. ; RETURN ; END IF
+
+    RHS = ZERO
+    DO mm = 1, N_PROFILES
+      DO ii = 1, N_LAYERS
+        RHS = RHS + Atm_TL(mm)%Temperature(ii)      * Atm_AD(mm)%Temperature(ii)
+        RHS = RHS + Atm_TL(mm)%Absorber(ii,IDX_H2O) * Atm_AD(mm)%Absorber(ii,IDX_H2O)
+        RHS = RHS + Atm_TL(mm)%Absorber(ii,IDX_O3)  * Atm_AD(mm)%Absorber(ii,IDX_O3)
+      END DO
+    END DO
+    rel_adj = ABS(LHS-RHS) / MAX(ABS(LHS), TINY(ONE))
+    ok = ( rel_adj < TOL_ADJ )
+    WRITE(*,'(/7x,"[ADJ] <dy,dy>=",es16.9,"   <x,gx>=",es16.9)') LHS, RHS
+    WRITE(*,'(7x,"-> relative difference = ",es11.4,"   ",a)') rel_adj, MERGE('PASS','FAIL',ok)
+  END SUBROUTINE check_adj
+
+  ! ----------------------------------------------------------------
+  ! Check 3 : K-Matrix vs Adjoint Jacobian (Temperature, H2O and O3
+  !           columns) on the most O3-sensitive channel (channel 1
+  !           for an O3-blind file).
+  ! ----------------------------------------------------------------
+  SUBROUTINE check_k( ok )
+    LOGICAL, INTENT(OUT) :: ok
+    REAL(fp) :: maxdiff, scal, rel_k
+    INTEGER  :: l0, m0, mm
+
+    l0 = MAX( ch_o3, 1 ) ; m0 = 1
+
+    CALL CRTM_Atmosphere_Zero( Atm_K ) ; CALL CRTM_Surface_Zero( Sfc_K )
+    CALL CRTM_RTSolution_Zero( RTSolution_K )
+    DO mm = 1, N_PROFILES
+      DO l = 1, n_Channels
+        RTSolution_K(l,mm)%Radiance = ONE
+      END DO
+    END DO
+    Error_Status = CRTM_K_Matrix( Atm, Sfc, RTSolution_K, Geometry, ChannelInfo, &
+                                  Atm_K, Sfc_K, RTSolution )
+    IF ( Error_Status /= SUCCESS ) THEN ; WRITE(*,*) 'K fail' ; ok=.FALSE. ; RETURN ; END IF
+
+    CALL CRTM_Atmosphere_Zero( Atm_AD ) ; CALL CRTM_Surface_Zero( Sfc_AD )
+    CALL CRTM_RTSolution_Zero( RTSolution_AD )
+    RTSolution_AD(l0,m0)%Radiance = ONE
+    Error_Status = CRTM_Adjoint( Atm, Sfc, RTSolution_AD, Geometry, ChannelInfo, &
+                                 Atm_AD, Sfc_AD, RTSolution )
+    IF ( Error_Status /= SUCCESS ) THEN ; WRITE(*,*) 'AD fail' ; ok=.FALSE. ; RETURN ; END IF
+
+    maxdiff = MAX( MAXVAL( ABS( Atm_K(l0,m0)%Temperature - Atm_AD(m0)%Temperature ) ),          &
+                   MAXVAL( ABS( Atm_K(l0,m0)%Absorber(:,IDX_H2O) - Atm_AD(m0)%Absorber(:,IDX_H2O) ) ), &
+                   MAXVAL( ABS( Atm_K(l0,m0)%Absorber(:,IDX_O3)  - Atm_AD(m0)%Absorber(:,IDX_O3)  ) ) )
+    scal    = MAX( MAXVAL(ABS(Atm_K(l0,m0)%Temperature)),          &
+                   MAXVAL(ABS(Atm_K(l0,m0)%Absorber(:,IDX_H2O))),  &
+                   MAXVAL(ABS(Atm_K(l0,m0)%Absorber(:,IDX_O3))), TINY(ONE) )
+    rel_k   = maxdiff / scal
+    ok = ( rel_k < TOL_K )
+    WRITE(*,'(/7x,"[K] K vs AD (channel ",i0,"):  max|K-AD|/max|K| = ",es11.4,"   ",a)') &
+          RTSolution(l0,m0)%Sensor_Channel, rel_k, MERGE('PASS','FAIL',ok)
+    IF ( o3_active ) THEN
+      WRITE(*,'(7x,"max|dR/dO3| (K, channel ",i0,") = ",es11.4)') &
+            RTSolution(l0,m0)%Sensor_Channel, MAXVAL(ABS(Atm_K(l0,m0)%Absorber(:,IDX_O3)))
+    END IF
+  END SUBROUTINE check_k
+
+  INCLUDE 'Load_ECMWF84_Atm_Data.inc'
+
+END PROGRAM test_MW_O3_TLAD


### PR DESCRIPTION
## What

Adds **`GROUP_MW_O3` (Group_Index = 7)**: an optional third ODPS component for microwave sensors — ozone (`Component_ID = 114`), with the ozone-amount predictor set — so CRTM can track the **scene** O₃ profile at 165–183 / 229 / 325+ GHz instead of the training-set climatology baked into the effective-dry component. Two commits:

- `b592145` — runtime support in `ODPS_Predictor.f90` (+163/−11): dimension tables extended to `N_G = 7` (`N_COMPONENTS_G(7)=3`, `N_ABSORBERS_G(7)=2` [H₂O, O₃], `MAX_N_PREDICTORS_G(7)=14`), the three `SELECT CASE(Group_ID)` dispatch sites (FWD/TL/AD) accept `GROUP_MW_O3` alongside `GROUP_3`, and the MW predictor routines gain a gated ozone block using the existing (validated) IR 11-predictor ozone formulation. Getters extended (`Get_Ozone_Component_ID` etc.). Group indexes 4–6 remain reserved for Zeeman.
- `b9c525a` — `test_MW_O3_TLAD`, the TL/AD/K parity test for the new blocks, registered in ctest.

**Backward compatibility is bit-exact**: existing 2-component (group-3) MW TauCoeffs take the unchanged `GROUP_3` path. The absorber mapping is file-driven with the standard `Ref_Absorber` fallback, so a group-7 file run against a scene with no O₃ geoval degrades gracefully to climatological behavior.

## Why

Real-obs evidence from an AWS MWR O-B campaign (244,386 clear-ocean footprints, ERA5/ERA5T backgrounds, 2.5° block bootstrap), decomposed with O₃-blind rebuilds of the same coefficients:

- MW O₃ physics **wins** where the runtime can apply it as trained: most of the 165–183 GHz σ advantage over an O₃-free reference is O₃-mediated, and it carries the entire 325 GHz mean advantage.
- The **climatological form loses σ at 325 GHz** (+0.0065 Δσ vs the same physics O₃-blind): scene O₃ deviating from the baked-in climatology is charged to σ because a 2-component file cannot track it. `od_o3` varies ~2× across profiles (165.5 GHz: 4–19×10⁻³; 326.35 GHz: 5–30×10⁻³ column OD).

With the group-7 component the runtime consumes the O₃ geoval (UFO already passes it): in the same O-B harness a group-7 build was the **best aggregate of five backends** — Δσ(vs reference) = **−0.0101 [−0.0124, −0.0077]**, significantly better than the otherwise-identical climatological build, recovering ~26% of the 325 GHz σ penalty while keeping the 89 and 165–183 GHz wins and most of the 325 mean win. Self-fit on the generation side tightens from 0.043 K (climatological) to 0.021 K (group-7). Increasingly load-bearing for MWS (229 GHz), AWS/Sterna (325 GHz), ICI (183–664 GHz).

Coefficient generation for group-7 files lives in `crtm-coeffgen` (JCSDA-internal PRs #36/#37): a third LBL run isolates `od_o3`, and the OZO set is emitted in ratio form so `EFFDRY × WET × OZO ≡ ALL` exactly.

## Validation

Forward (kit: `crtm_mw_o3_validation`, mwr_aws, 40-case delta sweep):
1. **Group-3 file, patched vs unpatched runtime: bit-identical.**
2. **Group-7 file with zero ozone coefficients: bit-identical to group-3** — load/alloc/absorber-mapping/component-loop plumbing identity.
3. Synthetic ozone coefficient on a single channel → 4.02 K response **exactly isolated** to that channel.

TL/AD/K (`test_MW_O3_TLAD`, clear-sky ECMWF84 two-profile column):

| TauCoeff | O₃ TL vs central FD | adjoint dot-product | K vs AD |
|---|---|---|---|
| group-7 (scene O₃) | FD/TL → 1 + 1.5×10⁻⁹ | 3.3×10⁻¹⁶ | exact; live O₃ Jacobian column |
| group-3 reference | identically zero (contract) | 4.1×10⁻¹⁵ | exact |
| group-7, zero O₃ coeffs | identically zero, ≡ group-3 numbers exactly | ≡ group-3 | exact |

The test also checks TL-vs-FD for H₂O-column and temperature perturbations (1×10⁻¹⁰ / 1×10⁻¹¹), and is self-adapting: against the stock 2-component `mwr_aws` testinput link (what ctest runs) it asserts the O₃ response is identically zero — i.e., it doubles as a backward-compatibility regression for group-3 files.

## Notes for review

- The ozone predictor block is a transcription of the IR formulation already exercised by every IR sensor; the new code paths are reachable **only** when a TauCoeff with `Group_Index = 7` is loaded. No such file ships in `fix_REL-3.2.0.0`, so all existing regression baselines are unaffected (verified bit-identical above).
- ctest runs `test_MW_O3_TLAD` in control mode (group-3). Exercising the group-7 mode in CI needs a group-7 TauCoeff in the fix tree — deferred to the coefficient-release process.
- Suggested entry for `REL-3.2.0_changes_vs_develop.md` (not included here to avoid colliding with in-flight edits): *"GROUP_MW_O3 (Group_Index=7): optional 3-component MW ODPS with a scene-ozone absorber. No common-suite TB change — the new path requires a group-7 TauCoeff, which no shipped sensor uses; group-3 files are bit-identical pre/post (`test_MW_O3_TLAD` control mode guards this)."*
