### PR TITLE
feat(SfcOptics): complete analytic MW-land surface Jacobians — Soil/Land temperature (#281 Phase 3)

### DIFF
--- a/REL-3.2.0_changes_vs_develop.md
+++ b/REL-3.2.0_changes_vs_develop.md
@@ -63,14 +63,15 @@ No TB change. The regression comparison includes these `RTSolution` fields, so t
 
 ## 5. Analytic MW-land emissivity Jacobians (issue #281)
 
-Commits: `9358caa` (analytic TL/AD), `57c9911` (`test_CONST_MIXED_Polarization` is unrelated; the Jacobian test is registered as `test_Unit_Land_Jacobian`, source `test_Land_Jacobian.f90`).
+Commits: `9358caa` (LAI/vegetation analytic TL/AD, Phase 1), Phase 2 (soil moisture), `aa31bb7` (soil/land temperature, Phase 3). The Jacobian test is registered as `test_Unit_Land_Jacobian`, source `test_Land_Jacobian.f90`.
 
 Files: `src/SfcOptics/CRTM_MW_Land_SfcOptics.f90`, `src/SfcOptics/NESDIS_Emissivity/NESDIS_LandEM_Module.f90`, `src/SfcOptics/CRTM_SfcOptics.f90` (3 land dispatcher call-sites), `src/SfcOptics/CRTM_SfcOptics_Define.f90` (`iVar%MWLSOV`), `test/mains/unit/Unit_Test/test_Land_Jacobian.f90`, `docs/design/surface_jacobians_281.md`.
 
-* Previously `Compute_MW_{Land,Snow,Ice}_SfcOptics_TL/_AD` were pure zero-stubs. This change gives the **MW-land** path analytic TL/AD by hand-differentiating `NESDIS_LandEM` (canopy `vlai = LAI*Veg_Fraction` optical-depth path, soil-moisture dielectric mixing, the Fresnel/roughness chain), caching the partials in `iVar%MWLSOV`. Snow/ice remain zero-stubs.
+* Previously `Compute_MW_{Land,Snow,Ice}_SfcOptics_TL/_AD` were pure zero-stubs. This change gives the **MW-land** path (NESDIS_LandEM, < 80 GHz) analytic TL/AD for **all** of its physical state variables by hand-differentiating `NESDIS_LandEM`: the canopy `vlai = LAI*Veg_Fraction` optical-depth path, the soil-moisture and soil-temperature soil dielectric, the Fresnel/roughness chain (factored into `Roughened_R23_Deriv`, shared by the moisture and temperature paths), and the canopy/soil thermal-ratio `gsect0` (soil and land temperature). Partials are cached in `iVar%MWLSOV`. Snow/ice remain zero-stubs.
+* **Land/soil temperature (Phase 3, `aa31bb7`):** soil temperature enters via the soil dielectric and `gsect0`; land (skin) temperature via `gsect0`. The soil-temperature out-of-range aliasing (`t_soil <- t_skin`) is resolved in the forward — the aliased input gets a zero derivative and its sensitivity re-attributes to land temperature. The land-temperature emissivity part **accumulates** onto the existing skin-T Planck emission Jacobian (`CRTM_Compute_SurfaceT_AD`). This corrects a latent bug: the forward already depended on skin temperature through `gsect0`, but `Surface_K%Land_Temperature` dropped it, so the below-cutoff land-temperature Jacobian was ~3-4x too large; it now matches finite differences. `Canopy_Water_Content` is never consumed by the forward → its analytic Jacobian is exactly zero (asserted in the test).
 * **Forward emissivity is bit-identical** — the new derivative code is gated behind `PRESENT(...)` optional arguments that the forward never supplies. So radiances/BT do not change.
 
-**TB effect:** none in the common ocean regression sweep. The change is to the **Surface-Jacobian reference data** for MW-over-land scenes: the `LAI` / `Vegetation_Fraction` / `Soil_Moisture_Content` columns of `Surface_K` (and the matching TL/AD outputs) go from identically zero to nonzero. MW-over-land Surface reference files must be regenerated after this change.
+**TB effect:** none in the common ocean regression sweep. The change is to the **Surface-Jacobian reference data** for MW-over-land scenes: the `LAI` / `Vegetation_Fraction` / `Soil_Moisture_Content` / `Soil_Temperature` / `Land_Temperature` columns of `Surface_K` (and the matching TL/AD outputs) change (from zero, except land temperature which had the emission-only value). A field-level diff confirms only those columns move; `Atmosphere_K` and `RTSolution_K` are unchanged. MW-over-land Surface reference files must be regenerated after this change (build-local, self-seeding on a fresh checkout).
 
 ## 6. CONST_MIXED_POLARIZATION (polarization type 13) Distance_Ratio fix
 
@@ -87,7 +88,7 @@ File: `src/SfcOptics/CRTM_SfcOptics.f90`.
 1. Difference is only in `WMO_*` / `Sensor_Id` → §4 (coeff-file metadata).
 2. CrIS-FSR `Radiance` / `Brightness_Temperature` change → §2 (NLTECoeff sibling now loaded).
 3. `v.abi_g18` `SOD` / `Layer_Optical_Depth` / `Single_Scatter_Albedo` / reflective-band `Radiance` / `Brightness_Temperature` → §3 (per-channel `Solar_Irradiance`).
-4. MW-over-land `Surface_K` / Surface TL/AD change in the `LAI` / `Vegetation_Fraction` / `Soil_Moisture_Content` columns (forward BT unchanged) → §5 (analytic MW-land Jacobians, #281).
+4. MW-over-land `Surface_K` / Surface TL/AD change in the `LAI` / `Vegetation_Fraction` / `Soil_Moisture_Content` / `Soil_Temperature` / `Land_Temperature` columns (forward BT unchanged) → §5 (analytic MW-land Jacobians, #281).
 5. `tms_*` / TROPICS pol-13 `Brightness_Temperature` change → §6 (CONST_MIXED_POLARIZATION Distance_Ratio fix).
 6. Difference depends on `OMP_NUM_THREADS` → not expected; that would be a bug, not one of these changes.
 7. MW-water `Radiance` / `Brightness_Temperature` / Jacobian change on a sensor with channels ≥ 200 GHz (e.g. `mwr_aws`, TROPICS/`tms_*`) → §8 (PARMIO backend — now auto-loaded and auto-dispatched at ≥ 200 GHz; no common-suite sensor reaches that frequency).

--- a/RELEASE_NOTES_v3.2.0.md
+++ b/RELEASE_NOTES_v3.2.0.md
@@ -31,8 +31,15 @@ impact) is in `REL-3.2.0_changes_vs_develop.md`.
 - **Vector radiative transfer (`Options%n_Stokes > 1`) usability fixes**,
   including nonzero Jacobians, polarized phase-matrix normalization, and
   SfcOptics Stokes-dimension handling.
-- **Analytic MW-land surface Jacobians** for LAI, vegetation fraction, and
-  soil moisture (issue #281).
+- **Analytic MW-land surface Jacobians** (issue #281) — the NESDIS_LandEM
+  microwave land path (< 80 GHz) now returns analytic TL/AD/K sensitivities for
+  **every physical land-state variable**: LAI, vegetation fraction, soil
+  moisture, soil temperature, and land (skin) temperature. `Canopy_Water_Content`
+  has an exactly-zero Jacobian (the forward never consumes it). This also
+  corrects the `Land_Temperature` Jacobian below 80 GHz, which previously omitted
+  the emissivity's skin-temperature dependence (through the LandEM `gsect0`
+  thermal ratio) and was therefore too large; it now matches finite differences.
+  Forward radiances are unchanged.
 - **MW scene-ozone transmittance component** (`GROUP_MW_O3`, Group_Index=7)
   for microwave sensors.
 - **CRTM-Exp cloud-optics schema (experimental, opt-in).** A new
@@ -71,8 +78,10 @@ impact) is in `REL-3.2.0_changes_vs_develop.md`.
    emissivity physics; removing them restores FASTEM / NESDIS_LandEM.
    `CRTM_Init` prints an INFORMATION message when a sensor with ≥ 200 GHz
    channels initializes without the PARMIO LUT. Note that with TELSEM2 active,
-   land-parameter Jacobians (LAI, vegetation, soil moisture) are zero — the
-   atlas does not depend on them.
+   all land-parameter Jacobians (LAI, vegetation, soil moisture, soil/land
+   temperature) are zero — the atlas is a climatology and does not depend on
+   them; the analytic NESDIS_LandEM Jacobians apply only when the atlas is not
+   loaded.
 7. **OpenMP threading.** `CRTM_Init` reads `OMP_NUM_THREADS` at run time; if
    it is **unset or empty, CRTM defaults to a single thread** via
    `OMP_SET_NUM_THREADS(1)`. Because that call is process-global, it also

--- a/docs/design/issue-281-comment.md
+++ b/docs/design/issue-281-comment.md
@@ -1,0 +1,60 @@
+## Status update — MW-land surface Jacobians complete below 80 GHz (for v3.2.0)
+
+The microwave **land** surface portion of this issue is now fully implemented and
+validated. The NESDIS_LandEM path (< 80 GHz) returns analytic TL/AD/K
+sensitivities for **every physical land-state variable**:
+
+| Variable | Status |
+|---|---|
+| `LAI` | ✅ analytic (Phase 1) |
+| `Vegetation_Fraction` | ✅ analytic (Phase 1) |
+| `Soil_Moisture_Content` | ✅ analytic (Phase 2) |
+| `Soil_Temperature` | ✅ analytic (Phase 3) |
+| `Land_Temperature` | ✅ analytic emissivity part + existing skin-T emission (Phase 3) |
+| `Canopy_Water_Content` | ✅ exactly zero — never consumed by the forward (asserted in the test) |
+
+**How the temperatures enter (Phase 3).** Temperature reaches the LandEM
+emissivity by two paths, both differentiated exactly: the soil dielectric
+(`Soil_Diel`, temperature-dependent water permittivity) → roughened Fresnel `r23`
+→ two-stream, and the canopy/soil thermal ratio `gsect0` inside the two-stream
+(the dominant term). The soil dielectric → `r23` chain is shared with the
+soil-moisture Jacobian. When `Soil_Temperature` is out of the LandEM valid range
+it is aliased to the skin temperature in the forward; the analytic path mirrors
+that — the aliased input gets a zero derivative and its sensitivity is
+re-attributed to `Land_Temperature`.
+
+**Latent bug fixed.** The forward emissivity already depended on skin temperature
+through `gsect0`, but that term was dropped from `Surface_K%Land_Temperature`. So
+the below-cutoff land-temperature Jacobian carried only the Planck emission term
+and was ~3–4× too large (the emissivity part is sizable and *negative*, partially
+cancelling the emission term). It now matches finite differences.
+
+**Validation.** `test_Unit_Land_Jacobian` (source `test_Land_Jacobian.f90`)
+checks AD ≡ TL ≡ central finite-difference of the forward for all five nonzero
+variables, plus a guarded `Canopy_Water_Content == 0`. Forward radiances are
+bit-identical; a field-level diff confirms only the `Land_Temperature` and
+`Soil_Temperature` Surface-Jacobian columns move (`Atmosphere_K` and
+`RTSolution_K` unchanged). Full regression suite passes (215/215).
+
+### Disposition of the remaining listed parameters
+
+**Structurally zero (no forward dependence — a valid Jacobian is zero).** These
+cannot be made nonzero without adding forward physics; proposing to close them
+out of this issue (or split to a forward-enhancement issue):
+`Canopy_Water_Content`, `Snow_Density`, `Snow_Grain_Size` (MW), `Ice_Density`,
+`Ice_Roughness`.
+
+**IR/VIS land.** Out of scope by construction: IR/VIS land emissivity is a
+lookup table indexed by `Land_Type` (a classifier), with no continuous
+physical-state dependence, so the physical-state Jacobians are identically zero
+there (the modules' TL/AD set emissivity sensitivity to zero). The skin-temperature
+Jacobian is frequency-independent and already provided by
+`CRTM_Compute_SurfaceT_AD`.
+
+**Snow / ice (`Snow_Depth`, `Snow_Temperature`, `Ice_Thickness`,
+`Ice_Temperature`).** Still open. These use separate models (NESDIS SnowEM /
+SeaIceEM) whose TL/AD are zero-stubs that don't take `Surface_TL/_AD`; a real
+implementation needs signature changes and per-model differentiation. Tracked as
+follow-on (Phase 4), not part of the v3.2.0 land completion.
+
+Design notes: `docs/design/surface_jacobians_281.md`.

--- a/docs/design/surface_jacobians_281.md
+++ b/docs/design/surface_jacobians_281.md
@@ -24,8 +24,29 @@ parameters listed in [JCSDA/CRTMv3#281](https://github.com/JCSDA/CRTMv3/issues/2
   `RTSolution_K` are unchanged; forward radiances are bit-identical. The `.bin`
   references are build-local (not git-tracked, regenerated on first run); fresh
   references must be accepted to green the suite.
-- **Next:** Phase 2 (`Soil_Moisture_Content`) — soil moisture/temperature
-  Jacobians are still zero.
+- **Phase 2 (done):** analytic TL/AD for `Soil_Moisture_Content` (mv -> `Soil_Diel`
+  esoil -> roughened r23 -> two-stream). Validated in `test_Land_Jacobian`
+  (dTb/dSMC ~ -45 K/K at 23.8 GHz; AD == TL == FD).
+- **Phase 3 (done, 2026-07-19):** analytic TL/AD for `Soil_Temperature` and the
+  emissivity part of `Land_Temperature`. Temperature enters the emissivity by two
+  paths: the soil dielectric (`Soil_Diel` `eswo`/`tauw` polynomials, reusing the
+  Phase-2 r23 chain now factored into `Roughened_R23_Deriv`) and the canopy/soil
+  thermal ratio `gsect0` in `Two_Stream_Solution` (the dominant term). The
+  `Soil_Temperature` out-of-range aliasing (`t_soil <- t_skin`) is resolved in the
+  forward: the aliased input gets a zero derivative and its sensitivity is
+  re-attributed to `Land_Temperature`. The `Land_Temperature` emissivity part
+  ACCUMULATES onto the existing skin-T Planck emission Jacobian
+  (`CRTM_Compute_SurfaceT_AD`). Also fixes a latent bug: the forward already
+  depended on skin T via `gsect0`, but that term was dropped from
+  `Surface_K%Land_Temperature`, making the below-cutoff Land_Temperature Jacobian
+  ~3-4x too large; it now matches FD. `Canopy_Water_Content` confirmed as a
+  structural zero (never consumed by the forward; asserted in the test). Branch
+  `feature/btj_landem_temperature_jacobians`, commit `aa31bb7`; suite 215/215
+  after regenerating the MW-over-land Surface references.
+- **Land MW analytic surface Jacobian set is now COMPLETE below 80 GHz**: LAI,
+  Vegetation_Fraction, Soil_Moisture_Content, Soil_Temperature, Land_Temperature
+  all analytic and FD-validated; Canopy_Water_Content structurally zero. Above
+  80 GHz LandEM is gated off (constant emissivity) by design.
 
 ## TL;DR / scope correction
 
@@ -87,12 +108,12 @@ give the TL/AD routines the MW_Water signature, and update the 3 dispatcher call
 
 | Parameter | Flows to emissivity? | Nature of dependence | Difficulty |
 |---|---|---|---|
-| **LAI** | Yes (`vlai = LAI*veg_frac`, `LandEM:210`) | Linear in canopy optical depth; all downstream smooth | **Easy** |
-| **Vegetation_Fraction** | Yes (`LandEM:205,210`) | Linear; only caveat is `MIN/MAX` clip at [0,1] | **Easy** |
-| **Soil_Moisture_Content** | Yes (`Soil_Diel`, `LandEM:220/429/436`) | Smooth dielectric mixing; clip at [0,1] + `vmc>0` guard | **Moderate** |
-| **Soil_Temperature** | Yes, but hard thresholds at 100/350/280 K (`LandEM:141,175`) | Smooth in valid range, branchy at edges | **Hard** |
-| **Land_Temperature** (emissivity part) | Yes (two-stream exponential) | Smooth + override branches | **Hard** |
-| **Canopy_Water_Content** | **No** — never passed into `Compute_MW_Land_SfcOptics`; absent from `NESDIS_LandEM` | n/a | **Not feasible** |
+| **LAI** | Yes (`vlai = LAI*veg_frac`, `LandEM:210`) | Linear in canopy optical depth; all downstream smooth | **Easy — DONE (Phase 1)** |
+| **Vegetation_Fraction** | Yes (`LandEM:205,210`) | Linear; only caveat is `MIN/MAX` clip at [0,1] | **Easy — DONE (Phase 1)** |
+| **Soil_Moisture_Content** | Yes (`Soil_Diel`, `LandEM:220/429/436`) | Smooth dielectric mixing; clip at [0,1] + `vmc>0` guard | **Moderate — DONE (Phase 2)** |
+| **Soil_Temperature** | Yes — soil dielectric + `gsect0` thermal ratio; aliased to skin T when out of [100,350] | Smooth in range; aliasing resolved to a zero derivative + re-attribution to Land_Temperature | **Hard — DONE (Phase 3)** |
+| **Land_Temperature** (emissivity part) | Yes (`gsect0` thermal ratio in two-stream) | Smooth; accumulates onto the skin-T emission Jacobian | **Hard — DONE (Phase 3)** |
+| **Canopy_Water_Content** | **No** — never passed into `Compute_MW_Land_SfcOptics`; absent from `NESDIS_LandEM` | n/a | **Structural zero (asserted in test)** |
 
 `NESDIS_LandEM` is also the fallback for the snow and ice angle corrections, so differentiating
 it once benefits multiple paths.

--- a/src/SfcOptics/CRTM_MW_Land_SfcOptics.f90
+++ b/src/SfcOptics/CRTM_MW_Land_SfcOptics.f90
@@ -105,6 +105,15 @@ MODULE CRTM_MW_Land_SfcOptics
     ! Cached d(emissivity)/d(Soil_Moisture_Content) per angle
     REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEV_dmv = ZERO
     REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEH_dmv = ZERO
+    ! Cached d(emissivity)/d(Soil_Temperature) and d(emissivity)/d(Land_Temperature)
+    ! per angle. The soil-temperature aliasing (Soil_Temperature out of range ->
+    ! t_skin) is resolved inside NESDIS_LandEM, so these are applied directly with
+    ! no clip handling here. dE/dLand_Temperature is the emissivity part only; the
+    ! dominant skin-T emission Jacobian is added by CRTM_Compute_SurfaceT_AD.
+    REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEV_dtsoil = ZERO
+    REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEH_dtsoil = ZERO
+    REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEV_dtland = ZERO
+    REAL(fp), DIMENSION(MAX_N_ANGLES) :: dEH_dtland = ZERO
   END TYPE iVar_type
 
 
@@ -300,10 +309,14 @@ CONTAINS
                            ZERO,                          & ! Input, Snow depth, mm
                            SfcOptics%Emissivity(i,2),     & ! Output, H component
                            SfcOptics%Emissivity(i,1),     & ! Output, V component
-                           dEV_dvlai = iVar%dEV_dvlai(i), & ! Optional output, V
-                           dEH_dvlai = iVar%dEH_dvlai(i), & ! Optional output, H
-                           dEV_dmv   = iVar%dEV_dmv(i),   & ! Optional output, V
-                           dEH_dmv   = iVar%dEH_dmv(i)    ) ! Optional output, H
+                           dEV_dvlai  = iVar%dEV_dvlai(i),  & ! Optional output, V
+                           dEH_dvlai  = iVar%dEH_dvlai(i),  & ! Optional output, H
+                           dEV_dmv    = iVar%dEV_dmv(i),    & ! Optional output, V
+                           dEH_dmv    = iVar%dEH_dmv(i),    & ! Optional output, H
+                           dEV_dtsoil = iVar%dEV_dtsoil(i), & ! Optional output, V
+                           dEH_dtsoil = iVar%dEH_dtsoil(i), & ! Optional output, H
+                           dEV_dtland = iVar%dEV_dtland(i), & ! Optional output, V
+                           dEH_dtland = iVar%dEH_dtland(i)  ) ! Optional output, H
         ! Assume specular surface
         SfcOptics%Reflectivity(i,1,i,1) = ONE-SfcOptics%Emissivity(i,1)
         SfcOptics%Reflectivity(i,2,i,2) = ONE-SfcOptics%Emissivity(i,2)
@@ -406,10 +419,17 @@ CONTAINS
       smc_TL = Surface_TL%Soil_Moisture_Content
     END IF
 
-    ! Propagate to the surface emissivity/reflectivity (specular: r = 1 - e)
+    ! Propagate to the surface emissivity/reflectivity (specular: r = 1 - e).
+    ! Temperature terms carry no clip handling: the Soil_Temperature aliasing is
+    ! resolved in the forward (iVar%dE?_dtsoil is zero when the input was aliased,
+    ! its sensitivity already folded into iVar%dE?_dtland).
     DO i = 1, SfcOptics%n_Angles
-      SfcOptics_TL%Emissivity(i,1) = iVar%dEV_dvlai(i)*vlai_TL + iVar%dEV_dmv(i)*smc_TL  ! V
-      SfcOptics_TL%Emissivity(i,2) = iVar%dEH_dvlai(i)*vlai_TL + iVar%dEH_dmv(i)*smc_TL  ! H
+      SfcOptics_TL%Emissivity(i,1) = iVar%dEV_dvlai(i)*vlai_TL + iVar%dEV_dmv(i)*smc_TL &
+                                   + iVar%dEV_dtsoil(i)*Surface_TL%Soil_Temperature &
+                                   + iVar%dEV_dtland(i)*Surface_TL%Land_Temperature  ! V
+      SfcOptics_TL%Emissivity(i,2) = iVar%dEH_dvlai(i)*vlai_TL + iVar%dEH_dmv(i)*smc_TL &
+                                   + iVar%dEH_dtsoil(i)*Surface_TL%Soil_Temperature &
+                                   + iVar%dEH_dtland(i)*Surface_TL%Land_Temperature  ! H
       SfcOptics_TL%Reflectivity(i,1,i,1) = -SfcOptics_TL%Emissivity(i,1)
       SfcOptics_TL%Reflectivity(i,2,i,2) = -SfcOptics_TL%Emissivity(i,2)
     END DO
@@ -481,7 +501,7 @@ CONTAINS
     CHARACTER(*), PARAMETER :: ROUTINE_NAME = 'Compute_MW_Land_SfcOptics_AD'
     ! Local variables
     INTEGER  :: i
-    REAL(fp) :: vlai_AD, smc_AD
+    REAL(fp) :: vlai_AD, smc_AD, tsoil_AD, tland_AD
 
 
     ! Set up
@@ -495,20 +515,27 @@ CONTAINS
       RETURN
     END IF
 
-    ! Adjoint of the emissivity/reflectivity -> vlai and soil moisture
-    vlai_AD = ZERO
-    smc_AD  = ZERO
+    ! Adjoint of the emissivity/reflectivity -> vlai, soil moisture, temperatures
+    vlai_AD  = ZERO
+    smc_AD   = ZERO
+    tsoil_AD = ZERO
+    tland_AD = ZERO
     DO i = 1, SfcOptics%n_Angles
       ! Adjoint of specular reflectivity (r = 1 - e): e_AD += -r_AD, then zero r_AD
       SfcOptics_AD%Emissivity(i,1) = SfcOptics_AD%Emissivity(i,1) - SfcOptics_AD%Reflectivity(i,1,i,1)
       SfcOptics_AD%Emissivity(i,2) = SfcOptics_AD%Emissivity(i,2) - SfcOptics_AD%Reflectivity(i,2,i,2)
       SfcOptics_AD%Reflectivity(i,1,i,1) = ZERO
       SfcOptics_AD%Reflectivity(i,2,i,2) = ZERO
-      ! Adjoint of emissivity = dE/dvlai * vlai + dE/dmv * soil_moisture
-      vlai_AD = vlai_AD + iVar%dEV_dvlai(i)*SfcOptics_AD%Emissivity(i,1) &
-                        + iVar%dEH_dvlai(i)*SfcOptics_AD%Emissivity(i,2)
-      smc_AD  = smc_AD  + iVar%dEV_dmv(i)*SfcOptics_AD%Emissivity(i,1) &
-                        + iVar%dEH_dmv(i)*SfcOptics_AD%Emissivity(i,2)
+      ! Adjoint of emissivity = dE/dvlai*vlai + dE/dmv*smc + dE/dtsoil*Tsoil
+      !                       + dE/dtland*Tland
+      vlai_AD  = vlai_AD  + iVar%dEV_dvlai(i)*SfcOptics_AD%Emissivity(i,1) &
+                         + iVar%dEH_dvlai(i)*SfcOptics_AD%Emissivity(i,2)
+      smc_AD   = smc_AD   + iVar%dEV_dmv(i)*SfcOptics_AD%Emissivity(i,1) &
+                         + iVar%dEH_dmv(i)*SfcOptics_AD%Emissivity(i,2)
+      tsoil_AD = tsoil_AD + iVar%dEV_dtsoil(i)*SfcOptics_AD%Emissivity(i,1) &
+                         + iVar%dEH_dtsoil(i)*SfcOptics_AD%Emissivity(i,2)
+      tland_AD = tland_AD + iVar%dEV_dtland(i)*SfcOptics_AD%Emissivity(i,1) &
+                         + iVar%dEH_dtland(i)*SfcOptics_AD%Emissivity(i,2)
       SfcOptics_AD%Emissivity(i,1) = ZERO
       SfcOptics_AD%Emissivity(i,2) = ZERO
     END DO
@@ -523,6 +550,13 @@ CONTAINS
     IF ( .NOT. iVar%Smc_Clipped ) THEN
       Surface_AD%Soil_Moisture_Content = Surface_AD%Soil_Moisture_Content + smc_AD
     END IF
+
+    ! Adjoint of the soil/land temperature EMISSIVITY sensitivity. These
+    ! accumulate (+=): the dominant skin-T emission Jacobian is added separately
+    ! by CRTM_Compute_SurfaceT_AD, so Land_Temperature ends up carrying both.
+    ! Soil_Temperature aliasing is already folded into the cached derivatives.
+    Surface_AD%Soil_Temperature = Surface_AD%Soil_Temperature + tsoil_AD
+    Surface_AD%Land_Temperature = Surface_AD%Land_Temperature + tland_AD
 
     ! Ensure no residual surface-optics adjoints leak downstream
     SfcOptics_AD%Reflectivity = ZERO

--- a/src/SfcOptics/NESDIS_Emissivity/NESDIS_LandEM_Module.f90
+++ b/src/SfcOptics/NESDIS_Emissivity/NESDIS_LandEM_Module.f90
@@ -71,7 +71,11 @@ CONTAINS
                            dEV_dvlai,             &   ! Optional Output
                            dEH_dvlai,             &   ! Optional Output
                            dEV_dmv,               &   ! Optional Output
-                           dEH_dmv)                   ! Optional Output
+                           dEH_dmv,               &   ! Optional Output
+                           dEV_dtsoil,            &   ! Optional Output
+                           dEH_dtsoil,            &   ! Optional Output
+                           dEV_dtland,            &   ! Optional Output
+                           dEH_dtland)                ! Optional Output
     ! Arguments
     REAL(fp), intent(in) :: Angle
     REAL(fp), intent(in) :: Frequency
