### PR TITLE
Release-readiness fixes for v3.2.0: TELSEM2 opt-in, Fastem1 SST Jacobian, DDA-ARTS ICE_CLOUD test (A1-A4)

### DIFF
--- a/src/CRTM_LifeCycle.f90
+++ b/src/CRTM_LifeCycle.f90
@@ -147,6 +147,7 @@ CONTAINS
 !                                 MWwaterCoeff_File   = MWwaterCoeff_File   , &
 !                                 PARMIOCoeff_File    = PARMIOCoeff_File    , &
 !                                 MWlandCoeff_File    = MWlandCoeff_File    , &
+!                                 Use_MWland_Atlas    = Use_MWland_Atlas    , &
 !                                 IRwaterCoeff_Format = IRwaterCoeff_Format , &
 !                                 IRlandCoeff_Format  = IRlandCoeff_Format  , &
 !                                 IRiceCoeff_Format   = IRiceCoeff_Format   , &
@@ -333,16 +334,33 @@ CONTAINS
 !       MWlandCoeff_File:   Name of the microwave land emissivity atlas file.
 !                           Available datafiles:
 !                           - TELSEM2.MWland.EmisCoeff.nc
-!                           If supplied (or if the default-named file is found
-!                           on the coefficient path) the TELSEM2 climatological
-!                           atlas replaces the NESDIS_LandEM physical model for
-!                           microwave land surfaces. The atlas depends only on
-!                           latitude, longitude and month, so its tangent-linear
-!                           and adjoint are zero; NESDIS_LandEM supplies
-!                           analytic land emissivity Jacobians and is used when
-!                           no atlas is loaded.
+!                           Supplying this argument is an explicit opt-in to the
+!                           TELSEM2 climatological atlas (it may name a
+!                           non-default location); a supplied-but-missing file is
+!                           an error. The atlas is NOT loaded from mere file
+!                           presence on the coefficient path -- opt-in is
+!                           required (this argument, or Use_MWland_Atlas below).
+!                           When loaded, the atlas replaces the NESDIS_LandEM
+!                           physical model for microwave land surfaces.
 !                           UNITS:      N/A
 !                           TYPE:       CHARACTER(*)
+!                           DIMENSION:  Scalar
+!                           ATTRIBUTES: INTENT(IN), OPTIONAL
+!
+!       Use_MWland_Atlas:   Opt-in switch for the microwave land emissivity
+!                           atlas. Default .FALSE.: microwave land surfaces use
+!                           the NESDIS_LandEM physical model, which supplies
+!                           analytic land-emissivity Jacobians (LAI, vegetation
+!                           fraction, soil moisture). Set .TRUE. to load the
+!                           default-named atlas (TELSEM2.MWland.EmisCoeff.nc)
+!                           from the coefficient path; if it is not found CRTM
+!                           issues a warning and falls back to NESDIS_LandEM
+!                           (non-fatal). Passing MWlandCoeff_File is an
+!                           equivalent opt-in for a non-default location. Note
+!                           the atlas depends only on latitude, longitude and
+!                           month, so its tangent-linear and adjoint are zero.
+!                           UNITS:      N/A
+!                           TYPE:       LOGICAL
 !                           DIMENSION:  Scalar
 !                           ATTRIBUTES: INTENT(IN), OPTIONAL
 !
@@ -601,6 +619,7 @@ CONTAINS
     MWwaterCoeff_Scheme , &  ! Optional input
     PARMIOCoeff_File    , &  ! Optional input
     MWlandCoeff_File    , &  ! Optional input
+    Use_MWland_Atlas    , &  ! Optional input
     IRwaterCoeff_Format , &  ! Optional input
     IRlandCoeff_Format  , &  ! Optional input
     IRsnowCoeff_Format  , &  ! Optional input
@@ -642,6 +661,7 @@ CONTAINS
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: MWwaterCoeff_Scheme
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: PARMIOCoeff_File
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: MWlandCoeff_File
+    LOGICAL     ,      OPTIONAL, INTENT(IN)  :: Use_MWland_Atlas
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: IRwaterCoeff_Format
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: IRlandCoeff_Format
     CHARACTER(*),      OPTIONAL, INTENT(IN)  :: IRsnowCoeff_Format
@@ -706,7 +726,7 @@ CONTAINS
     LOGICAL :: netCDF, isSEcategory
     LOGICAL :: Quiet_
     LOGICAL :: parmio_explicit, parmio_present
-    LOGICAL :: mwland_explicit, mwland_present
+    LOGICAL :: mwland_explicit, mwland_present, mwland_opt_in
     INTEGER :: iQuiet ! TODO: iQuiet should be removed once load routine interfaces have been modified
     Quiet_ = .TRUE.
     IF ( PRESENT(Quiet) ) Quiet_ = Quiet
@@ -1227,51 +1247,66 @@ CONTAINS
         END DO
       END IF
 
-      ! ...TELSEM2 MW land emissivity atlas. Same "drop-in when present" policy
-      !    as PARMIO: by default CRTM_Init auto-loads
-      !    File_Path/TELSEM2.MWland.EmisCoeff.nc when present, otherwise the MW
-      !    land surface optics fall back to the NESDIS_LandEM model. Passing
-      !    MWlandCoeff_File explicitly points at a non-default location and a
-      !    missing file is then treated as an error.
+      ! ...TELSEM2 MW land emissivity atlas. OPT-IN (default: NESDIS_LandEM).
+      !    Unlike PARMIO, the atlas is NOT activated by mere file presence on the
+      !    coefficient path: it loads only when the caller explicitly opts in,
+      !    either by setting Use_MWland_Atlas=.TRUE. (auto-resolves the
+      !    default-named TELSEM2.MWland.EmisCoeff.nc from File_Path/NC_File_Path)
+      !    or by passing MWlandCoeff_File (which also opts in and may name a
+      !    non-default location). Without opt-in the atlas is skipped even if the
+      !    file is present, so MW land surface optics use NESDIS_LandEM, which
+      !    carries the analytic land-emissivity Jacobians. Rationale: loading the
+      !    atlas silently zeroes those Jacobians, so it must be a deliberate act.
       mwland_explicit = .FALSE.
       IF ( PRESENT(MWlandCoeff_File) ) THEN
         Resolved_MWlandCoeff_File = TRIM(ADJUSTL(MWlandCoeff_File))
         IF ( LEN_TRIM(Resolved_MWlandCoeff_File) > 0 ) mwland_explicit = .TRUE.
       END IF