@@ -86,10 +90,14 @@ CONTAINS
     REAL(fp), intent(out):: Emissivity_V,Emissivity_H
     ! Optional tangent-linear/adjoint support, returned only for the (no-snow)
     ! canopy path and set to zero otherwise (snow/ice callers omit them):
-    !   dEV_dvlai/dEH_dvlai : d(emissivity)/d(vlai), vlai = Lai*Vegetation_Fraction
-    !   dEV_dmv/dEH_dmv     : d(emissivity)/d(Soil_Moisture_Content)
+    !   dEV_dvlai/dEH_dvlai   : d(emissivity)/d(vlai), vlai = Lai*Vegetation_Fraction
+    !   dEV_dmv/dEH_dmv       : d(emissivity)/d(Soil_Moisture_Content)
+    !   dEV_dtsoil/dEH_dtsoil : d(emissivity)/d(Soil_Temperature)
+    !   dEV_dtland/dEH_dtland : d(emissivity)/d(t_skin = Land_Temperature)
     REAL(fp), OPTIONAL, intent(out) :: dEV_dvlai, dEH_dvlai
     REAL(fp), OPTIONAL, intent(out) :: dEV_dmv, dEH_dmv
+    REAL(fp), OPTIONAL, intent(out) :: dEV_dtsoil, dEH_dtsoil
+    REAL(fp), OPTIONAL, intent(out) :: dEV_dtland, dEH_dtland
     ! Local parameters
     REAL(fp), PARAMETER :: snow_depth_c     = 10.0_fp
     REAL(fp), PARAMETER :: tsoilc_undersnow = 280.0_fp
@@ -133,22 +141,29 @@ CONTAINS
     REAL(fp) :: local_snow_depth
     REAL(fp) :: dtau_dvlai_l, desv_dtauv_l, desh_dtauh_l
     REAL(fp) :: desv_dr23v_l, desh_dr23h_l
-    REAL(fp) :: dtheta_t_dmv, ds_dmv, cos_i_l, cos_tt, sin_tt, qr_l
-    REAL(fp) :: drv0_dmv, drh0_dmv, dr23v_dmv, dr23h_dmv
+    REAL(fp) :: dr23v_dmv, dr23h_dmv
+    ! Soil/land temperature Jacobian locals (canopy path). The Fresnel/roughness
+    ! chain esoil -> r23 is shared with soil moisture via Roughened_R23_Deriv.
+    REAL(fp) :: dr23v_dt, dr23h_dt
+    REAL(fp) :: desv_dtsoil_l, desh_dtsoil_l, desv_dtskin_l, desh_dtskin_l
+    REAL(fp) :: dEV_dtsoil_slot, dEH_dtsoil_slot
+    LOGICAL  :: t_soil_aliased
     COMPLEX(fp) :: esoil, eveg, esnow, eair
-    COMPLEX(fp) :: desoil_dmv, dqc_dmv, m1c, m2c, dm2_dmv, angle_i_c, angle_t_c, dangle_t_dmv
-    COMPLEX(fp) :: nv_c, dv_c, dnv_c, ddv_c, zv_c, dzv_c
-    COMPLEX(fp) :: nh_c, dh_c, dnh_c, ddh_c, zh_c, dzh_c
+    COMPLEX(fp) :: desoil_dmv, desoil_dt
     LOGICAL :: SnowEM_Physical_Model
 
     eair = CMPLX(ONE,-ZERO,fp)
     theta = Angle*PI/180.0_fp
 
     ! Default the optional derivative outputs (filled only on the canopy path)