-      IF ( .NOT. mwland_explicit ) THEN
-        Resolved_MWlandCoeff_File = 'TELSEM2.MWland.EmisCoeff.nc'
-      END IF
-      IF ( PRESENT(File_Path) ) THEN
-        Resolved_MWlandCoeff_File = TRIM(ADJUSTL(File_Path)) // TRIM(Resolved_MWlandCoeff_File)
-      END IF
-      INQUIRE(FILE=TRIM(Resolved_MWlandCoeff_File), EXIST=mwland_present)
-      ! ...The drop-in default is a netCDF file: when the caller keeps netCDF
-      !    data under a separate NC_File_Path, probe that tree too.
-      IF ( .NOT. mwland_present .AND. .NOT. mwland_explicit .AND. &
-           PRESENT(NC_File_Path) ) THEN
-        Resolved_MWlandCoeff_File = TRIM(ADJUSTL(NC_File_Path)) // 'TELSEM2.MWland.EmisCoeff.nc'
-        INQUIRE(FILE=TRIM(Resolved_MWlandCoeff_File), EXIST=mwland_present)
-      END IF
-      IF ( mwland_present ) THEN
-        IF ( .NOT. Quiet_ ) THEN
-          WRITE(*, '("Loading TELSEM2 MW land emissivity atlas: ", a)') TRIM(Resolved_MWlandCoeff_File)
+      mwland_opt_in = mwland_explicit
+      IF ( PRESENT(Use_MWland_Atlas) ) mwland_opt_in = mwland_opt_in .OR. Use_MWland_Atlas
+      Load_MWland_Atlas: IF ( mwland_opt_in ) THEN
+        IF ( .NOT. mwland_explicit ) THEN
+          Resolved_MWlandCoeff_File = 'TELSEM2.MWland.EmisCoeff.nc'
         END IF