-    IF (PRESENT(dEV_dvlai)) dEV_dvlai = ZERO
-    IF (PRESENT(dEH_dvlai)) dEH_dvlai = ZERO
-    IF (PRESENT(dEV_dmv))   dEV_dmv   = ZERO
-    IF (PRESENT(dEH_dmv))   dEH_dmv   = ZERO
+    IF (PRESENT(dEV_dvlai))  dEV_dvlai  = ZERO
+    IF (PRESENT(dEH_dvlai))  dEH_dvlai  = ZERO
+    IF (PRESENT(dEV_dmv))    dEV_dmv    = ZERO
+    IF (PRESENT(dEH_dmv))    dEH_dmv    = ZERO
+    IF (PRESENT(dEV_dtsoil)) dEV_dtsoil = ZERO
+    IF (PRESENT(dEH_dtsoil)) dEH_dtsoil = ZERO
+    IF (PRESENT(dEV_dtland)) dEV_dtland = ZERO
+    IF (PRESENT(dEH_dtland)) dEH_dtland = ZERO
 
     ! By default use the 
     ! Assign local variable
@@ -160,9 +175,16 @@ CONTAINS
     rhob = rhob_soil(Soil_Type )
     local_snow_depth = Snow_Depth
 
-    ! Check soil/skin temperature
+    ! Check soil/skin temperature. When Soil_Temperature is out of range it is
+    ! aliased to t_skin; record that so the temperature Jacobian attributes the
+    ! soil-slot sensitivity to Land_Temperature (the input Soil_Temperature had
+    ! no effect and so has a zero derivative).
+    t_soil_aliased = .FALSE.
     if ( (t_soil <= 100.0_fp .OR.  t_soil >= 350.0_fp) .AND. &
-         (t_skin >= 100.0_fp .AND. t_skin <= 350.0_fp) ) t_soil = t_skin
+         (t_skin >= 100.0_fp .AND. t_skin <= 350.0_fp) ) then
+      t_soil = t_skin
+      t_soil_aliased = .TRUE.
+    end if
 
     ! Check soil moisture content range
     mv = MAX(MIN(mv,ONE),ZERO)
@@ -241,7 +263,7 @@ CONTAINS
       t21_v    = ONE
 
       CALL Soil_Diel(Frequency, t_soil, mv, rhob, rhos, sand, clay, esoil, &
-                     desm_dvmc=desoil_dmv)
+                     desm_dvmc=desoil_dmv, desm_dt=desoil_dt)
       theta_t = ASIN(REAL(SIN(theta)*SQRT(eair)/SQRT(esoil),fp))
       CALL Reflectance(eair, esoil, theta, theta_t, r23_v, r23_h)
       CALL Roughness_Reflectance(Frequency, sigma, r23_v, r23_h)
@@ -252,7 +274,9 @@ CONTAINS
                                r21_h,r21_v,r23_h,r23_v,t21_v,t21_h,Emissivity_V,Emissivity_H, &
                                frequency, t_soil, t_skin, &
                                desv_dtauv=desv_dtauv_l, desh_dtauh=desh_dtauh_l, &
-                               desv_dr23v=desv_dr23v_l, desh_dr23h=desh_dr23h_l)
+                               desv_dr23v=desv_dr23v_l, desh_dr23h=desh_dr23h_l, &
+                               desv_dtsoil=desv_dtsoil_l, desh_dtsoil=desh_dtsoil_l, &
+                               desv_dtskin=desv_dtskin_l, desh_dtskin=desh_dtskin_l)
 
       ! Chain rule: d(emissivity)/d(vlai) = d(emissivity)/d(tau) * d(tau)/d(vlai)
       IF (PRESENT(dEV_dvlai)) dEV_dvlai = desv_dtauv_l*dtau_dvlai_l
@@ -261,49 +285,95 @@ CONTAINS
       ! Chain rule for soil moisture: mv -> esoil (Soil_Diel) -> {theta_t, Fresnel
       ! reflectances rv0,rh0} -> roughened r23 -> emissivity (two-stream).
       IF ( PRESENT(dEV_dmv) .OR. PRESENT(dEH_dmv) ) THEN
-        ! theta_t = ASIN(arg), arg = SIN(theta)*SQRT(eair)/SQRT(esoil); sin(theta_t)=arg
-        ! d/dmv of arg = SIN(theta)*SQRT(eair)*esoil^(-1/2): -1/2*esoil^(-3/2)*desoil_dmv
-        dqc_dmv      = SIN(theta)*SQRT(eair)*(-POINT5)*esoil**(-1.5_fp)*desoil_dmv
-        ds_dmv       = REAL(dqc_dmv, fp)
-        cos_tt       = COS(theta_t)
-        sin_tt       = SIN(theta_t)
-        dtheta_t_dmv = ds_dmv/cos_tt
-        ! Fresnel reflectance derivatives (medium 1 = air, medium 2 = soil)
-        cos_i_l      = COS(theta)
-        m1c          = SQRT(eair)
-        m2c          = SQRT(esoil)
-        dm2_dmv      = POINT5*esoil**(-POINT5)*desoil_dmv
-        angle_i_c    = CMPLX(cos_i_l, ZERO, fp)
-        angle_t_c    = CMPLX(cos_tt,  ZERO, fp)
-        dangle_t_dmv = CMPLX(-sin_tt*dtheta_t_dmv, ZERO, fp)
-        ! Vertical polarisation: rv0 = |nv/dv|^2
-        nv_c  = m1c*angle_t_c - m2c*angle_i_c
-        dv_c  = m1c*angle_t_c + m2c*angle_i_c
-        dnv_c = m1c*dangle_t_dmv - dm2_dmv*angle_i_c
-        ddv_c = m1c*dangle_t_dmv + dm2_dmv*angle_i_c
-        zv_c  = nv_c/dv_c
-        dzv_c = (dnv_c*dv_c - nv_c*ddv_c)/(dv_c*dv_c)
-        drv0_dmv = TWO*REAL(CONJG(zv_c)*dzv_c, fp)
-        ! Horizontal polarisation: rh0 = |nh/dh|^2
-        nh_c  = m1c*angle_i_c - m2c*angle_t_c
-        dh_c  = m1c*angle_i_c + m2c*angle_t_c
-        dnh_c = -(dm2_dmv*angle_t_c + m2c*dangle_t_dmv)
-        ddh_c =  (dm2_dmv*angle_t_c + m2c*dangle_t_dmv)
-        zh_c  = nh_c/dh_c
-        dzh_c = (dnh_c*dh_c - nh_c*ddh_c)/(dh_c*dh_c)
-        drh0_dmv = TWO*REAL(CONJG(zh_c)*dzh_c, fp)
-        ! Roughness mixing (linear), matching Roughness_Reflectance
-        qr_l = 0.35_fp*(ONE - EXP(-0.60_fp*Frequency*sigma**TWO))
-        dr23h_dmv = 0.3_fp*drh0_dmv + qr_l*(0.3_fp*drv0_dmv - 0.3_fp*drh0_dmv)
-        dr23v_dmv = 0.3_fp*drv0_dmv + qr_l*(0.3_fp*drh0_dmv - 0.3_fp*drv0_dmv)
+        CALL Roughened_R23_Deriv(esoil, eair, theta, theta_t, sigma, Frequency, &
+                                 desoil_dmv, dr23v_dmv, dr23h_dmv)
         IF (PRESENT(dEV_dmv)) dEV_dmv = desv_dr23v_l*dr23v_dmv
         IF (PRESENT(dEH_dmv)) dEH_dmv = desh_dr23h_l*dr23h_dmv
+      END IF
+
+      ! Chain rule for temperatures. Temperature reaches the emissivity via two
+      ! paths: (A) the soil dielectric esoil (t_soil only) -> r23 -> two-stream,
+      ! reusing the same Fresnel/roughness chain as soil moisture; and (B) the
+      ! thermal ratio gsect0 (t_soil and t_skin) inside the two-stream. The
+      ! "soil slot" collects the sensitivity to the t_soil value actually used
+      ! by the forward (paths A + B_tsoil); the "land slot" is the gsect0 t_skin
+      ! term. If Soil_Temperature was aliased to t_skin above, the input
+      ! Soil_Temperature had no effect, so its derivative is zero and the soil
+      ! slot is re-attributed to Land_Temperature.
+      IF ( PRESENT(dEV_dtsoil) .OR. PRESENT(dEH_dtsoil) .OR. &
+           PRESENT(dEV_dtland) .OR. PRESENT(dEH_dtland) ) THEN
+        CALL Roughened_R23_Deriv(esoil, eair, theta, theta_t, sigma, Frequency, &
+                                 desoil_dt, dr23v_dt, dr23h_dt)
+        dEV_dtsoil_slot = desv_dr23v_l*dr23v_dt + desv_dtsoil_l   ! path A + path B(t_soil)
+        dEH_dtsoil_slot = desh_dr23h_l*dr23h_dt + desh_dtsoil_l
+        IF ( t_soil_aliased ) THEN
+          IF (PRESENT(dEV_dtsoil)) dEV_dtsoil = ZERO
+          IF (PRESENT(dEH_dtsoil)) dEH_dtsoil = ZERO
+          IF (PRESENT(dEV_dtland)) dEV_dtland = dEV_dtsoil_slot + desv_dtskin_l
+          IF (PRESENT(dEH_dtland)) dEH_dtland = dEH_dtsoil_slot + desh_dtskin_l
+        ELSE
+          IF (PRESENT(dEV_dtsoil)) dEV_dtsoil = dEV_dtsoil_slot
+          IF (PRESENT(dEH_dtsoil)) dEH_dtsoil = dEH_dtsoil_slot
+          IF (PRESENT(dEV_dtland)) dEV_dtland = desv_dtskin_l
+          IF (PRESENT(dEH_dtland)) dEH_dtland = desh_dtskin_l
+        END IF
       END IF
     END IF
 
   END SUBROUTINE NESDIS_LandEM
 
 
+  ! d(roughened soil reflectance r23_{v,h})/d(param) given d(esoil)/d(param).
+  ! Extracted from the soil-moisture chain so the soil-moisture and soil/land
+  ! temperature Jacobians walk identical Fresnel + roughness-mixing math.
+  ! Inputs: forward esoil, eair, incidence/transmission angles, roughness sigma,
+  ! frequency, and the complex esoil derivative desoil. Outputs: real dr23v/dr23h.
+  subroutine Roughened_R23_Deriv(esoil, eair, theta, theta_t, sigma, frequency, &
+                                 desoil, dr23v, dr23h)
+    COMPLEX(fp), INTENT(IN)  :: esoil, eair, desoil
+    REAL(fp),    INTENT(IN)  :: theta, theta_t, sigma, frequency
+    REAL(fp),    INTENT(OUT) :: dr23v, dr23h
+    REAL(fp)    :: ds, cos_tt, sin_tt, dtheta_t, cos_i, qr, drv0, drh0
+    COMPLEX(fp) :: dqc, m1c, m2c, dm2, angle_i_c, angle_t_c, dangle_t
+    COMPLEX(fp) :: nv_c, dv_c, dnv_c, ddv_c, zv_c, dzv_c
+    COMPLEX(fp) :: nh_c, dh_c, dnh_c, ddh_c, zh_c, dzh_c
+
+    ! theta_t = ASIN(arg), arg = SIN(theta)*SQRT(eair)/SQRT(esoil); sin(theta_t)=arg
+    ! d(arg) = SIN(theta)*SQRT(eair)*(-1/2)*esoil^(-3/2)*desoil
+    dqc      = SIN(theta)*SQRT(eair)*(-POINT5)*esoil**(-1.5_fp)*desoil
+    ds       = REAL(dqc, fp)
+    cos_tt   = COS(theta_t)
+    sin_tt   = SIN(theta_t)
+    dtheta_t = ds/cos_tt
+    ! Fresnel reflectance derivatives (medium 1 = air, medium 2 = soil)
+    cos_i     = COS(theta)
+    m1c       = SQRT(eair)
+    m2c       = SQRT(esoil)
+    dm2       = POINT5*esoil**(-POINT5)*desoil
+    angle_i_c = CMPLX(cos_i,  ZERO, fp)
+    angle_t_c = CMPLX(cos_tt, ZERO, fp)
+    dangle_t  = CMPLX(-sin_tt*dtheta_t, ZERO, fp)
+    ! Vertical polarisation: rv0 = |nv/dv|^2
+    nv_c  = m1c*angle_t_c - m2c*angle_i_c
+    dv_c  = m1c*angle_t_c + m2c*angle_i_c
+    dnv_c = m1c*dangle_t - dm2*angle_i_c
+    ddv_c = m1c*dangle_t + dm2*angle_i_c
+    zv_c  = nv_c/dv_c
+    dzv_c = (dnv_c*dv_c - nv_c*ddv_c)/(dv_c*dv_c)
+    drv0  = TWO*REAL(CONJG(zv_c)*dzv_c, fp)
+    ! Horizontal polarisation: rh0 = |nh/dh|^2
+    nh_c  = m1c*angle_i_c - m2c*angle_t_c
+    dh_c  = m1c*angle_i_c + m2c*angle_t_c
+    dnh_c = -(dm2*angle_t_c + m2c*dangle_t)
+    ddh_c =  (dm2*angle_t_c + m2c*dangle_t)
+    zh_c  = nh_c/dh_c
+    dzh_c = (dnh_c*dh_c - nh_c*ddh_c)/(dh_c*dh_c)
+    drh0  = TWO*REAL(CONJG(zh_c)*dzh_c, fp)
+    ! Roughness mixing (linear), matching Roughness_Reflectance
+    qr    = 0.35_fp*(ONE - EXP(-0.60_fp*frequency*sigma**TWO))
+    dr23h = 0.3_fp*drh0 + qr*(0.3_fp*drv0 - 0.3_fp*drh0)
+    dr23v = 0.3_fp*drv0 + qr*(0.3_fp*drh0 - 0.3_fp*drv0)
+  end subroutine Roughened_R23_Deriv
 
 
 