-        err_stat = CRTM_MWlandCoeff_Load( &
-                     TRIM(Resolved_MWlandCoeff_File), &
-                     Quiet             = Quiet            , &
-                     Process_ID        = Process_ID       , &
-                     Output_Process_ID = Output_Process_ID  )
-        IF ( err_stat /= SUCCESS ) THEN
-          msg = 'Error loading MWlandCoeff data from '//TRIM(Resolved_MWlandCoeff_File)
+        IF ( PRESENT(File_Path) ) THEN
+          Resolved_MWlandCoeff_File = TRIM(ADJUSTL(File_Path)) // TRIM(Resolved_MWlandCoeff_File)
+        END IF
+        INQUIRE(FILE=TRIM(Resolved_MWlandCoeff_File), EXIST=mwland_present)
+        ! ...The default-named atlas is a netCDF file: when the caller keeps
+        !    netCDF data under a separate NC_File_Path, probe that tree too.
+        IF ( .NOT. mwland_present .AND. .NOT. mwland_explicit .AND. &
+             PRESENT(NC_File_Path) ) THEN
+          Resolved_MWlandCoeff_File = TRIM(ADJUSTL(NC_File_Path)) // 'TELSEM2.MWland.EmisCoeff.nc'
+          INQUIRE(FILE=TRIM(Resolved_MWlandCoeff_File), EXIST=mwland_present)
+        END IF
+        IF ( mwland_present ) THEN
+          IF ( .NOT. Quiet_ ) THEN
+            WRITE(*, '("Loading TELSEM2 MW land emissivity atlas: ", a)') TRIM(Resolved_MWlandCoeff_File)
+          END IF
+          err_stat = CRTM_MWlandCoeff_Load( &
+                       TRIM(Resolved_MWlandCoeff_File), &
+                       Quiet             = Quiet            , &
+                       Process_ID        = Process_ID       , &
+                       Output_Process_ID = Output_Process_ID  )
+          IF ( err_stat /= SUCCESS ) THEN
+            msg = 'Error loading MWlandCoeff data from '//TRIM(Resolved_MWlandCoeff_File)
+            CALL Display_Message( ROUTINE_NAME,TRIM(msg)//TRIM(pid_msg),err_stat )
+            RETURN
+          END IF
+        ELSE IF ( mwland_explicit ) THEN
+          ! Named a specific file that isn't there: a hard error.
+          msg = 'MWlandCoeff_File explicitly supplied but file not found: '//TRIM(Resolved_MWlandCoeff_File)
+          err_stat = FAILURE
           CALL Display_Message( ROUTINE_NAME,TRIM(msg)//TRIM(pid_msg),err_stat )
           RETURN
+        ELSE
+          ! Opt-in via Use_MWland_Atlas but the default-named atlas is absent:
+          ! non-fatal, fall back to NESDIS_LandEM with a warning.
+          msg = 'Use_MWland_Atlas requested but TELSEM2.MWland.EmisCoeff.nc not '// &
+                'found on the coefficient path; using NESDIS_LandEM.'
+          CALL Display_Message( ROUTINE_NAME,TRIM(msg)//TRIM(pid_msg),WARNING )
         END IF
-      ELSE IF ( mwland_explicit ) THEN
-        msg = 'MWlandCoeff_File explicitly supplied but file not found: '//TRIM(Resolved_MWlandCoeff_File)
-        err_stat = FAILURE
-        CALL Display_Message( ROUTINE_NAME,TRIM(msg)//TRIM(pid_msg),err_stat )
-        RETURN
-      END IF
+      END IF Load_MWland_Atlas
     END IF Microwave_Sensor
 
 

--- a/src/SfcOptics/CRTM_MW_Water_SfcOptics.f90
+++ b/src/SfcOptics/CRTM_MW_Water_SfcOptics.f90
@@ -71,6 +71,10 @@ MODULE CRTM_MW_Water_SfcOptics
   ! -----------------
   ! Low frequency model threshold
   REAL(fp), PARAMETER :: LOW_F_THRESHOLD = 20.0_fp ! GHz
+  ! Finite-difference step (K) for the Fastem1 emissivity SST derivative. Fastem1
+  ! returns only wind-speed derivatives, so d(emissivity)/d(Water_Temperature) is
+  ! obtained by a central difference around the forward call (see below).
+  REAL(fp), PARAMETER :: FASTEM1_DTS = 0.1_fp
   ! PARMIO LUT is the surface-emissivity backend at and above this frequency
   ! when the LUT has been loaded. Below this threshold the FASTEM/Stogryn
   ! legacy path is used.
@@ -219,6 +223,8 @@ CONTAINS
     REAL(fp) :: Frequency
     REAL(fp) :: Source_Azimuth_Angle, Sensor_Azimuth_Angle
     REAL(fp) :: Reflectivity(N_STOKES)
+    ! Fastem1 SST-derivative finite-difference scratch (V=1, H=2)
+    REAL(fp) :: emis_pTs(2), emis_mTs(2), dwind_h, dwind_v
 
 
     ! Set up
@@ -312,6 +318,15 @@ CONTAINS
                         SfcOptics%Emissivity(i,:), & ! Output
                         iVar%dEH_dWindSpeed(i)   , & ! Output
                         iVar%dEV_dWindSpeed(i)     ) ! Output
+          ! Fastem1 returns no SST derivative; obtain d(emissivity)/d(Water_Temperature)
+          ! by a central finite difference around the forward call so the TL/AD SST
+          ! Jacobian (iVar%dE?_dTs, read below) is not silently zero.
+          CALL Fastem1( Frequency, SfcOptics%Angle(i), Surface%Water_Temperature+FASTEM1_DTS, &
+                        Surface%Wind_Speed, emis_pTs, dwind_h, dwind_v )
+          CALL Fastem1( Frequency, SfcOptics%Angle(i), Surface%Water_Temperature-FASTEM1_DTS, &
+                        Surface%Wind_Speed, emis_mTs, dwind_h, dwind_v )
+          iVar%dEV_dTs(i) = (emis_pTs(1) - emis_mTs(1))/(2.0_fp*FASTEM1_DTS)  ! V (index 1)
+          iVar%dEH_dTs(i) = (emis_pTs(2) - emis_mTs(2))/(2.0_fp*FASTEM1_DTS)  ! H (index 2)
           SfcOptics%Reflectivity(i,1,i,1) = ONE-SfcOptics%Emissivity(i,1)
           SfcOptics%Reflectivity(i,2,i,2) = ONE-SfcOptics%Emissivity(i,2)
         END DO

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -366,6 +366,12 @@ target_link_libraries(Unit_Land_Jacobian PRIVATE crtm)
 add_test(NAME test_Unit_Land_Jacobian
          COMMAND $<TARGET_FILE:Unit_Land_Jacobian>)
 
+# Legacy Fastem1 MW-water SST (Water_Temperature) Jacobian vs finite differences.
+add_executable(Unit_Fastem1_SST_Jacobian mains/unit/Unit_Test/test_Fastem1_SST_Jacobian.f90)
+target_link_libraries(Unit_Fastem1_SST_Jacobian PRIVATE crtm)
+add_test(NAME test_Unit_Fastem1_SST_Jacobian
+         COMMAND $<TARGET_FILE:Unit_Fastem1_SST_Jacobian>)
+
 # Surface downwelling radiance (RTSolution%Down_Radiance) TL/AD/K correctness:
 # baseline-independent finite-difference, adjoint dot-product, and K-vs-AD checks
 # for a TOA-radiance control plus the surface downwelling output.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -578,11 +578,16 @@ unset(_TMS_TAU)
 unset(_TMS_SPC)
 
 # test_TELSEM2_MWland
-# Stage the TELSEM2 atlas under a test-only name (NOT the default
-# TELSEM2.MWland.EmisCoeff.nc) so the drop-in default behaviour of the other
-# land tests, which use NESDIS_LandEM, is left unchanged. The test loads it
-# explicitly via the MWlandCoeff_File argument. Registered only when the atlas
-# is present in the staged fix tree.
+# Stage the TELSEM2 atlas under two names in the shared testinput:
+#   * TELSEM2.MWland.test.nc       -- explicit-opt-in path (MWlandCoeff_File).
+#   * TELSEM2.MWland.EmisCoeff.nc  -- the DEFAULT drop-in name, staged ON PURPOSE
+#     so the test can prove the opt-in gate: with the default-named atlas present
+#     on the coefficient path, CRTM_Init must still use NESDIS_LandEM unless the
+#     caller opts in (Use_MWland_Atlas=.TRUE. or MWlandCoeff_File). Because the
+#     atlas is now opt-in rather than presence-activated, staging the default name
+#     is inert for every other land test -- and any regression of the gate would
+#     surface as those tests changing. Registered only when the atlas is present
+#     in the staged fix tree.
 set(_TELSEM2_FIX "${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}/fix/EmisCoeff/MW_Land/netCDF/TELSEM2.MWland.EmisCoeff.nc")
 add_executable(test_TELSEM2_MWland mains/unit/Unit_Test/test_TELSEM2_MWland.f90)
 target_link_libraries(test_TELSEM2_MWland PRIVATE crtm)
@@ -590,6 +595,9 @@ if(EXISTS "${_TELSEM2_FIX}")
   execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
                    "${_TELSEM2_FIX}"
                    "${CMAKE_CURRENT_BINARY_DIR}/testinput/TELSEM2.MWland.test.nc" )
+  execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+                   "${_TELSEM2_FIX}"
+                   "${CMAKE_CURRENT_BINARY_DIR}/testinput/TELSEM2.MWland.EmisCoeff.nc" )
   add_test(NAME test_TELSEM2_MWland
            COMMAND $<TARGET_FILE:test_TELSEM2_MWland>)
 else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -375,7 +375,7 @@ add_test(NAME test_Unit_Fastem1_SST_Jacobian
 # Pins the v3.2.0 DDA-ARTS ICE_CLOUD scattering change (ICE_CLOUD now scatters via
 # the full branch / IconCloudIce habit). Registered only when a DDA-ARTS CloudCoeff
 # is present in the staged fix tree.
-set(_CC_DDA_FIX "${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}/fix/CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2022.nc")
+set(_CC_DDA_FIX "${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}/fix/CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2024.nc")
 add_executable(test_DDA_ICE_CLOUD_Forward mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90)
 target_link_libraries(test_DDA_ICE_CLOUD_Forward PRIVATE crtm)
 if(EXISTS "${_CC_DDA_FIX}")
@@ -925,6 +925,7 @@ AerosolCoeff/netCDF/AerosolCoeff.GOCART-GEOS5.BRC.kb.v2.nc
 AerosolCoeff/netCDF/AerosolCoeff.CMAQ.nc
 CloudCoeff/netCDF/CloudCoeff.nc
 CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2022.nc
+CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2024.nc
 BeCoeff/netCDF/BeCoeff.nc
 EmisCoeff/MW_Water/netCDF/FASTEM6.MWwater.EmisCoeff.nc
 EmisCoeff/MW_Water/netCDF/FASTEM4.MWwater.EmisCoeff.nc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -372,6 +372,20 @@ target_link_libraries(Unit_Fastem1_SST_Jacobian PRIVATE crtm)
 add_test(NAME test_Unit_Fastem1_SST_Jacobian
          COMMAND $<TARGET_FILE:Unit_Fastem1_SST_Jacobian>)
 
+# Pins the v3.2.0 DDA-ARTS ICE_CLOUD scattering change (ICE_CLOUD now scatters via
+# the full branch / IconCloudIce habit). Registered only when a DDA-ARTS CloudCoeff
+# is present in the staged fix tree.
+set(_CC_DDA_FIX "${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH_PREFIX}/${CRTM_COEFFS_BRANCH}/fix/CloudCoeff/netCDF/CloudCoeff_DDA_Moradi_2022.nc")
+add_executable(test_DDA_ICE_CLOUD_Forward mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90)
+target_link_libraries(test_DDA_ICE_CLOUD_Forward PRIVATE crtm)
+if(EXISTS "${_CC_DDA_FIX}")
+  add_test(NAME test_DDA_ICE_CLOUD_Forward
+           COMMAND $<TARGET_FILE:test_DDA_ICE_CLOUD_Forward>)
+else()
+  message(STATUS "DDA-ARTS CloudCoeff not found at ${_CC_DDA_FIX}; test_DDA_ICE_CLOUD_Forward not registered.")
+endif()
+unset(_CC_DDA_FIX)
+
 # Surface downwelling radiance (RTSolution%Down_Radiance) TL/AD/K correctness:
 # baseline-independent finite-difference, adjoint dot-product, and K-vs-AD checks
 # for a TOA-radiance control plus the surface downwelling output.

--- a/test/mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90
+++ b/test/mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90
@@ -1,0 +1,154 @@
+!
+! test_DDA_ICE_CLOUD_Forward
+!
+! Regression coverage for the v3.2.0 DDA-ARTS behavior change: ICE_CLOUD now goes
+! through the full scattering branch (the legacy non-scattering shortcut applies
+! only to Mie-TAMU tables), with the default DDA habit IconCloudIce. This altered
+! radiances/Jacobians for DDA-ARTS users, and nothing pinned the new values.
+!
+! Loads a DDA-ARTS CloudCoeff (CloudCoeff_DDA_Moradi_2022.nc) and runs atms_n21
+! (183 GHz channels) over an ocean US-Standard column for three profiles:
+!     1 = clear, 2 = thin ice, 3 = heavy ice
+! and asserts the ICE_CLOUD scattering path is physical and ACTIVE:
+!     * every TB (all channels/profiles) is physical,
+!     * an ice cloud produces a brightness-temperature DEPRESSION (scattering),
+!     * the depression GROWS with ice water content.
+! If ICE_CLOUD ever reverts to the non-scattering shortcut under DDA-ARTS, the
+! depression collapses and this test fails.
+!
+! STOP 0 on success, STOP 1 on failure.
+!
+PROGRAM test_DDA_ICE_CLOUD_Forward
+
+  USE CRTM_Module
+  IMPLICIT NONE
+
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME = 'test_DDA_ICE_CLOUD_Forward'
+  CHARACTER(*), PARAMETER :: PATH   = './testinput/'
+  CHARACTER(*), PARAMETER :: SENSOR = 'atms_n21'
+  CHARACTER(*), PARAMETER :: LUT    = 'CloudCoeff_DDA_Moradi_2022.nc'
+
+  INTEGER,  PARAMETER :: N_PROFILES  = 3       ! 1=clear, 2=thin ice, 3=heavy ice
+  INTEGER,  PARAMETER :: N_LAYERS    = 100
+  INTEGER,  PARAMETER :: N_ABSORBERS = 6
+  INTEGER,  PARAMETER :: N_CLOUDS    = 1
+  INTEGER,  PARAMETER :: N_AEROSOLS  = 0
+  REAL(fp), PARAMETER :: ZENITH      = 30.0_fp
+  INTEGER,  PARAMETER :: KC1 = 60, KC2 = 72     ! upper-tropospheric (cold) ice band
+  REAL(fp), PARAMETER :: REFF_I      = 100.0_fp ! ice effective radius (microns)
+  REAL(fp), PARAMETER :: WC_THIN     = 0.05_fp  ! kg/m^2 per layer (thin)
+  REAL(fp), PARAMETER :: WC_HEAVY    = 1.00_fp  ! kg/m^2 per layer (heavy)
+
+  REAL(fp), PARAMETER :: MIN_DEPRESSION = 1.0_fp   ! K
+  REAL(fp), PARAMETER :: TB_LO = 50.0_fp, TB_HI = 330.0_fp
+
+  TYPE(CRTM_ChannelInfo_type)             :: chinfo(1)
+  TYPE(CRTM_Geometry_type)                :: geo(N_PROFILES)
+  TYPE(CRTM_Atmosphere_type)              :: atm(N_PROFILES)
+  TYPE(CRTM_Surface_type)                 :: sfc(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: rts(:,:)
+  INTEGER  :: err, nch, m
+  REAL(fp) :: dep_thin, dep_heavy, tb_min, tb_max
+  LOGICAL  :: ok
+
+  ok = .TRUE.
+
+  ! Init CRTM with the DDA-ARTS cloud table (scheme is read from the file)
+  err = CRTM_Init( (/ SENSOR /), chinfo,         &
+                   CloudCoeff_File   = LUT,       &
+                   CloudCoeff_Format = 'netCDF',  &
+                   File_Path         = PATH,      &
+                   Quiet             = .TRUE. )
+  IF ( err /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'CRTM_Init (DDA-ARTS CloudCoeff) failed', FAILURE ); STOP 1
+  END IF
+  nch = SUM( CRTM_ChannelInfo_n_Channels(chinfo) )
+  IF ( nch < 1 ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'no channels loaded for '//SENSOR, FAILURE ); STOP 1
+  END IF
+
+  ALLOCATE( rts(nch, N_PROFILES) )
+  CALL CRTM_Atmosphere_Create( atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  IF ( ANY(.NOT. CRTM_Atmosphere_Associated(atm)) ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'CRTM_Atmosphere_Create failed', FAILURE ); STOP 1
+  END IF
+
+  CALL Load_ECMWF84_Atm_Data()
+  DO m = 2, N_PROFILES
+    atm(m) = atm(1)
+  END DO
+  atm(1)%n_Clouds       = 0
+  atm(1)%Cloud_Fraction = ZERO
+  CALL Set_Ice( atm(2), WC_THIN )
+  CALL Set_Ice( atm(3), WC_HEAVY )
+
+  DO m = 1, N_PROFILES
+    sfc(m)%Water_Coverage    = 1.0_fp
+    sfc(m)%Water_Type        = 1          ! SEA_WATER
+    sfc(m)%Water_Temperature = 290.0_fp
+    sfc(m)%Wind_Speed        = 6.0_fp
+    sfc(m)%Salinity          = 33.0_fp
+    CALL CRTM_Geometry_SetValue( geo(m), Sensor_Zenith_Angle = ZENITH )
+  END DO
+
+  err = CRTM_Forward( atm, sfc, geo, chinfo, rts )
+  IF ( err /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'CRTM_Forward failed', FAILURE ); STOP 1
+  END IF
+
+  tb_min = MINVAL( rts%Brightness_Temperature )
+  tb_max = MAXVAL( rts%Brightness_Temperature )
+  dep_thin  = MAXVAL( rts(:,1)%Brightness_Temperature - rts(:,2)%Brightness_Temperature )
+  dep_heavy = MAXVAL( rts(:,1)%Brightness_Temperature - rts(:,3)%Brightness_Temperature )
+
+  WRITE(*,'(/a)')       ' DDA-ARTS ICE_CLOUD forward scattering check (atms_n21, ice over ocean):'
+  WRITE(*,'(a,i0)')     '   channels                 : ', nch
+  WRITE(*,'(a,2f8.2)')  '   all-profile TB range (K) : ', tb_min, tb_max
+  WRITE(*,'(a,f8.3)')   '   max depression, thin     : ', dep_thin
+  WRITE(*,'(a,f8.3)')   '   max depression, heavy    : ', dep_heavy
+
+  IF ( tb_min < TB_LO .OR. tb_max > TB_HI ) THEN
+    WRITE(*,'(a,2f10.2)') ' FAIL: a TB is outside the physical range ', tb_min, tb_max
+    ok = .FALSE.
+  END IF
+  IF ( dep_heavy < MIN_DEPRESSION ) THEN
+    WRITE(*,'(a,f8.3,a,f6.2,a)') ' FAIL: heavy-ice depression ', dep_heavy, &
+         ' K is below the ', MIN_DEPRESSION, ' K threshold (ICE_CLOUD not scattering?)'
+    ok = .FALSE.
+  END IF
+  IF ( dep_heavy <= dep_thin ) THEN
+    WRITE(*,'(a)') ' FAIL: depression did not increase with ice water content'
+    ok = .FALSE.
+  END IF
+
+  DEALLOCATE( rts )
+  CALL CRTM_Atmosphere_Destroy( atm )
+  err = CRTM_Destroy( chinfo )
+
+  IF ( ok ) THEN
+    WRITE(*,'(/a)') ' PASS: DDA-ARTS ICE_CLOUD forward path produces physical scattering.'
+    STOP 0
+  ELSE
+    WRITE(*,'(/a)') ' FAIL: DDA-ARTS ICE_CLOUD forward checks failed.'
+    STOP 1
+  END IF
+
+CONTAINS
+
+  ! Put an ice cloud of the given per-layer water content into the band.
+  SUBROUTINE Set_Ice( a, wc )
+    TYPE(CRTM_Atmosphere_type), INTENT(IN OUT) :: a
+    REAL(fp),                   INTENT(IN)     :: wc
+    a%n_Clouds                            = 1
+    a%Cloud_Fraction                      = ZERO
+    a%Cloud_Fraction(KC1:KC2)             = 1.0_fp
+    a%Cloud(1)%Type                       = ICE_CLOUD
+    a%Cloud(1)%Effective_Radius           = ZERO
+    a%Cloud(1)%Water_Content              = ZERO
+    a%Cloud(1)%Effective_Radius(KC1:KC2)  = REFF_I
+    a%Cloud(1)%Water_Content(KC1:KC2)     = wc
+  END SUBROUTINE Set_Ice
+
+  INCLUDE 'Load_ECMWF84_Atm_Data.inc'
+
+END PROGRAM test_DDA_ICE_CLOUD_Forward

--- a/test/mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90
+++ b/test/mains/unit/Unit_Test/test_DDA_ICE_CLOUD_Forward.f90
@@ -6,7 +6,7 @@
 ! only to Mie-TAMU tables), with the default DDA habit IconCloudIce. This altered
 ! radiances/Jacobians for DDA-ARTS users, and nothing pinned the new values.
 !
-! Loads a DDA-ARTS CloudCoeff (CloudCoeff_DDA_Moradi_2022.nc) and runs atms_n21
+! Loads a DDA-ARTS CloudCoeff (CloudCoeff_DDA_Moradi_2024.nc) and runs atms_n21
 ! (183 GHz channels) over an ocean US-Standard column for three profiles:
 !     1 = clear, 2 = thin ice, 3 = heavy ice
 ! and asserts the ICE_CLOUD scattering path is physical and ACTIVE:
@@ -26,7 +26,7 @@ PROGRAM test_DDA_ICE_CLOUD_Forward
   CHARACTER(*), PARAMETER :: PROGRAM_NAME = 'test_DDA_ICE_CLOUD_Forward'
   CHARACTER(*), PARAMETER :: PATH   = './testinput/'
   CHARACTER(*), PARAMETER :: SENSOR = 'atms_n21'
-  CHARACTER(*), PARAMETER :: LUT    = 'CloudCoeff_DDA_Moradi_2022.nc'
+  CHARACTER(*), PARAMETER :: LUT    = 'CloudCoeff_DDA_Moradi_2024.nc'
 
   INTEGER,  PARAMETER :: N_PROFILES  = 3       ! 1=clear, 2=thin ice, 3=heavy ice
   INTEGER,  PARAMETER :: N_LAYERS    = 100

--- a/test/mains/unit/Unit_Test/test_Fastem1_SST_Jacobian.f90
+++ b/test/mains/unit/Unit_Test/test_Fastem1_SST_Jacobian.f90
@@ -1,0 +1,179 @@
+!
+! test_Fastem1_SST_Jacobian
+!
+! Validates the sea-surface-temperature (Water_Temperature) Jacobian on the
+! legacy Fastem1 MW-water path (Options%Use_Old_MWSSEM=.TRUE., frequency >= 20 GHz).
+!
+! Fastem1 returns only wind-speed derivatives, so d(emissivity)/d(SST) used to be
+! silently zero -> Surface_K%Water_Temperature carried only the skin-emission term
+! and disagreed with a finite difference of the forward. The forward now caches a
+! central-difference d(emissivity)/d(Water_Temperature), so the analytic K-matrix
+! SST Jacobian must match a central finite difference of the forward.
+!
+! amsua_n19 over ocean; all channels are >= 20 GHz, so all use Fastem1 here.
+! Exit status: STOP 0 = success, STOP 1 = failure.
+!
+PROGRAM test_Fastem1_SST_Jacobian
+
+  USE CRTM_Module
+  IMPLICIT NONE
+
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME      = 'test_Fastem1_SST_Jacobian'
+  CHARACTER(*), PARAMETER :: COEFFICIENTS_PATH = './testinput/'
+  CHARACTER(*), PARAMETER :: SENSOR_ID         = 'amsua_n19'
+  INTEGER,  PARAMETER :: N_PROFILES  = 2   ! matches Load_Atm_Data.inc
+  INTEGER,  PARAMETER :: N_LAYERS    = 92
+  INTEGER,  PARAMETER :: N_ABSORBERS = 2
+  INTEGER,  PARAMETER :: N_CLOUDS    = 0
+  INTEGER,  PARAMETER :: N_AEROSOLS  = 0
+  INTEGER,  PARAMETER :: N_SENSORS   = 1
+  REAL(fp), PARAMETER :: ZENITH_ANGLE = 30.0_fp
+  REAL(fp), PARAMETER :: SCAN_ANGLE   = 26.37293341421_fp
+  ! Ocean base state
+  REAL(fp), PARAMETER :: TS0 = 290.0_fp, WIND0 = 5.0_fp, SAL0 = 33.0_fp
+  REAL(fp), PARAMETER :: DTS = 1.0e-2_fp          ! central-FD SST perturbation (K)
+  REAL(fp), PARAMETER :: TOL_REL = 5.0e-3_fp, TOL_ABS = 1.0e-4_fp
+  REAL(fp), PARAMETER :: ACTIVE = 1.0e-2_fp       ! surface-sensitive threshold (K/K)
+
+  CHARACTER(256) :: Message, Version
+  INTEGER :: Error_Status, Alloc_Status, n_Channels, l, m, n_active
+  LOGICAL :: failed
+  TYPE(CRTM_ChannelInfo_type) :: ChannelInfo(N_SENSORS)
+  TYPE(CRTM_Geometry_type)    :: Geometry(N_PROFILES)
+  TYPE(CRTM_Options_type)     :: Options(N_PROFILES)
+  TYPE(CRTM_Atmosphere_type)  :: Atm(N_PROFILES)
+  TYPE(CRTM_Surface_type)     :: Sfc(N_PROFILES)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTSolution(:,:), RTSolution_K(:,:)
+  TYPE(CRTM_RTSolution_type), ALLOCATABLE :: RTS_p(:,:), RTS_m(:,:)
+  TYPE(CRTM_Atmosphere_type), ALLOCATABLE :: Atmosphere_K(:,:)
+  TYPE(CRTM_Surface_type),    ALLOCATABLE :: Surface_K(:,:)
+  REAL(fp), ALLOCATABLE :: ad_ts(:,:), fd_ts(:,:)
+
+  CALL CRTM_Version( Version )
+  CALL Program_Message( PROGRAM_NAME, &
+    'Validate the legacy Fastem1 SST (Water_Temperature) Jacobian vs finite differences.', &
+    'CRTM Version: '//TRIM(Version) )
+
+  Error_Status = CRTM_Init( (/SENSOR_ID/), ChannelInfo, File_Path=COEFFICIENTS_PATH )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error initializing CRTM', FAILURE ); STOP 1
+  END IF
+  n_Channels = SUM(CRTM_ChannelInfo_n_Channels(ChannelInfo))
+
+  ALLOCATE( RTSolution(n_Channels,N_PROFILES), RTSolution_K(n_Channels,N_PROFILES), &
+            Atmosphere_K(n_Channels,N_PROFILES), Surface_K(n_Channels,N_PROFILES), &
+            RTS_p(n_Channels,N_PROFILES), RTS_m(n_Channels,N_PROFILES), &
+            ad_ts(n_Channels,N_PROFILES), fd_ts(n_Channels,N_PROFILES), STAT=Alloc_Status )
+  IF ( Alloc_Status /= 0 ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error allocating arrays', FAILURE ); STOP 1
+  END IF
+  CALL CRTM_Atmosphere_Create( Atm, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  CALL CRTM_Atmosphere_Create( Atmosphere_K, N_LAYERS, N_ABSORBERS, N_CLOUDS, N_AEROSOLS )
+  CALL CRTM_RTSolution_Create( RTSolution,   N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTSolution_K, N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTS_p,        N_LAYERS )
+  CALL CRTM_RTSolution_Create( RTS_m,        N_LAYERS )
+
+  CALL Load_Atm_Data()
+  CALL Load_Ocean_Surface()
+  CALL CRTM_Geometry_SetValue( Geometry, Sensor_Zenith_Angle=ZENITH_ANGLE, Sensor_Scan_Angle=SCAN_ANGLE )
+  ! Force the legacy Fastem1 path
+  Options%Use_Old_MWSSEM = .TRUE.
+
+  ! Analytic SST Jacobian (K-matrix / adjoint path)
+  CALL CRTM_Atmosphere_Zero( Atmosphere_K )
+  CALL CRTM_Surface_Zero( Surface_K )
+  RTSolution_K%Radiance = ZERO
+  RTSolution_K%Brightness_Temperature = ONE
+  Error_Status = CRTM_K_Matrix( Atm, Sfc, RTSolution_K, Geometry, ChannelInfo, &
+                                Atmosphere_K, Surface_K, RTSolution, Options=Options )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error in CRTM K_Matrix', FAILURE ); STOP 1
+  END IF
+  DO m = 1, N_PROFILES
+    DO l = 1, n_Channels
+      ad_ts(l,m) = Surface_K(l,m)%Water_Temperature
+    END DO
+  END DO
+
+  ! Central finite difference of the forward
+  Sfc%Water_Temperature = TS0 + DTS
+  CALL Run_Forward( RTS_p, 'Ts+' )
+  Sfc%Water_Temperature = TS0 - DTS
+  CALL Run_Forward( RTS_m, 'Ts-' )
+  fd_ts = (RTS_p%Brightness_Temperature - RTS_m%Brightness_Temperature)/(2.0_fp*DTS)
+  Sfc%Water_Temperature = TS0
+
+  failed = .FALSE.; n_active = 0
+  WRITE(*,'(/5x,a)') 'Fastem1 SST Jacobian dTb/dWater_Temperature (K/K). Columns: AD / FD'
+  WRITE(*,'(5x,a)')  '  m  ch        AD           FD'
+  DO m = 1, N_PROFILES
+    DO l = 1, n_Channels
+      WRITE(*,'(5x,i3,i4,2x,2es14.5)') m, RTSolution(l,m)%Sensor_Channel, ad_ts(l,m), fd_ts(l,m)
+      IF ( ABS(fd_ts(l,m)) > ACTIVE ) n_active = n_active + 1
+      CALL Check( 'AD dTb/dTs', m, RTSolution(l,m)%Sensor_Channel, ad_ts(l,m), fd_ts(l,m), failed )
+    END DO
+  END DO
+  WRITE(*,'(/5x,"Surface-sensitive channels (|FD|>",es8.1,"): ",i0)') ACTIVE, n_active
+  IF ( n_active < 1 ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'No SST-sensitive channels exercised -- test not meaningful', FAILURE )
+    failed = .TRUE.
+  END IF
+
+  Error_Status = CRTM_Destroy( ChannelInfo )
+  CALL CRTM_Atmosphere_Destroy( Atm )
+  CALL CRTM_Atmosphere_Destroy( Atmosphere_K )
+  DEALLOCATE( RTSolution, RTSolution_K, Atmosphere_K, Surface_K, RTS_p, RTS_m, ad_ts, fd_ts )
+
+  IF ( failed ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'FAILED: Fastem1 SST Jacobian disagrees with finite differences', FAILURE )
+    STOP 1
+  ELSE
+    CALL Display_Message( PROGRAM_NAME, 'PASSED: Fastem1 SST Jacobian matches finite differences', INFORMATION )
+    STOP 0
+  END IF
+
+CONTAINS
+
+  SUBROUTINE Run_Forward( RTS, label )
+    TYPE(CRTM_RTSolution_type), INTENT(IN OUT) :: RTS(:,:)
+    CHARACTER(*),               INTENT(IN)     :: label
+    INTEGER :: stat
+    stat = CRTM_Forward( Atm, Sfc, Geometry, ChannelInfo, RTS, Options=Options )
+    IF ( stat /= SUCCESS ) THEN
+      CALL Display_Message( PROGRAM_NAME, 'Error in CRTM Forward ('//label//')', FAILURE ); STOP 1
+    END IF
+  END SUBROUTINE Run_Forward
+
+  SUBROUTINE Check( name, m, ch, analytic, fd, failed )
+    CHARACTER(*), INTENT(IN)     :: name
+    INTEGER,      INTENT(IN)     :: m, ch
+    REAL(fp),     INTENT(IN)     :: analytic, fd
+    LOGICAL,      INTENT(IN OUT) :: failed
+    REAL(fp) :: tol
+    tol = TOL_ABS + TOL_REL*ABS(fd)
+    IF ( ABS(analytic - fd) > tol ) THEN
+      WRITE(Message,'(a," mismatch: profile ",i0," channel ",i0,": analytic=",es13.5,&
+            &" FD=",es13.5," |diff|=",es11.3," tol=",es11.3)') &
+            TRIM(name), m, ch, analytic, fd, ABS(analytic-fd), tol
+      CALL Display_Message( PROGRAM_NAME, TRIM(Message), FAILURE ); failed = .TRUE.
+    END IF
+  END SUBROUTINE Check
+
+  SUBROUTINE Load_Ocean_Surface()
+    INTEGER :: mm
+    DO mm = 1, N_PROFILES
+      Sfc(mm)%Water_Coverage    = 1.0_fp
+      Sfc(mm)%Land_Coverage     = 0.0_fp
+      Sfc(mm)%Snow_Coverage     = 0.0_fp
+      Sfc(mm)%Ice_Coverage      = 0.0_fp
+      Sfc(mm)%Water_Type        = 1          ! SEA_WATER
+      Sfc(mm)%Water_Temperature = TS0
+      Sfc(mm)%Wind_Speed        = WIND0
+      Sfc(mm)%Salinity          = SAL0
+    END DO
+  END SUBROUTINE Load_Ocean_Surface
+
+  INCLUDE 'Load_Atm_Data.inc'
+
+END PROGRAM test_Fastem1_SST_Jacobian

--- a/test/mains/unit/Unit_Test/test_TELSEM2_MWland.f90
+++ b/test/mains/unit/Unit_Test/test_TELSEM2_MWland.f90
@@ -20,9 +20,16 @@
 !        - an ocean point (no land climatology) falls back to NESDIS_LandEM
 !          through the full CRTM_Forward path, bit-identical to a NESDIS-only run.
 !
-! The atlas is loaded explicitly via the MWlandCoeff_File argument pointing at a
-! test-only staged copy, so the default drop-in behaviour of the other land
-! tests is left unchanged.
+!   4. The opt-in gate: the atlas is NOT activated by file presence. With the
+!      default-named TELSEM2.MWland.EmisCoeff.nc staged on the coefficient path,
+!        - Use_MWland_Atlas=.TRUE. loads it (emissivity matches the explicit-file
+!          run), while
+!        - the default init (no opt-in) ignores it and uses NESDIS_LandEM.
+!
+! The atlas is staged under two names: a test-only TELSEM2.MWland.test.nc (loaded
+! explicitly via MWlandCoeff_File) and the default TELSEM2.MWland.EmisCoeff.nc
+! (present on the path to exercise the opt-in gate). Because the atlas is opt-in,
+! the default-named copy is inert for the other land tests.
 !
 ! Exit status: STOP 0 = success, STOP 1 = failure.
 !
@@ -76,7 +83,7 @@ PROGRAM test_TELSEM2_MWland
   TYPE(CRTM_Surface_type),    ALLOCATABLE :: Surface_K(:,:)
   ! Surface emissivity (profile 1) for each scenario
   REAL(fp), ALLOCATABLE :: emis_A(:), emis_B(:), emis_A_jan(:), emis_O_atlas(:)
-  REAL(fp), ALLOCATABLE :: emis_nesdis_A(:), emis_nesdis_O(:)
+  REAL(fp), ALLOCATABLE :: emis_nesdis_A(:), emis_nesdis_O(:), emis_A_optin(:)
 
   CALL CRTM_Version( Version )
   CALL Program_Message( PROGRAM_NAME, &
@@ -100,6 +107,7 @@ PROGRAM test_TELSEM2_MWland
             Surface_K(n_Channels,N_PROFILES), &
             emis_A(n_Channels), emis_B(n_Channels), emis_A_jan(n_Channels), &
             emis_O_atlas(n_Channels), emis_nesdis_A(n_Channels), emis_nesdis_O(n_Channels), &
+            emis_A_optin(n_Channels), &
             STAT = Alloc_Status )
   IF ( Alloc_Status /= 0 ) THEN
     CALL Display_Message( PROGRAM_NAME, 'Error allocating arrays', FAILURE ); STOP 1
@@ -175,7 +183,27 @@ PROGRAM test_TELSEM2_MWland
   Error_Status = CRTM_Destroy( ChannelInfo )
 
   ! ------------------------------------------------------------------
-  ! 2. Initialise WITHOUT the atlas -> NESDIS_LandEM fallback
+  ! 1B. Opt-in gate (open): Use_MWland_Atlas=.TRUE. with no explicit file must
+  !     auto-resolve the default-named TELSEM2.MWland.EmisCoeff.nc on the path
+  !     and load it -> emissivity matches the explicit-file run in section 1.
+  ! ------------------------------------------------------------------
+  Error_Status = CRTM_Init( (/SENSOR_ID/), ChannelInfo, &
+                            File_Path=COEFFICIENTS_PATH, Use_MWland_Atlas=.TRUE. )
+  IF ( Error_Status /= SUCCESS ) THEN
+    CALL Display_Message( PROGRAM_NAME, 'Error initializing CRTM (Use_MWland_Atlas)', FAILURE ); STOP 1
+  END IF
+  CALL Run_Forward_At( LAT_A, LON_A, MON_SEP, emis_A_optin, 'A/Sep (opt-in boolean)' )
+  Error_Status = CRTM_Destroy( ChannelInfo )
+  CALL Require_Same( emis_A_optin, emis_A, TOL_ZERO, &
+                     'opt-in boolean loads the default-named atlas (== explicit-file run)' )
+
+  ! ------------------------------------------------------------------
+  ! 2. Initialise WITHOUT opt-in -> NESDIS_LandEM. This is also the opt-in gate
+  !    (closed): the default-named TELSEM2.MWland.EmisCoeff.nc is present on the
+  !    coefficient path, but with no opt-in CRTM_Init must ignore it and use
+  !    NESDIS_LandEM. Section 2a (atlas != NESDIS) therefore doubles as the gate
+  !    guard -- if presence alone activated the atlas, emis_nesdis_A would equal
+  !    emis_A and 2a would fail.
   ! ------------------------------------------------------------------
   Error_Status = CRTM_Init( (/SENSOR_ID/), ChannelInfo, File_Path=COEFFICIENTS_PATH )
   IF ( Error_Status /= SUCCESS ) THEN
@@ -185,7 +213,8 @@ PROGRAM test_TELSEM2_MWland
   CALL Run_Forward_At( LAT_O, LON_O, MON_SEP, emis_nesdis_O, 'ocean (NESDIS)' )
   Error_Status = CRTM_Destroy( ChannelInfo )
 
-  ! 2a. Atlas must change the emissivity at cell A (i.e. it was actually used)
+  ! 2a. Atlas must change the emissivity at cell A (i.e. it was actually used),
+  !     AND the default-named atlas present here was correctly gated off.
   CALL Require_Different( emis_A, emis_nesdis_A, MIN_DIFF, 'atlas active (cell A: TELSEM2 vs NESDIS)' )
 
   ! 2b. Ocean fallback: atlas-loaded run must equal the NESDIS-only run (bit-identical)
@@ -204,13 +233,15 @@ PROGRAM test_TELSEM2_MWland
   CALL CRTM_Atmosphere_Destroy( Atm_TL )
   CALL CRTM_Atmosphere_Destroy( Atmosphere_K )
   DEALLOCATE( RTSolution, RTSolution_TL, RTSolution_K, Atmosphere_K, Surface_K, &
-              emis_A, emis_B, emis_A_jan, emis_O_atlas, emis_nesdis_A, emis_nesdis_O )
+              emis_A, emis_B, emis_A_jan, emis_O_atlas, emis_nesdis_A, emis_nesdis_O, &
+              emis_A_optin )
 
   IF ( failed ) THEN
     CALL Display_Message( PROGRAM_NAME, 'FAILED', FAILURE ); STOP 1
   ELSE
     CALL Display_Message( PROGRAM_NAME, &
-      'PASSED: atlas active; spatial/seasonal dependence; ocean fallback; zero surface Jacobians', &
+      'PASSED: atlas active; spatial/seasonal dependence; ocean fallback; '// &
+      'zero surface Jacobians; opt-in gate (present-but-off)', &
       INFORMATION ); STOP 0
   END IF
 


### PR DESCRIPTION
## Summary

Release-readiness fixes for v3.2.0, from the documented-but-untackled review. Each
is validated; the full suite is 217/217.

### A1 — TELSEM2 MW-land atlas made opt-in (#314)  `2ffdf22`
The atlas ships in the fix tarball and `CRTM_Init` auto-loaded it on presence,
which silently switched MW-land emissivity to the atlas **and zeroed the #281
land Jacobians** in the default deployment. New optional `CRTM_Init` argument
`Use_MWland_Atlas` (default `.FALSE.`); without opt-in the atlas is not loaded
even if the default-named file is present, so MW-land optics use NESDIS_LandEM.
An explicit `MWlandCoeff_File` still counts as opt-in. `test_TELSEM2_MWland`
stages the default-named atlas and proves the gate both ways. (Release-line
counterpart of the gate on the deferred hybrid branch.)

### A2 — Fastem1 MW-water SST Jacobian restored  `a94a6ac`
On the legacy `Fastem1` path (`Options%Use_Old_MWSSEM=.TRUE.`, freq >= 20 GHz),
`iVar%dEH_dTs/dEV_dTs` were read by TL/AD but never assigned, so the SST
sensitivity of the emissivity was silently zero (a wrong, not just missing,
Jacobian). Now obtained by a central finite difference around the forward call.
Default FastemX/PARMIO paths untouched. New `test_Unit_Fastem1_SST_Jacobian`
checks K-vs-FD (destructive check confirms it fails when zeroed).

### A3 — DDA-ARTS ICE_CLOUD scattering pinned  `8da16ed`
Breaking change #5 made `ICE_CLOUD` scatter under DDA-ARTS with no regression
pinning the new values. New `test_DDA_ICE_CLOUD_Forward` (atms_n21 + a DDA-ARTS
CloudCoeff) asserts a physical ice scattering depression (heavy ~141 K) that
grows with ice water content; collapses if ICE_CLOUD reverts to non-scattering.

### A4 — downwelling `n_Stokes>1` emission broadcast — verified, no change
The `Down_Radiance` / `Downwelling_Radiance(:)` outputs are scalar Stokes-I by
design; the scattering branch indexes the Stokes-I row `n1` and the emission
branch writes the scalar `e_Level_Rad_DOWN`. The flagged "broadcast into all
Stokes" risk does not manifest in the shipped code.

## Validation
Full suite 217/217 (adds the two new unit tests). A1 forward paths unchanged for
non-opted-in deployments; A2 default MW-water path byte-identical.