@@ -480,7 +550,7 @@ subroutine Snow_Optic(frequency,a,h,f,ep_real,ep_imag,gv,gh, ssalb_v,ssalb_h,tau
 end subroutine Snow_Optic
 
 
-subroutine Soil_Diel(freq,t_soil,vmc,rhob,rhos,sand,clay,esm,desm_dvmc)
+subroutine Soil_Diel(freq,t_soil,vmc,rhob,rhos,sand,clay,esm,desm_dvmc,desm_dt)
 
 
   REAL(fp) :: f,tauw,freq,t_soil,vmc,rhob,rhos,sand,clay
@@ -490,6 +560,10 @@ subroutine Soil_Diel(freq,t_soil,vmc,rhob,rhos,sand,clay,esm,desm_dvmc)
   ! Optional tangent-linear/adjoint support: d(esm)/d(vmc) (complex)
   COMPLEX(fp), OPTIONAL, INTENT(OUT) :: desm_dvmc
   COMPLEX(fp) :: des1_dvmc, dinner_dvmc
+  ! Optional tangent-linear/adjoint support: d(esm)/d(t_soil) (complex)
+  COMPLEX(fp), OPTIONAL, INTENT(OUT) :: desm_dt
+  REAL(fp)    :: deswo_dt, dtauw_dt
+  COMPLEX(fp) :: den_c, des2_dt, desw_dt, dinner_dt
 
   alpha = 0.65_fp
   beta  = 1.09_fp - 0.11_fp*sand + 0.18_fp*clay
@@ -535,12 +609,36 @@ subroutine Soil_Diel(freq,t_soil,vmc,rhob,rhos,sand,clay,esm,desm_dvmc)
     END IF
   END IF
 
+  ! Analytic d(esm)/d(t_soil): temperature enters only through eswo(t) and
+  ! tauw(t) (t = t_soil - 273), which set es2 -> esw. es1 and the ess/vmc terms
+  ! are temperature-independent, so only the vmc**beta*esw**alpha term carries a
+  ! t derivative. At vmc = 0 that term vanishes and so does the derivative.
+  IF ( PRESENT(desm_dt) ) THEN
+    IF ( vmc > ZERO ) THEN
+      ! d(eswo)/dt and d(tauw)/dt from the Horner polynomials above
+      deswo_dt = -1.949e-1_fp + (-2.0_fp*1.276e-2_fp + 3.0_fp*2.491e-4_fp*t)*t
+      dtauw_dt = -3.824e-12_fp + (2.0_fp*6.938e-14_fp - 3.0_fp*5.096e-16_fp*t)*t
+      ! es2 = (eswo-eswi)/(1 + i*f*tauw); quotient rule w.r.t. t
+      den_c   = CMPLX(ONE, f*tauw, fp)
+      des2_dt = ( CMPLX(deswo_dt, ZERO, fp)*den_c &
+                - CMPLX(eswo-eswi, ZERO, fp)*CMPLX(ZERO, f*dtauw_dt, fp) ) / (den_c*den_c)
+      desw_dt   = des2_dt   ! es1 is independent of t
+      dinner_dt = vmc**beta*alpha*esw**(alpha-ONE)*desw_dt
+      desm_dt   = (ONE/alpha)*esm**(ONE/alpha - ONE)*dinner_dt
+    ELSE
+      desm_dt = CMPLX(ZERO, ZERO, fp)
+    END IF
+  END IF
+
   esm = esm**(ONE/alpha)
 
   ! The forward clamps the imaginary part of esm to a constant when it is
   ! non-negative; in that branch the imaginary part of the derivative is zero.
   IF ( PRESENT(desm_dvmc) ) THEN
     IF ( AIMAG(esm) >= ZERO ) desm_dvmc = CMPLX(REAL(desm_dvmc,fp), ZERO, fp)
+  END IF
+  IF ( PRESENT(desm_dt) ) THEN
+    IF ( AIMAG(esm) >= ZERO ) desm_dt = CMPLX(REAL(desm_dt,fp), ZERO, fp)
   END IF
 
   if(AIMAG(esm) >= ZERO) esm = CMPLX(REAL(esm,fp),-0.0001_fp, fp)
@@ -694,7 +792,8 @@ end subroutine Roughness_Reflectance
 
 subroutine Two_Stream_Solution(mu,gv,gh,ssalb_h,ssalb_v,tau_h,tau_v, &
       r21_h,r21_v,r23_h,r23_v,t21_v,t21_h,esv,esh,frequency,t_soil,t_skin, &
-      desv_dtauv,desh_dtauh,desv_dr23v,desh_dr23h)
+      desv_dtauv,desh_dtauh,desv_dr23v,desh_dr23h, &
+      desv_dtsoil,desh_dtsoil,desv_dtskin,desh_dtskin)
 
 
   REAL(fp) :: mu, gv, gh, ssalb_h, ssalb_v, tau_h,tau_v,                 &
@@ -708,11 +807,18 @@ subroutine Two_Stream_Solution(mu,gv,gh,ssalb_h,ssalb_v,tau_h,tau_v, &
   ! soil moisture).
   REAL(fp), OPTIONAL, INTENT(OUT) :: desv_dtauv, desh_dtauh
   REAL(fp), OPTIONAL, INTENT(OUT) :: desv_dr23v, desh_dr23h
+  ! Optional tangent-linear/adjoint support: d(emissivity)/d(t_soil) and
+  ! d(emissivity)/d(t_skin), both entering only through the thermal-ratio gsect0.
+  REAL(fp), OPTIONAL, INTENT(OUT) :: desv_dtsoil, desh_dtsoil
+  REAL(fp), OPTIONAL, INTENT(OUT) :: desv_dtskin, desh_dtskin
   REAL(fp) :: num_h, den_h, num_v, den_v
   REAL(fp) :: dfact1_dtauh, dfact2_dtauv, dgsect2_h_dtauh, dgsect2_v_dtauv
   REAL(fp) :: dnum_h, dden_h, dnum_v, dden_v
   REAL(fp) :: e1h, e2h, e1v, e2v, dgamma_h, dgamma_v, dAcoef_h, dAcoef_v
   REAL(fp) :: dfact1_dr23h, dfact2_dr23v, dgsect1_dr23, dgsect2_h_dr23h, dgsect2_v_dr23v
+  REAL(fp) :: C2f, exp_skin, exp_soil, B_soil, dgsect0_dtskin, dgsect0_dtsoil
+  REAL(fp) :: desh_dgsect0, desv_dgsect0
+  LOGICAL  :: want_dt
 
   alfa_h  = SQRT((ONE - ssalb_h)/(ONE - gh*ssalb_h))
   kk_h    = SQRT((ONE - ssalb_h)*(ONE -  gh*ssalb_h))/mu
@@ -786,26 +892,58 @@ subroutine Two_Stream_Solution(mu,gv,gh,ssalb_h,ssalb_v,tau_h,tau_v, &
     IF (PRESENT(desv_dr23v)) desv_dr23v = t21_v*(dnum_v*den_v - num_v*dden_v)/(den_v*den_v)
   END IF
 
+  ! Tangent-linear/adjoint sensitivities to the soil/skin temperatures. These
+  ! enter the (pre-clip) emissivity ONLY through the thermal ratio
+  !   gsect0 = (EXP(C2*f/t_skin)-1)/(EXP(C2*f/t_soil)-1),
+  ! via gsect1 = (1-r23)*(gsect0-1) -> num. Everything else (beta, kk, gamma,
+  ! r21, r23, t21, gsect2, den) is temperature-independent, so
+  !   d(es)/d(gsect0) = t21*(1-r23)*gsect2/den,
+  ! and the chain rule gives the t_soil / t_skin derivatives below.
+  want_dt = PRESENT(desv_dtsoil) .OR. PRESENT(desh_dtsoil) .OR. &
+            PRESENT(desv_dtskin) .OR. PRESENT(desh_dtskin)
+  IF ( want_dt ) THEN
+    C2f            = C_2*frequency
+    exp_skin       = EXP(C2f/t_skin)
+    exp_soil       = EXP(C2f/t_soil)
+    B_soil         = exp_soil - ONE
+    dgsect0_dtskin = -exp_skin*C2f/(t_skin*t_skin*B_soil)
+    dgsect0_dtsoil = (exp_skin-ONE)*exp_soil*C2f/(t_soil*t_soil*B_soil*B_soil)
+    desh_dgsect0   = t21_h*(ONE-r23_h)*gsect2_h/den_h
+    desv_dgsect0   = t21_v*(ONE-r23_v)*gsect2_v/den_v
+    IF (PRESENT(desh_dtsoil)) desh_dtsoil = desh_dgsect0*dgsect0_dtsoil
+    IF (PRESENT(desv_dtsoil)) desv_dtsoil = desv_dgsect0*dgsect0_dtsoil
+    IF (PRESENT(desh_dtskin)) desh_dtskin = desh_dgsect0*dgsect0_dtskin
+    IF (PRESENT(desv_dtskin)) desv_dtskin = desv_dgsect0*dgsect0_dtskin
+  END IF
+
   if (esh < EMISSH_DEFAULT) then
     esh = EMISSH_DEFAULT
-    if (PRESENT(desh_dtauh)) desh_dtauh = ZERO
-    if (PRESENT(desh_dr23h)) desh_dr23h = ZERO
+    if (PRESENT(desh_dtauh))  desh_dtauh  = ZERO
+    if (PRESENT(desh_dr23h))  desh_dr23h  = ZERO
+    if (PRESENT(desh_dtsoil)) desh_dtsoil = ZERO
+    if (PRESENT(desh_dtskin)) desh_dtskin = ZERO
   end if
   if (esv < EMISSV_DEFAULT) then
     esv = EMISSV_DEFAULT
-    if (PRESENT(desv_dtauv)) desv_dtauv = ZERO
-    if (PRESENT(desv_dr23v)) desv_dr23v = ZERO
+    if (PRESENT(desv_dtauv))  desv_dtauv  = ZERO
+    if (PRESENT(desv_dr23v))  desv_dr23v  = ZERO
+    if (PRESENT(desv_dtsoil)) desv_dtsoil = ZERO
+    if (PRESENT(desv_dtskin)) desv_dtskin = ZERO
   end if
 
   if (esh > ONE) then
     esh = ONE
-    if (PRESENT(desh_dtauh)) desh_dtauh = ZERO
-    if (PRESENT(desh_dr23h)) desh_dr23h = ZERO
+    if (PRESENT(desh_dtauh))  desh_dtauh  = ZERO
+    if (PRESENT(desh_dr23h))  desh_dr23h  = ZERO
+    if (PRESENT(desh_dtsoil)) desh_dtsoil = ZERO
+    if (PRESENT(desh_dtskin)) desh_dtskin = ZERO
   end if
   if (esv > ONE) then
     esv = ONE
-    if (PRESENT(desv_dtauv)) desv_dtauv = ZERO
-    if (PRESENT(desv_dr23v)) desv_dr23v = ZERO
+    if (PRESENT(desv_dtauv))  desv_dtauv  = ZERO
+    if (PRESENT(desv_dr23v))  desv_dr23v  = ZERO
+    if (PRESENT(desv_dtsoil)) desv_dtsoil = ZERO
+    if (PRESENT(desv_dtskin)) desv_dtskin = ZERO
   end if
 
 end subroutine Two_Stream_Solution

--- a/test/mains/unit/Unit_Test/test_Land_Jacobian.f90
+++ b/test/mains/unit/Unit_Test/test_Land_Jacobian.f90
@@ -2,11 +2,21 @@
 ! test_Land_Jacobian
 !
 ! Validation oracle for the analytic microwave LAND surface Jacobians
-! (issue #281, Phase 0/1). For a pure-land MW scene it checks the analytic
-! d(Tb)/d(LAI) and d(Tb)/d(Vegetation_Fraction) obtained from both
+! (issue #281, Phases 1/2/3). For a pure-land MW scene it checks the analytic
+! d(Tb)/d{LAI, Vegetation_Fraction, Soil_Moisture_Content, Soil_Temperature,
+! Land_Temperature} obtained from both
 !   * the K-matrix (adjoint path), and
 !   * the tangent-linear model
-! against central finite differences of the forward model.
+! against central finite differences of the forward model. It also asserts that
+! Canopy_Water_Content has an exactly-zero Jacobian (the LandEM forward never
+! consumes it, so a valid analytic Jacobian is zero by construction).
+!
+! Temperature note: Land_Temperature carries TWO contributions -- the dominant
+! skin-T Planck emission term (frequency-independent, via CRTM_Compute_SurfaceT_AD)
+! plus the emissivity part through the LandEM thermal ratio gsect0. Soil_Temperature
+! carries only the emissivity part (it never enters the surface emission), so it is
+! the clean oracle for the Phase-3 dielectric+gsect0 derivative. The FD of the
+! forward captures the full total in each case.
 !
 ! A microwave window sensor is used (amsua_n19: channels 1-2 at 23.8/31.4 GHz
 ! sit below the 80 GHz cutoff of the NESDIS land emissivity model, so they are
@@ -42,13 +52,16 @@ PROGRAM test_Land_Jacobian
   REAL(fp), PARAMETER :: SCAN_ANGLE   = 26.37293341421_fp
 
   ! Base land state (fractions kept inside (0,1) so they are not clipped)
-  REAL(fp), PARAMETER :: LAI0 = 2.0_fp
-  REAL(fp), PARAMETER :: VEG0 = 0.5_fp
-  REAL(fp), PARAMETER :: SMC0 = 0.2_fp
+  REAL(fp), PARAMETER :: LAI0   = 2.0_fp
+  REAL(fp), PARAMETER :: VEG0   = 0.5_fp
+  REAL(fp), PARAMETER :: SMC0   = 0.2_fp
+  REAL(fp), PARAMETER :: TSOIL0 = 290.0_fp   ! in [100,350] -> not aliased to skin
+  REAL(fp), PARAMETER :: TLAND0 = 290.0_fp
   ! Central finite-difference perturbations
   REAL(fp), PARAMETER :: DLAI = 1.0e-3_fp
   REAL(fp), PARAMETER :: DVEG = 1.0e-3_fp
   REAL(fp), PARAMETER :: DSMC = 1.0e-4_fp
+  REAL(fp), PARAMETER :: DTS  = 1.0e-2_fp    ! soil/land temperature perturbation (K)
   ! Agreement tolerances: |analytic - FD| <= TOL_ABS + TOL_REL*|FD|
   REAL(fp), PARAMETER :: TOL_REL = 5.0e-3_fp
   REAL(fp), PARAMETER :: TOL_ABS = 1.0e-4_fp
@@ -80,6 +93,9 @@ PROGRAM test_Land_Jacobian
   REAL(fp), ALLOCATABLE :: ad_lai(:,:), ad_veg(:,:), ad_smc(:,:)   ! K-matrix (adjoint)
   REAL(fp), ALLOCATABLE :: tl_lai(:,:), tl_veg(:,:), tl_smc(:,:)   ! tangent-linear
   REAL(fp), ALLOCATABLE :: fd_lai(:,:), fd_veg(:,:), fd_smc(:,:)   ! finite difference
+  REAL(fp), ALLOCATABLE :: ad_tsoil(:,:), ad_tland(:,:), ad_cwc(:,:)
+  REAL(fp), ALLOCATABLE :: tl_tsoil(:,:), tl_tland(:,:)
+  REAL(fp), ALLOCATABLE :: fd_tsoil(:,:), fd_tland(:,:)
 
 
   ! Header
@@ -108,6 +124,9 @@ PROGRAM test_Land_Jacobian
             ad_lai(n_Channels,N_PROFILES), ad_veg(n_Channels,N_PROFILES), ad_smc(n_Channels,N_PROFILES), &
             tl_lai(n_Channels,N_PROFILES), tl_veg(n_Channels,N_PROFILES), tl_smc(n_Channels,N_PROFILES), &
             fd_lai(n_Channels,N_PROFILES), fd_veg(n_Channels,N_PROFILES), fd_smc(n_Channels,N_PROFILES), &
+            ad_tsoil(n_Channels,N_PROFILES), ad_tland(n_Channels,N_PROFILES), ad_cwc(n_Channels,N_PROFILES), &
+            tl_tsoil(n_Channels,N_PROFILES), tl_tland(n_Channels,N_PROFILES), &
+            fd_tsoil(n_Channels,N_PROFILES), fd_tland(n_Channels,N_PROFILES), &
             STAT = Alloc_Status )
   IF ( Alloc_Status /= 0 ) THEN
     CALL Display_Message( PROGRAM_NAME, 'Error allocating arrays', FAILURE ); STOP 1
@@ -145,9 +164,12 @@ PROGRAM test_Land_Jacobian
   END IF
   DO m = 1, N_PROFILES
     DO l = 1, n_Channels
-      ad_lai(l,m) = Surface_K(l,m)%Lai
-      ad_veg(l,m) = Surface_K(l,m)%Vegetation_Fraction
-      ad_smc(l,m) = Surface_K(l,m)%Soil_Moisture_Content
+      ad_lai(l,m)   = Surface_K(l,m)%Lai
+      ad_veg(l,m)   = Surface_K(l,m)%Vegetation_Fraction
+      ad_smc(l,m)   = Surface_K(l,m)%Soil_Moisture_Content
+      ad_tsoil(l,m) = Surface_K(l,m)%Soil_Temperature
+      ad_tland(l,m) = Surface_K(l,m)%Land_Temperature
+      ad_cwc(l,m)   = Surface_K(l,m)%Canopy_Water_Content
     END DO
   END DO
 
@@ -187,6 +209,28 @@ PROGRAM test_Land_Jacobian
   END IF
   tl_smc = RTSolution_TL%Brightness_Temperature
 
+  ! ...Soil_Temperature direction
+  CALL CRTM_Atmosphere_Zero( Atm_TL )
+  CALL CRTM_Surface_Zero( Sfc_TL )
+  Sfc_TL%Soil_Temperature = ONE
+  Error_Status = CRTM_Tangent_Linear( Atm, Sfc, Atm_TL, Sfc_TL, Geometry, ChannelInfo, &
+                                      RTSolution, RTSolution_TL )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error in CRTM Tangent_Linear (Tsoil)', FAILURE ); STOP 1
+  END IF
+  tl_tsoil = RTSolution_TL%Brightness_Temperature
+
+  ! ...Land_Temperature direction (emission + emissivity parts)
+  CALL CRTM_Atmosphere_Zero( Atm_TL )
+  CALL CRTM_Surface_Zero( Sfc_TL )
+  Sfc_TL%Land_Temperature = ONE
+  Error_Status = CRTM_Tangent_Linear( Atm, Sfc, Atm_TL, Sfc_TL, Geometry, ChannelInfo, &
+                                      RTSolution, RTSolution_TL )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error in CRTM Tangent_Linear (Tland)', FAILURE ); STOP 1
+  END IF
+  tl_tland = RTSolution_TL%Brightness_Temperature
+
 
   ! 6. Central finite differences of the forward model
   ! --------------------------------------------------
@@ -211,6 +255,20 @@ PROGRAM test_Land_Jacobian
   CALL Run_Forward( RTS_m, 'SMC-' )
   fd_smc = (RTS_p%Brightness_Temperature - RTS_m%Brightness_Temperature)/(2.0_fp*DSMC)
   Sfc%Soil_Moisture_Content = SMC0
+  ! ...Soil_Temperature
+  Sfc%Soil_Temperature = TSOIL0 + DTS
+  CALL Run_Forward( RTS_p, 'Tsoil+' )
+  Sfc%Soil_Temperature = TSOIL0 - DTS
+  CALL Run_Forward( RTS_m, 'Tsoil-' )
+  fd_tsoil = (RTS_p%Brightness_Temperature - RTS_m%Brightness_Temperature)/(2.0_fp*DTS)
+  Sfc%Soil_Temperature = TSOIL0
+  ! ...Land_Temperature
+  Sfc%Land_Temperature = TLAND0 + DTS
+  CALL Run_Forward( RTS_p, 'Tland+' )
+  Sfc%Land_Temperature = TLAND0 - DTS
+  CALL Run_Forward( RTS_m, 'Tland-' )
+  fd_tland = (RTS_p%Brightness_Temperature - RTS_m%Brightness_Temperature)/(2.0_fp*DTS)
+  Sfc%Land_Temperature = TLAND0
 
 
   ! 7. Compare
@@ -237,6 +295,30 @@ PROGRAM test_Land_Jacobian
     END DO
   END DO
 
+  ! ...temperatures (separate table) + Canopy_Water_Content structural zero
+  WRITE(*,'(/5x,a)') 'Temperature Jacobians (K per K). Columns: AD / TL / FD'
+  WRITE(*,'(5x,a)')  '  m  ch     dTb/dTsoil (AD/TL/FD)       dTb/dTland (AD/TL/FD)     K(Canopy_Water)'
+  DO m = 1, N_PROFILES
+    DO l = 1, n_Channels
+      WRITE(*,'(5x,i3,i4,2x,3es12.3,2x,3es12.3,2x,es11.3)') &
+            m, RTSolution(l,m)%Sensor_Channel, &
+            ad_tsoil(l,m), tl_tsoil(l,m), fd_tsoil(l,m), &
+            ad_tland(l,m), tl_tland(l,m), fd_tland(l,m), ad_cwc(l,m)
+      CALL Check( 'AD dTb/dTsoil', m, RTSolution(l,m)%Sensor_Channel, ad_tsoil(l,m), fd_tsoil(l,m), failed )
+      CALL Check( 'TL dTb/dTsoil', m, RTSolution(l,m)%Sensor_Channel, tl_tsoil(l,m), fd_tsoil(l,m), failed )
+      CALL Check( 'AD dTb/dTland', m, RTSolution(l,m)%Sensor_Channel, ad_tland(l,m), fd_tland(l,m), failed )
+      CALL Check( 'TL dTb/dTland', m, RTSolution(l,m)%Sensor_Channel, tl_tland(l,m), fd_tland(l,m), failed )
+      ! Canopy_Water_Content is never consumed by the LandEM forward -> Jacobian
+      ! must be exactly zero (guarded so a future forward change that wires it in
+      ! is flagged here rather than silently producing an unvalidated Jacobian).
+      IF ( ABS(ad_cwc(l,m)) > TOL_ABS ) THEN
+        WRITE(Message,'("Canopy_Water_Content Jacobian expected 0 but got ",es13.5, &
+              &" (profile ",i0," channel ",i0,")")') ad_cwc(l,m), m, RTSolution(l,m)%Sensor_Channel
+        CALL Display_Message( PROGRAM_NAME, TRIM(Message), FAILURE ); failed = .TRUE.
+      END IF
+    END DO
+  END DO
+
   WRITE(*,'(/5x,"Surface-sensitive channel evaluations (|FD|>",es8.1,"): ",i0)') ACTIVE_THRESHOLD, n_active
   IF ( n_active < 1 ) THEN
     CALL Display_Message( PROGRAM_NAME, &
@@ -253,7 +335,8 @@ PROGRAM test_Land_Jacobian
   CALL CRTM_Atmosphere_Destroy( Atmosphere_K )
   DEALLOCATE( RTSolution, RTSolution_TL, RTSolution_K, Atmosphere_K, Surface_K, &
               RTS_p, RTS_m, ad_lai, ad_veg, ad_smc, tl_lai, tl_veg, tl_smc, &
-              fd_lai, fd_veg, fd_smc )
+              fd_lai, fd_veg, fd_smc, ad_tsoil, ad_tland, ad_cwc, &
+              tl_tsoil, tl_tland, fd_tsoil, fd_tland )
 
   IF ( failed ) THEN
     CALL Display_Message( PROGRAM_NAME, 'FAILED: analytic Jacobians disagree with finite differences', FAILURE )
@@ -308,8 +391,8 @@ CONTAINS
       Sfc(mm)%Land_Type            = 1            ! valid NPOESS land type (IR/VIS only)
       Sfc(mm)%Soil_Type            = 1            ! COARSE          (MW land model)
       Sfc(mm)%Vegetation_Type      = 7            ! GROUNDCOVER     (MW land model)
-      Sfc(mm)%Land_Temperature     = 290.0_fp
-      Sfc(mm)%Soil_Temperature     = 290.0_fp
+      Sfc(mm)%Land_Temperature     = TLAND0
+      Sfc(mm)%Soil_Temperature     = TSOIL0
       Sfc(mm)%Soil_Moisture_Content= SMC0
       Sfc(mm)%Lai                  = LAI0
       Sfc(mm)%Vegetation_Fraction  = VEG0


### PR DESCRIPTION
## Summary

Completes the analytic **MW-land (NESDIS_LandEM, < 80 GHz) surface Jacobian set**
for issue #281: adds `Soil_Temperature` and the emissivity part of
`Land_Temperature`, so every physical land-state variable now has a valid analytic
TL/AD/K Jacobian. Targeted at **v3.2.0**.

| Variable | Status | dTb/dx @ 23.8 GHz |
|---|---|---|
| LAI, Vegetation_Fraction, Soil_Moisture | already in (Phases 1/2) | 1.4 / 5.5 / −45 |
| **Soil_Temperature** | **new (Phase 3)** | ~0.59 K/K |
| **Land_Temperature** | **emissivity part added (Phase 3)** | ~0.17 K/K net |
| Canopy_Water_Content | structural zero (asserted) | 0 |

## What it does

- Differentiates the two temperature paths exactly: the soil dielectric
  (`Soil_Diel`, `eswo`/`tauw` polynomials) → roughened Fresnel `r23` → two-stream,
  and the dominant canopy/soil thermal ratio `gsect0` in `Two_Stream_Solution`.
  The `esoil → r23` chain is factored into a shared helper `Roughened_R23_Deriv`
  so the moisture and temperature Jacobians use identical math.
- Resolves the `Soil_Temperature` out-of-range aliasing (`t_soil ← t_skin`) in the
  forward: aliased input → zero derivative, sensitivity re-attributed to
  `Land_Temperature`.
- The `Land_Temperature` emissivity part **accumulates** onto the existing skin-T
  Planck emission Jacobian (`CRTM_Compute_SurfaceT_AD`).

## Latent bug fixed

The forward emissivity already depended on skin temperature via `gsect0`, but that
term was dropped from `Surface_K%Land_Temperature`. The below-cutoff
`Land_Temperature` Jacobian was therefore ~3–4× too large (the emissivity part is
sizable and negative, partially cancelling the emission term). It now matches
finite differences.

## Validation (meticulous)

- `test_Unit_Land_Jacobian` extended: **AD ≡ TL ≡ central-FD of the forward** for
  `Soil_Temperature` and `Land_Temperature`, plus a guarded
  `Canopy_Water_Content == 0`.
- **Forward bit-identical**: `RTSolution` and `Atmosphere_K/AD` unchanged. A
  field-level netCDF diff confirms only the `Land_Temperature` (idx 6) and
  `Soil_Temperature` (idx 10) Surface-Jacobian slices move — all other surface
  fields byte-identical.
- **Full suite 215/215** (stable across two runs) after regenerating the
  MW-over-land Surface references (build-local, self-seeding on fresh checkout).

## Scope

MW **land** (LandEM) only. IR/VIS land emissivity is a LUT indexed by `Land_Type`
(a classifier) with no continuous-state dependence, so those physical-state
Jacobians are identically zero by construction. Snow/ice use separate models
(SnowEM/SeaIceEM, zero-stub TL/AD) and remain follow-on (Phase 4).

## Files

- `src/SfcOptics/NESDIS_Emissivity/NESDIS_LandEM_Module.f90`
- `src/SfcOptics/CRTM_MW_Land_SfcOptics.f90`
- `test/mains/unit/Unit_Test/test_Land_Jacobian.f90`
- release notes / changes doc / `docs/design/surface_jacobians_281.md`

Ref: #281.
