### PR TITLE
ODPS group system modernization: load-time validation, group registry, per-component kernels, file-roster dispatch

### DIFF
--- a/docs/design/odps_group_modernization.md
+++ b/docs/design/odps_group_modernization.md
@@ -1,0 +1,241 @@
+# Evaluation: modernizing the ODPS transmittance group system
+
+Date: 2026-07-26
+Status: evaluation / proposal, no code changes.
+Companion document: `crtm-coeffgen/docs/omps_group4_odps_group_assessment.md`
+(the Group_Index=4 forensic assessment; this document builds on its verified
+findings and does not repeat the history).
+
+## 1. Purpose
+
+The ODPS "group" system works, but it has accreted since 2008 and its recent
+growth (GROUP_MW_O3, GROUP_UV_NO2) plus the OMPS Group-4 incident exposed how
+cumbersome and ad hoc it has become. This document inventories the actual design
+debt, separates it from the parts that are sound, and proposes a tiered
+modernization path with effort and risk called out per tier.
+
+## 2. What a "group" actually is today
+
+A Group_Index bundles four orthogonal things into one hardcoded integer:
+
+1. A shared predictor basis class: the IR-style basis (groups 1, 2, 8) or the
+   MW-style basis (groups 3, 7), selected in `ODPS_Compute_Predictor`
+   (`ODPS_Predictor.f90:823-828` and the TL/AD copies at 1378 and 2013).
+2. A component roster: which effective-transmittance components exist and in
+   what order (`COMPONENT_ID_MAP_G*`, `N_COMPONENTS_G`).
+3. An absorber roster: which variable gases the coordinate mapping must supply
+   (`ABSORBER_ID_MAP_G*`, `N_ABSORBERS_G`).
+4. A per-component predictor recipe: which formulas, and how many, feed each
+   component (`N_PREDICTORS_G*` plus roughly 2,000 lines of positional
+   assignments, three times over for FWD, TL, and AD).
+
+Because all four axes are welded to one index, adding one scene gas to an
+existing sensor class has each time required a whole new group: MW plus ozone
+became group 7; UV/VIS (group-2 basis) plus NO2 became group 8. The next such
+need (IR plus NO2? MW plus N2O?) means another group, another set of parallel
+arrays, and another pass through three copies of the predictor code.
+
+## 3. What is sound and should be kept
+
+- The optical-depth application side is already data-driven. `ODPS_AtmAbsorption.f90`
+  loops components using the file's own per-channel `n_Predictors(j, channel)`
+  and `Pos_Index(j, channel)` (lines 172-198, 359-386, 563-588). Nothing there
+  cares about the group.
+- Absorber gathering is already data-driven. `ODPS_CoordinateMapping.f90:246`
+  matches `Atm%Absorber_ID` against the file's `Absorber_ID` list, not against
+  the group table.
+- The physics must be compiled code. Predictor functional forms cannot be
+  meaningfully "data-driven" without an expression interpreter, which is the
+  wrong trade for an operational Fortran library. Any modernization keeps
+  compiled predictor kernels; the question is how they are organized and
+  dispatched.
+- The ODPS file format itself is adequate. It already stores `n_Components`,
+  `Component_ID(:)`, `Absorber_ID(:)`, and per-channel predictor counts, which
+  is precisely the metadata a modern dispatch would want. No format change is
+  required for most of what follows.
+
+## 4. Design debt inventory
+
+Each item is verified against source on branch `feature/btj_uv_no2_group8`.
+
+D1. Two sources of truth, never cross-checked. The file carries the component
+    and absorber rosters; the library carries compile-time tables keyed by
+    Group_Index; nothing ever verifies they agree. `Component_ID` from the file
+    is read, stored, and never consulted by the runtime (the predictor code is
+    purely positional). A file whose component count happens to match a group
+    but whose components mean something else would compute silently wrong
+    radiances. The OMPS Group-4 files failed loudly only because the group-4
+    table entry is zero; with a nonzero entry they would have "worked".
+
+D2. No load-time validation surface. An unsupported Group_Index is discovered
+    as a generic "Error allocating predictor structure" deep inside
+    `CRTM_Predictor_Create`, with no mention of the sensor, the group, or what
+    would be supported. The OMPS diagnosis took a forensic session largely
+    because of this.
+
+D3. Magic reserved indices and split ownership. Groups 4 to 6 are zero-padded
+    holes in the ODPS table (`ODPS_Predictor.f90:93-95`) whose meaning
+    (`ODPS_gINDEX_ZSSMIS = 4`, `ODPS_gINDEX_ZAMSUA = 5`) lives in a different
+    module (`ODZeeman_Predictor.f90`), while the actual Zeeman routing decision
+    is made in a third place by WMO sensor ID (`CRTM_TauCoeff.f90:633,655`).
+    The Group_Index in a Zeeman file is decorative; the Group_Index in an ODPS
+    file is load-bearing. Same field, two unrelated meanings.
+
+D4. Parallel-array table growth. A new group touches `N_G`, three dimension
+    arrays, a `GROUP_*` constant, a `COMPONENT_ID_MAP_G*`, an
+    `ABSORBER_ID_MAP_G*`, an `N_PREDICTORS_G*`, the accessor SELECT CASE blocks
+    (`ODPS_Predictor.f90:3506-3536`), and the compute dispatch in three places.
+    That is roughly ten scattered edit sites for what is conceptually one row of
+    a table.
+
+D5. FWD/TL/AD triplication at the wrong granularity. The three copies of the
+    predictor computation are monolithic per basis class (one giant contained
+    subroutine each), so every roster change re-touches all three monoliths.
+    Triplication of formulas is inherent to hand-written TL/AD; triplication of
+    roster and dispatch logic is not.
+
+D6. Undocumented identifier conventions. Component IDs are heritage
+    molecule-set numbers (12 = wet, 13 = dry, 14 = ozone, 101/113/114 =
+    effective variants) documented only in a generation-side parameter file in
+    another repository. This directly enabled the OMPS confusion, and the
+    library exports accessors (`ODPS_Get_Component_ID`, `ODPS_Get_Absorber_ID`,
+    `ODPS_Get_Ozone_Component_ID`) that no code outside the module calls, with a
+    CASE DEFAULT that returns `HUGE()` in the hope of inducing a downstream
+    failure (`ODPS_Predictor.f90:3517-3518`).
+
+D7. Generator mirroring. `crtm-coeffgen` re-implements the group tables in
+    Python (`odps/predictors.py`, `taucoeff/netcdf_io.py`) and must be kept in
+    lockstep with the Fortran by hand. There is no shared, machine-readable
+    definition of what a group means.
+
+One honest complication to record: components are not fully independent within
+a group. Group 1's water-line component includes CH4 and CO cross-terms as
+predictors 16 to 18, and its CO2 component includes a CO term as predictor 11
+(`ODPS_Predictor.f90:1013-1020`). The same Component_ID (101, WLO) means an
+18-predictor recipe in group 1 and a 15-predictor recipe in group 2. So
+predictor kernels cannot be keyed on Component_ID alone; they key on
+(Component_ID, basis class), and a few kernels consume other components' gas
+variables. Any refactor must model this honestly rather than pretending
+components are independent.
+
+## 5. Constraints
+
+- Bit-for-bit reproducibility of existing sensors is the acceptance criterion
+  for any refactor tier below Tier 3. The 200+ ctest baselines plus the
+  machine-precision TL/AD parity tests (for example test_UV_NO2_TLAD) are the
+  safety net.
+- TL and AD stay hand-written (project convention); the goal is to shrink what
+  must be written by hand, not to introduce automatic differentiation.
+- The binary and netCDF TauCoeff formats keep working unchanged through Tier 2.
+- Fortran 2008, no external dependencies.
+
+## 6. Modernization tiers
+
+### Tier 0: hygiene and guardrails (small; no numerical change possible)
+
+1. Load-time validation in the TauCoeff loader: when an ODPS file is loaded,
+   verify Group_Index is a supported, non-reserved group AND that the file's
+   n_Components, Component_ID list, and Absorber_ID list exactly match the
+   group's compiled maps. On mismatch, fail CRTM_Init with the sensor name, the
+   offending values, and the supported set. This closes D1 and D2 outright: the
+   OMPS files would have produced a one-line, self-explanatory error.
+2. Reserved-index ownership: move the Zeeman gINDEX constants (or at minimum a
+   mirror of them, compile-checked) into ODPS_Predictor next to the table, so
+   one module states the whole index space. Replace the zero-padding comment
+   with named RESERVED entries.
+3. Document the component-ID registry (molecule-set heritage, the effective +100
+   convention, who assigns new IDs) in ODPS_Predictor.f90 and in crtm-coeffgen
+   docs. NO2 = 122 already follows the pattern; write the pattern down.
+4. Delete or wire up the dead accessors; replace the HUGE() sentinel with an
+   explicit error path.
+
+This tier is shippable in a 3.2.x timeframe and is worth doing regardless of
+any later tier.
+
+### Tier 1: registry plus component kernels (medium; the substantive cleanup)
+
+1. Replace the parallel arrays with a single derived-type registry:
+
+   ```fortran
+   TYPE :: ODPS_Group_Spec
+     CHARACTER(16) :: Name              ! 'IR_HIRES', 'UV_NO2', ...
+     INTEGER       :: Basis             ! BASIS_IR or BASIS_MW (or RESERVED_ZEEMAN)
+     INTEGER       :: n_Components
+     INTEGER       :: Component_ID(MAX_COMPONENTS)
+     INTEGER       :: n_Absorbers
+     INTEGER       :: Absorber_ID(MAX_ABSORBERS)
+     INTEGER       :: n_Predictors(MAX_COMPONENTS)
+   END TYPE
+   TYPE(ODPS_Group_Spec), PARAMETER :: GROUP_REGISTRY(N_G) = [ ... ]
+   ```
+
+   All accessors become one bounds-checked lookup. Adding a group becomes one
+   registry row. D4 closed.
+2. Break the per-basis monoliths into per-component kernel subroutines (FWD, TL,
+   AD triples): dry_ir, wlo, wco, ozo, co2, n2o, co, ch4, no2, edry_mw, wet_mw,
+   ozo_mw. The shared layer quantities (T, DT, gas ratios, secant products) stay
+   in a basis-level "context" derived type computed once per layer sweep and
+   passed to kernels, which resolves the cross-component coupling cleanly (the
+   WLO group-1 kernel variant reads CH4_A and CO_A from the context). Kernel
+   selection is a loop over the registry roster dispatching on
+   (Component_ID, Basis), replacing the interleaved IF(Group_ID == ...) blocks.
+   D5 reduced to its irreducible core (formula triples).
+3. Positional layout stays exactly as is (component k of the file is roster
+   entry k, enforced by the Tier 0 validation), so results are bit-identical and
+   the file format is untouched.
+
+Payoff test: after Tier 1, "add scene gas X to class Y" is one registry row,
+one kernel triple (if the gas is new), and the generator change. Today the same
+change is a new group threaded through roughly ten sites and three monoliths
+(this is precisely what the GROUP_MW_O3 and GROUP_UV_NO2 efforts had to do).
+
+### Tier 2: allocate and dispatch from the file (medium-large; optional beyond Tier 1)
+
+1. Allocate the predictor structure from the file's own dimensions
+   (n_Components, MAXVAL of per-channel n_Predictors, n_Absorbers) instead of
+   the registry, keeping the registry as the validator and kernel-selector.
+2. Dispatch kernels by the file's Component_ID sequence rather than by roster
+   position. At that point Group_Index degrades to a basis tag plus a validation
+   convenience, and a well-formed file whose components are all known kernels
+   loads even if its exact roster combination was never enshrined as a group.
+   A future dry+ozone-only UV file (the physics the OMPS files actually
+   contain) would load without anyone defining a group for it.
+3. This is the right moment to also normalize the Zeeman side-load: select the
+   ODZeeman path from file metadata (Algorithm or a sub-algorithm field)
+   instead of hardwired WMO IDs, removing the last out-of-band dispatch (D3
+   fully closed). Requires a coordinated coefficient re-release or a
+   dual-acceptance window, so schedule it with a release, not a patch.
+
+### Tier 3: schema and cross-algorithm unification (large; v4 material)
+
+Per-component recipe version tags in the TauCoeff schema; one strategy-style
+interface over ODAS, ODPS, ODSSU, and ODZeeman; shared machine-readable group
+and component registry consumed by both the library and crtm-coeffgen (D7
+closed at the root, for example a small JSON or Fortran namelist shipped with
+the fix set and code-generated into both languages). Worth designing only as
+part of a deliberate v4 / TauCoeff-Release-bump effort.
+
+## 7. Recommendation
+
+1. Do Tier 0 now. It is small, cannot change numbers, and converts the entire
+   OMPS class of failure into a one-line diagnostic. It also documents the
+   conventions while the forensic context is fresh.
+2. Adopt Tier 1 as the modernization target for the next minor release cycle.
+   It is a pure refactor with bit-identical acceptance against the existing
+   baselines, and it is where the "cumbersome and ad hoc" feeling actually
+   lives: ten edit sites and three monoliths per group become one registry row
+   and a kernel set.
+3. Treat Tier 2 as opportunistic follow-on once Tier 1 has soaked, with the
+   Zeeman de-gating explicitly scheduled alongside a coefficient release.
+4. Defer Tier 3 to a v4 conversation.
+
+## 8. Validation strategy for Tiers 1 and 2
+
+- Bit-identical forward, TL, AD, and K baselines across all ODPS sensors in the
+  suite (groups 1, 2, 3, 7, 8 are all exercised by current ctests).
+- The existing machine-precision TL/AD/K parity tests re-run unchanged.
+- New negative tests: a synthetic TauCoeff with a reserved Group_Index, one
+  with a Component_ID/roster mismatch, and one with an unknown Component_ID,
+  each asserting the specific CRTM_Init error message (Tier 0 deliverable).
+- OpenMP consistency test unchanged (registry is PARAMETER data; kernels are
+  pure; no new shared state).

--- a/docs/design/odps_group_modernization_log.md
+++ b/docs/design/odps_group_modernization_log.md
@@ -1,0 +1,113 @@
+# ODPS group modernization: implementation log
+
+Branch: `feature/btj_odps_group_modernization` (off `feature/btj_uv_no2_group8`).
+Purpose: running record of exactly what changed and why, kept current as Tiers
+0 through 2 land. This file is the source for the developer-facing GitHub issue
+to be posted on JCSDA/CRTMv3 after Tier 2 is complete. Design rationale lives in
+`odps_group_modernization.md`; forensic background in
+`crtm-coeffgen/docs/omps_group4_odps_group_assessment.md`.
+
+## Tier 0: validation and guardrails
+
+Status: implemented; full-suite verification in progress.
+
+What changed, file by file:
+
+1. `src/AtmAbsorption/ODPS/ODPS_Predictor.f90`
+   - New PUBLIC parameters `RESERVED_ZSSMIS_GROUP = 4` and
+     `RESERVED_ZAMSUA_GROUP = 5`, declared beside the group table with a
+     comment making this module the single owner of the ODPS group index
+     space (previously the reserved indexes existed only as magic numbers in
+     `ODZeeman_Predictor.f90`).
+   - New PUBLIC parameter `VALID_GROUPS = (/1, 2, 3, 7, 8/)`.
+   - New PUBLIC function `ODPS_Validate_Group(Group_Index, Component_ID,
+     Absorber_ID, Message)`: verifies the group is supported and that the
+     file's component and absorber rosters match the group's compiled maps
+     exactly, in content and order (the predictor code addresses components
+     positionally). Returns a specific, self-explanatory message for:
+     Zeeman-reserved indexes, unknown indexes, roster size mismatches, and
+     roster content/order mismatches.
+   - Component-ID registry documented in place: the IDs are heritage
+     transmittance-production "molecule set" numbers (12 wet, 13 dry, 14
+     ozone, 15 wco, 101 effective-mol1, 113 effdry, 114 effozo, 118 to 121
+     effective trace gases, 122 NO2 CRTM extension). New IDs must be
+     coordinated with crtm-coeffgen.
+   - The `HUGE()` poison values returned by `ODPS_Get_Component_ID` and
+     `ODPS_Get_Absorber_ID` for out-of-range queries are replaced by a named
+     PUBLIC sentinel `ODPS_INVALID_ID = -1` (also now used by
+     `ODPS_Get_Ozone_Component_ID`).
+
+2. `src/AtmAbsorption/ODZeeman/ODZeeman_Predictor.f90`
+   - `ODPS_gINDEX_ZSSMIS` and `ODPS_gINDEX_ZAMSUA` are now derived from the
+     `RESERVED_*` constants via `USE ODPS_Predictor` instead of hardcoding 4
+     and 5 independently. Values unchanged; single source of truth.
+
+3. `src/Coefficients/CRTM_TauCoeff.f90`
+   - After the ODPS container load, every `TC%ODPS(i)` is validated with
+     `ODPS_Validate_Group`; failure aborts `CRTM_Load_TauCoeff` with the
+     sensor name and the specific reason. Before this change, a bad file
+     surfaced later as a generic "Error allocating predictor structure" from
+     `CRTM_Predictor_Create` with no sensor context (this is exactly how the
+     OMPS Group-4 files failed).
+   - The same validation runs over every nested ODPS sub-structure of each
+     loaded ODSSU sensor (guarded on the ODPS pointer being associated, since
+     ODSSU can instead carry ODAS sub-structures).
+   - Zeeman companion files are exempt by construction: they load into the
+     separate ODZeeman container, which this check does not touch.
+
+4. `test/mains/unit/Unit_Test/test_ODPS_Group_Validation.f90` (new) plus
+   CMake registration as `test_Unit_ODPS_Group_Validation`: 17 cases covering
+   all five canonical rosters (accepted), the three Zeeman-reserved indexes,
+   unknown/fill/negative indexes, and size, content, and order mismatches
+   (all rejected with non-blank messages). Includes the literal OMPS roster
+   (Group 4, Component_ID [13, 14], Absorber_ID [3]) as a must-reject case.
+
+Compatibility statement: no coefficient file changes. A pre-change sweep of
+all 568 ODPS structures (including ODSSU sub-blocks) in fix_REL-3.2.0.0
+confirmed every group 1/2/3/7/8 roster matches its compiled map exactly, so
+the new validation rejects only the nine Group-4 files, which never loaded
+successfully anyway (four OMPS: clean failure replaces cryptic failure; five
+zssmis: unaffected, they use the ODZeeman path).
+
+## Tier 1: group registry and per-component predictor kernels
+
+Status: in design; key verified facts recorded here for the implementation.
+
+Verified structure of the current monoliths (needed to preserve bit-identical
+results):
+
+- FWD `ODPS_Compute_Predictor` (driver at 739; contained IR at 869, MW at
+  1127 by pre-change numbering): driver computes integrated variables (Tz,
+  Tzp, GAz, GAzp, GATzp) in a layer loop sized by `N_ABSORBERS_G(Group_ID)`,
+  then dispatches IR (groups 1, 2, 8) or MW (groups 3, 7). Within the IR
+  layer loop, component blocks execute in order: DRY, WCO, OZO, CO2, WLO,
+  then the group-1 extension block (CO2 predictor 11, WLO predictors 16-18,
+  CO, CH4, N2O), then NO2 (group 8). Forward X assignments are independent
+  (no cross-accumulation), so kernel execution order is bit-irrelevant in
+  FWD and TL.
+- TL mirrors FWD exactly (value + derivative pairs); NO2 TL block sits after
+  the group-1 block. MW TL has two quirks to preserve verbatim: it zeroes
+  `X(:, 8:, COMP_DRY_MW)` inside the layer loop, and one H2OdH2OTzp_TL term
+  indexes `GATzp_TL(k, ABS_H2O_IR)` (harmless: both constants are 1).
+- AD is NOT a strict reverse of FWD and its accumulation order determines
+  bit-level results. Verified per-layer order in IR_AD: recompute forward
+  scalars; then adjoint blocks DRY, WCO, NO2 (group 8, self-contained
+  through to Absorber_AD), OZO, CO2 (1-10), WLO (1-15), group-1 extension
+  (WLO 16-18 AND CO2 predictor 11 together), CO, CH4, N2O; then the group-1
+  variable-chain epilogue (CH4, CO, N2O chains to Absorber_AD); then the
+  common epilogue (O3 chain, H2O chain, DT2/T2 chains, absorber and
+  temperature propagation). MW_AD: DRY, WET, then a fully self-contained
+  OZO block (group 7), then the common epilogue. Any kernel decomposition
+  must call AD kernels in exactly this order.
+- Group variants are encoded by per-component predictor counts (WLO 18 in
+  group 1 vs 15 in group 2/8; CO2 11 vs 10), so kernels can key their
+  extensions on the roster's count instead of the group index.
+
+Planned decomposition (bit-identity preserving): keep the single layer loop
+per basis; replace the interleaved IF(Group_ID) blocks with per-component
+kernel calls in the monolith's exact statement order; kernels are contained
+subroutines host-associating the shared per-layer scalars.
+
+## Tier 2: file-driven allocation and dispatch, Zeeman dual-acceptance
+
+Status: pending.

--- a/docs/design/odps_group_modernization_log.md
+++ b/docs/design/odps_group_modernization_log.md
@@ -71,7 +71,55 @@ zssmis: unaffected, they use the ODZeeman path).
 
 ## Tier 1: group registry and per-component predictor kernels
 
-Status: in design; key verified facts recorded here for the implementation.
+Status: implemented (two commits); full-suite verification in progress.
+
+Tier 1a (registry): `ODPS_Group_Spec_type` plus the `GROUP_REGISTRY`
+parameter array replace the six families of parallel tables
+(N_COMPONENTS_G, N_ABSORBERS_G, MAX_N_PREDICTORS_G, N_PREDICTORS_G*,
+COMPONENT_ID_MAP_G*, ABSORBER_ID_MAP_G*). Each row carries: group name,
+basis class (BASIS_IR = groups 1/2/8, BASIS_MW = groups 3/7,
+BASIS_RESERVED = rows 4 to 6), n_Components, n_Absorbers,
+Max_n_Predictors, the component roster, the absorber roster, and the
+per-component predictor counts. Accessors became bounds-checked registry
+lookups; ODPS_Validate_Group compares against registry rosters; the
+driver absorber loops and n_CP assignments read the registry. Adding a
+group is now one registry row plus its named constant.
+
+Tier 1b (kernelization): the three predictor monoliths
+(ODPS_Compute_Predictor and its TL and AD companions) were decomposed
+into per-component kernel subroutines dispatched from the registry
+roster inside a single per-basis layer loop.
+
+- FWD and TL: kernels are dispatched by Component_ID in roster order
+  (assignments are independent, so order is bit-irrelevant); the group-1
+  variants live inside the WLO and CO2 kernels keyed on the roster's
+  predictor count (np >= 18 adds WLO 16-18; np >= 11 adds CO2 11), not
+  on the group index. Shared per-layer scalars are computed once in the
+  basis loop; the trace-gas block (CO/CH4/N2O) is guarded by roster
+  presence (has_trace), the MW ozone block by absorber presence.
+- AD: kernel call order is bit-significant (adjoint accumulations are
+  floating-point sums), so the dispatch reproduces the heritage monolith
+  order exactly and documents it as load-bearing: DRY, WCO, NO2, OZO,
+  CO2, WLO (with the group-1 extension, which also owns the CO2
+  predictor-11 adjoint to preserve the heritage accumulation point),
+  CO, CH4, N2O, trace-gas variable chains, common variable chains.
+- Absorber array positions (ja_h2o, ja_o3, ...) are resolved from the
+  registry roster by HITRAN ID at dispatch setup instead of hardwired
+  ABS_* index constants, which is the seam Tier 2 uses to resolve them
+  from the file instead.
+- Duplicate formulations collapsed: IR dry and MW effective-dry use one
+  kernel (identical formulas), as do IR ozone and MW_O3 ozone.
+- Quirks preserved verbatim: the MW TL dry-slot zeroing
+  (X(:, 8:, dry) = ZERO inside the layer loop), the warning-silencing
+  HUGE() initializations, and the AD zeroing of the relic ozone
+  predictor slots 12 and 13.
+
+Verification: 82/82 forward tests after the FWD stage; 20/20
+tangent-linear plus both machine-precision parity tests after the TL
+stage; full suite after the AD stage: 227/227 (ctest exit 0), plus a 91-test
+adjoint/k-matrix/parity re-run after switching the AD WLO variant
+selector from the forward-filled n_CP to the deterministic registry
+value.
 
 Verified structure of the current monoliths (needed to preserve bit-identical
 results):

--- a/docs/design/odps_group_modernization_log.md
+++ b/docs/design/odps_group_modernization_log.md
@@ -158,4 +158,67 @@ subroutines host-associating the shared per-layer scalars.
 
 ## Tier 2: file-driven allocation and dispatch, Zeeman dual-acceptance
 
-Status: pending.
+Status: implemented and verified: full suite 227/227.
+
+Implementation note for reviewers: the first Tier-2 build failed 38
+hyperspectral-IR (group 1) forward tests with BT errors up to 0.5 K. The
+cause was an ordering bug introduced while switching n_CP to the kernel
+capability function: the n_CP loop consumed has_trace before it was
+computed, so the group-1 WLO capability collapsed from 18 to 15 and
+predictors 16 to 18 went stale. Fixed by computing has_trace immediately
+before the n_CP loop in the FWD and TL drivers (the AD driver already
+ordered them correctly). This is exactly the class of defect the
+regression suite exists to catch, and it did.
+
+1. Compute dispatch from the file's own rosters. The three compute drivers
+   (`ODPS_Compute_Predictor` and TL/AD) take two new arguments, the file's
+   `Component_ID(:)` and `Absorber_ID(:)` (passed from the TC by the
+   assemble routines). Kernel dispatch loops over the file roster; gas
+   positions (ja_h2o, ...) are resolved from the file's absorber list; the
+   AD's position lookups search the file roster; per-component predictor
+   counts (n_CP) come from the new `ODPS_Kernel_n_Predictors(Basis,
+   Component_ID, Has_Trace)` capability function. For every canonical
+   roster these all yield exactly the Tier-1 values.
+
+2. Allocation from the file. `CRTM_Predictor_Define.f90` sizes the
+   predictor structure from `SIZE(TC%...%Component_ID)`,
+   `SIZE(TC%...%Absorber_ID)`, and the new
+   `ODPS_Max_n_Predictors_For(Group_Index, Component_ID)` (maximum kernel
+   capability over the file's components), for both plain ODPS sensors and
+   ODSSU's nested ODPS sub-structures. Identical dimensions for all
+   canonical rosters.
+
+3. Validation semantics widen from "exact registry roster" to kernel
+   capability: a file is valid when its Group_Index is a supported group
+   (which fixes the basis), every component ID maps to a compiled kernel
+   for that basis, rosters carry no duplicates, absorber IDs are gases
+   CRTM knows, the group-1 trace trio (CO/CH4/N2O) appears all-or-none
+   (and then requires the WLO and CO2 components that carry its extension
+   predictors), and every gas a present kernel consumes is in the file's
+   absorber roster. Consequences: subset and reordered rosters become
+   loadable (for example a dry+ozone UV file, the physics the OMPS files
+   actually contain, as a group-8 subset), while unknown component IDs
+   (raw molecule sets 13/14 from externally trained files) remain
+   rejected: a kernel is a trained CRTM predictor formulation, not just a
+   gas label. Shared-scalar blocks and the AD epilogue chains gained
+   gas-presence guards so subset rosters never touch an absent gas.
+
+4. Zeeman dual-acceptance. A sensor is Zeeman-eligible through the
+   heritage WMO gate (SSMIS, AMSU-A) OR when its netCDF companion
+   z<Sensor_ID>.TauCoeff.nc exists and carries global attribute
+   `Zeeman_Algorithm = 1` (new `Zeeman_Metadata_OptIn` probe in
+   `CRTM_TauCoeff.f90`). Existing coefficient sets carry no such
+   attribute and behave exactly as before; future Zeeman-corrected
+   sensors opt in via metadata instead of hardwired WMO IDs. No
+   coefficient file changes.
+
+5. Unit test updated to the Tier-2 semantics: 8 accepted rosters
+   (canonical five plus G7-style group-3, reordered, and the dry+ozone
+   UV subset) and 15 rejected (reserved/unknown groups, unknown component
+   IDs including the literal OMPS 13/14 roster, duplicates, partial trace
+   trio, missing required gases, basis mismatches, unknown absorber).
+
+Compatibility: no coefficient file changes anywhere in Tiers 0 through 2.
+Canonical rosters produce bit-identical results (dimensions, dispatch
+order, and n_CP all reduce to the Tier-1 values); the widened validation
+only adds acceptance, never removes it.

--- a/src/AtmAbsorption/CRTM_Predictor_Define.f90
+++ b/src/AtmAbsorption/CRTM_Predictor_Define.f90
@@ -34,9 +34,7 @@ MODULE CRTM_Predictor_Define
                                         PAFV_Associated          , &
                                         PAFV_Destroy             , &
                                         PAFV_Create
-  USE ODPS_Predictor,             ONLY: ODPS_Get_n_Components    , &
-                                        ODPS_Get_max_n_Predictors, &
-                                        ODPS_Get_n_Absorbers     , &
+  USE ODPS_Predictor,             ONLY: ODPS_Max_n_Predictors_For, &
                                         ODPS_Get_SaveFWVFlag     , &
                                         ALLOW_OPTRAN
   ! ODZeeman modules
@@ -250,14 +248,15 @@ CONTAINS
         i = TC%ODPS(idx)%Group_Index
         ! ...Set OPTRAN flag
         no_optran = .NOT. ((TC%ODPS(idx)%n_OCoeffs > 0) .AND. ALLOW_OPTRAN)
-        ! ...Allocate main structure
+        ! ...Allocate main structure from the file's own rosters (the
+        !    load-time validation guarantees kernel support)
         CALL ODPS_Predictor_Create( &
-               self%ODPS                   , &
-               TC%ODPS(idx)%n_Layers       , &
-               n_Layers                    , &
-               ODPS_Get_n_Components(i)    , &
-               ODPS_Get_max_n_Predictors(i), &
-               No_OPTRAN = no_optran         )
+               self%ODPS                        , &
+               TC%ODPS(idx)%n_Layers            , &
+               n_Layers                         , &
+               SIZE(TC%ODPS(idx)%Component_ID)  , &
+               ODPS_Max_n_Predictors_For(i, TC%ODPS(idx)%Component_ID), &
+               No_OPTRAN = no_optran              )
         allocate_success = ODPS_Predictor_Associated(self%ODPS)
         ! ...Allocate memory for saved forward variables
         ! *****FLAW*****
@@ -265,11 +264,11 @@ CONTAINS
         IF ( PRESENT(SaveFWV) .AND. ODPS_Get_SaveFWVFlag() ) THEN
         ! *****FLAW*****
           CALL PAFV_Create( &
-                 self%ODPS%PAFV         , &
-                 TC%ODPS(idx)%n_Layers  , &
-                 n_Layers               , &
-                 ODPS_Get_n_Absorbers(i), &
-                 No_OPTRAN = no_optran    )
+                 self%ODPS%PAFV                 , &
+                 TC%ODPS(idx)%n_Layers          , &
+                 n_Layers                       , &
+                 SIZE(TC%ODPS(idx)%Absorber_ID) , &
+                 No_OPTRAN = no_optran            )
           allocate_success = allocate_success .AND. &
                              PAFV_Associated(self%ODPS%PAFV)
         END IF
@@ -295,14 +294,14 @@ CONTAINS
             i = TC%ODSSU(idx)%ODPS(1)%Group_Index
             ! ...Set OPTRAN flag
             no_optran = .NOT. ((TC%ODSSU(idx)%ODPS(1)%n_OCoeffs > 0) .AND. ALLOW_OPTRAN)
-            ! ...Allocate main structure
+            ! ...Allocate main structure from the file's own rosters
             CALL ODPS_Predictor_Create( &
-                   self%ODPS                     , &
-                   TC%ODSSU(idx)%ODPS(1)%n_Layers, &
-                   n_Layers                      , &
-                   ODPS_Get_n_Components(i)      , &
-                   ODPS_Get_max_n_Predictors(i)  , &
-                   No_OPTRAN = no_optran           )
+                   self%ODPS                                 , &
+                   TC%ODSSU(idx)%ODPS(1)%n_Layers            , &
+                   n_Layers                                  , &
+                   SIZE(TC%ODSSU(idx)%ODPS(1)%Component_ID)  , &
+                   ODPS_Max_n_Predictors_For(i, TC%ODSSU(idx)%ODPS(1)%Component_ID), &
+                   No_OPTRAN = no_optran                       )
             allocate_success = ODPS_Predictor_Associated(self%ODPS)
             ! ...Allocate memory for saved forward variables
             ! *****FLAW*****
@@ -310,11 +309,11 @@ CONTAINS
             IF ( PRESENT(SaveFWV) .AND. ODPS_Get_SaveFWVFlag() ) THEN
             ! *****FLAW*****
               CALL PAFV_Create( &
-                     self%ODPS%PAFV                , &
-                     TC%ODSSU(idx)%ODPS(1)%n_Layers, &
-                     n_Layers                      , &
-                     ODPS_Get_n_Absorbers(i)       , &
-                     No_OPTRAN = no_optran           )
+                     self%ODPS%PAFV                          , &
+                     TC%ODSSU(idx)%ODPS(1)%n_Layers          , &
+                     n_Layers                                , &
+                     SIZE(TC%ODSSU(idx)%ODPS(1)%Absorber_ID) , &
+                     No_OPTRAN = no_optran                     )
               allocate_success = allocate_success .AND. &
                                  PAFV_Associated(self%ODPS%PAFV)
             END IF

--- a/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
+++ b/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
@@ -87,18 +87,20 @@ MODULE ODPS_Predictor
   ! -----------------
   ! Module parameters
   ! -----------------
-  ! Dimensions of each predictor group.
+  ! The ODPS groups. The complete definition of every group (its predictor
+  ! basis, component roster, absorber roster, and per-component predictor
+  ! counts) lives in the single GROUP_REGISTRY table declared below, after
+  ! the component and absorber ID constants it references.
   ! Group 7 is the MW+ozone variant of group 3 (indexes 4 - 6 are Zeeman);
-  ! entries 4 - 6 in the dimension tables are placeholders (Zeeman has its
-  ! own predictor module and never reaches these tables).
-  ! Group 8 is the UV/VIS variant of group 2 with an added scene-NO2 component
-  ! (components [Dry,WLO,WCO,Ozone,CO2,NO2], absorbers [H2O,O3,CO2,NO2]).
+  ! group 8 is the UV/VIS variant of group 2 with an added scene-NO2
+  ! component.
   INTEGER, PARAMETER  :: N_G = 8
-  INTEGER, PARAMETER  :: N_COMPONENTS_G(N_G)     = (/8,   5, 2, 0, 0, 0, 3, 6/)
-  INTEGER, PARAMETER  :: N_ABSORBERS_G(N_G)      = (/6,   3, 1, 0, 0, 0, 2, 4/)
-  INTEGER, PARAMETER  :: MAX_N_PREDICTORS_G(N_G) = (/18, 15, 14, 0, 0, 0, 14, 15/)
-  INTEGER, PARAMETER  :: MAX_COMPONENTS_ANY_GROUP = MAXVAL(N_COMPONENTS_G)
-  INTEGER, PARAMETER  :: MAX_ABSORBERS_ANY_GROUP  = MAXVAL(N_ABSORBERS_G)
+  INTEGER, PARAMETER  :: MAX_COMPONENTS_ANY_GROUP = 8
+  INTEGER, PARAMETER  :: MAX_ABSORBERS_ANY_GROUP  = 6
+  ! Predictor basis classes: which shared per-layer formulation a group uses
+  INTEGER, PARAMETER :: BASIS_RESERVED = 0  ! Zeeman-reserved; never dispatched here
+  INTEGER, PARAMETER :: BASIS_IR       = 1  ! IR/VIS/UV formulation (groups 1, 2, 8)
+  INTEGER, PARAMETER :: BASIS_MW       = 2  ! MW formulation (groups 3, 7)
   ! Group index. Group indexes 4 - 6 are RESERVED for the Zeeman sub-algorithms
   ! and are never valid in a standard ODPS TauCoeff file: 4 is Zeeman SSMIS,
   ! 5 is Zeeman AMSU-A, 6 is an unassigned Zeeman reserve. This module is the
@@ -117,45 +119,6 @@ MODULE ODPS_Predictor
   ! The groups a standard ODPS TauCoeff file may legitimately carry
   INTEGER, PARAMETER :: VALID_GROUPS(5) = &
     (/ GROUP_1, GROUP_2, GROUP_3, GROUP_MW_O3, GROUP_UV_NO2 /)
-
-  ! Number of predictors for each component
-  INTEGER, PARAMETER :: N_PREDICTORS_G1(8) = (/ &
-                     7, &  ! dry gas
-                    18, &  ! water vapor line only, no continua
-                     7, &  ! water vapor continua only, no line absorption
-!                    13, &  ! ozone
-                    11, &  ! ozone
-                    11, &  ! CO2
-                    14, &  ! N2O
-                    10, &  ! CO
-                    11 /)  ! CH4
-
-  INTEGER, PARAMETER :: N_PREDICTORS_G2(5) = (/ &
-                     7, &  ! dry gas
-                    15, &  ! water vapor line only, no continua
-                     7, &  ! water vapor continua only, no line absorption
-!                    13, &  ! ozone
-                    11, &  ! ozone
-                    10 /)  ! CO2
-
-  INTEGER, PARAMETER :: N_PREDICTORS_G3(2) = (/ &
-                     7, &  ! dry gas
-                    14 /)  ! water vapor line and continua
-
-  INTEGER, PARAMETER :: N_PREDICTORS_G7(3) = (/ &
-                     7, &  ! effective dry gas (climatological trace gases folded in)
-                    14, &  ! water vapor line and continua
-                    11 /)  ! ozone (same formulation as the IR ozone component)
-
-  ! Group 8 = group 2 (IR/VIS) predictor counts plus the NO2 component.
-  INTEGER, PARAMETER :: N_PREDICTORS_G8(6) = (/ &
-                     7, &  ! dry gas
-                    15, &  ! water vapor line only, no continua
-                     7, &  ! water vapor continua only, no line absorption
-                    11, &  ! ozone
-                    10, &  ! CO2
-                     3 /)  ! NO2 (scene component: amount*secant, and its T, T^2 terms)
-
 
   ! Component IDs.
   !
@@ -211,41 +174,6 @@ MODULE ODPS_Predictor
   ! UV/VIS group-8 NO2 component index (6th component of the group-2-based set)
   INTEGER, PARAMETER :: COMP_NO2_G8 = 6   ! GROUP_UV_NO2 only
 
-  ! Component index to component ID mapping
-  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G1(8) = (/ &
-                                DRY_ComID_G1, &
-                                   WLO_ComID, &
-                                   WCO_ComID, &
-                                   OZO_ComID, &
-                                   CO2_ComID, &
-                                   N2O_ComID, &
-                                   CO_ComID , &
-                                   CH4_ComID /)
-
-  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G2(5) = (/ &
-                                DRY_ComID_G2, &
-                                   WLO_ComID, &
-                                   WCO_ComID, &
-                                   OZO_ComID, &
-                                   CO2_ComID /)
-
-  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G3(2) = (/ &
-                                  EDRY_ComID, &
-                                   WET_ComID /)
-
-  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G7(3) = (/ &
-                                  EDRY_ComID, &
-                                   WET_ComID, &
-                                   OZO_ComID /)
-
-  INTEGER, PARAMETER :: COMPONENT_ID_MAP_G8(6) = (/ &
-                                DRY_ComID_G2, &
-                                   WLO_ComID, &
-                                   WCO_ComID, &
-                                   OZO_ComID, &
-                                   CO2_ComID, &
-                                   NO2_ComID /)
-
   ! Absorber IDs (HITRAN)
   INTEGER, PARAMETER ::   H2O_ID =  1
   INTEGER, PARAMETER ::   CO2_ID =  2
@@ -270,32 +198,61 @@ MODULE ODPS_Predictor
   ! IR indexes (ABS_H2O_IR/ABS_O3_IR/ABS_CO2_IR = 1/2/3), NO2 is the 4th.
   INTEGER,  PARAMETER :: ABS_NO2_G8 = 4   ! GROUP_UV_NO2 only
 
-  ! Absorber index to absorber ID mapping
-  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G1(6) = (/ &
-                                    H2O_ID, &
-                                    O3_ID,  &
-                                    CO2_ID, &
-                                    N2O_ID, &
-                                    CO_ID,  &
-                                    CH4_ID /)
+  ! ---------------------------------------------------------------------
+  ! THE GROUP REGISTRY: one row per ODPS group, the complete definition in
+  ! one place (basis class, component roster, absorber roster, and the
+  ! per-component predictor counts). Rows 4 to 6 are the Zeeman-reserved
+  ! placeholders (BASIS_RESERVED, all-zero rosters). The rosters are padded
+  ! with zeros to the fixed component/absorber maximums; only the first
+  ! n_Components / n_Absorbers entries are meaningful.
+  !
+  ! To add a group: add one row here, extend N_G, add the group's named
+  ! index constant above, add it to VALID_GROUPS, and provide predictor
+  ! kernels for any component ID not already handled (see the kernel
+  ! dispatch in ODPS_Compute_Predictor and its TL/AD companions).
+  ! ---------------------------------------------------------------------
+  TYPE :: ODPS_Group_Spec_type
+    CHARACTER(12) :: Name
+    INTEGER       :: Basis
+    INTEGER       :: n_Components
+    INTEGER       :: n_Absorbers
+    INTEGER       :: Max_n_Predictors
+    INTEGER       :: Component_ID(MAX_COMPONENTS_ANY_GROUP)
+    INTEGER       :: Absorber_ID(MAX_ABSORBERS_ANY_GROUP)
+    INTEGER       :: n_Predictors(MAX_COMPONENTS_ANY_GROUP)
+  END TYPE ODPS_Group_Spec_type
 
-  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G2(3) = (/ &
-                                    H2O_ID, &
-                                    O3_ID,  &
-                                    CO2_ID /)
+  TYPE(ODPS_Group_Spec_type), PARAMETER :: GROUP_REGISTRY(N_G) = (/ &
+    ODPS_Group_Spec_type( 'IR_HIRES    ', BASIS_IR, 8, 6, 18, &
+      (/ DRY_ComID_G1, WLO_ComID, WCO_ComID, OZO_ComID, CO2_ComID, N2O_ComID, CO_ComID, CH4_ComID /), &
+      (/ H2O_ID, O3_ID, CO2_ID, N2O_ID, CO_ID, CH4_ID /), &
+      (/ 7, 18, 7, 11, 11, 14, 10, 11 /) ), &
+    ODPS_Group_Spec_type( 'IR_BROAD    ', BASIS_IR, 5, 3, 15, &
+      (/ DRY_ComID_G2, WLO_ComID, WCO_ComID, OZO_ComID, CO2_ComID, 0, 0, 0 /), &
+      (/ H2O_ID, O3_ID, CO2_ID, 0, 0, 0 /), &
+      (/ 7, 15, 7, 11, 10, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'MW          ', BASIS_MW, 2, 1, 14, &
+      (/ EDRY_ComID, WET_ComID, 0, 0, 0, 0, 0, 0 /), &
+      (/ H2O_ID, 0, 0, 0, 0, 0 /), &
+      (/ 7, 14, 0, 0, 0, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'RSVD_ZSSMIS ', BASIS_RESERVED, 0, 0, 0, &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /), (/ 0, 0, 0, 0, 0, 0 /), &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'RSVD_ZAMSUA ', BASIS_RESERVED, 0, 0, 0, &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /), (/ 0, 0, 0, 0, 0, 0 /), &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'RSVD_ZEEMAN3', BASIS_RESERVED, 0, 0, 0, &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /), (/ 0, 0, 0, 0, 0, 0 /), &
+      (/ 0, 0, 0, 0, 0, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'MW_O3       ', BASIS_MW, 3, 2, 14, &
+      (/ EDRY_ComID, WET_ComID, OZO_ComID, 0, 0, 0, 0, 0 /), &
+      (/ H2O_ID, O3_ID, 0, 0, 0, 0 /), &
+      (/ 7, 14, 11, 0, 0, 0, 0, 0 /) ), &
+    ODPS_Group_Spec_type( 'UV_NO2      ', BASIS_IR, 6, 4, 15, &
+      (/ DRY_ComID_G2, WLO_ComID, WCO_ComID, OZO_ComID, CO2_ComID, NO2_ComID, 0, 0 /), &
+      (/ H2O_ID, O3_ID, CO2_ID, NO2_ID, 0, 0 /), &
+      (/ 7, 15, 7, 11, 10, 3, 0, 0 /) ) /)
 
-  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G3(1) = (/ &
-                                           H2O_ID /)
-
-  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G7(2) = (/ &
-                                           H2O_ID, &
-                                           O3_ID /)
-
-  INTEGER,  PARAMETER :: ABSORBER_ID_MAP_G8(4) = (/ &
-                                           H2O_ID, &
-                                            O3_ID, &
-                                           CO2_ID, &
-                                           NO2_ID /)
   ! Literal constants
   REAL(fp), PARAMETER :: ZERO      = 0.0_fp
   REAL(fp), PARAMETER :: ONE       = 1.0_fp
@@ -820,7 +777,7 @@ CONTAINS
       Tzp(k)  = Tzp_sum/Tzp_ref
 
       ! absorbers
-      DO j = 1, N_ABSORBERS_G(Group_ID)
+      DO j = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
         GAz_ref(j)   = GAz_ref(j) + Ref_absorber(k, j)
         GAz_sum(j)   = GAz_sum(j) + Absorber(k, j)
         GAz(k, j)    = GAz_sum(j) / GAz_ref(j)
@@ -963,11 +920,11 @@ CONTAINS
           CH4_ACH4zp = SECANG(k)*GAzp(k, ABS_CH4_IR)
 
           ! set number of predictors
-          Predictor%n_CP = N_PREDICTORS_G1
+          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE IF( Group_ID == GROUP_UV_NO2 )THEN
-          Predictor%n_CP = N_PREDICTORS_G8
+          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE
-          Predictor%n_CP = N_PREDICTORS_G2
+          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         END IF
 
        !#-------------------------------------------------------------------#
@@ -1173,9 +1130,9 @@ CONTAINS
 
        ! set number of predictors
         IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor%n_CP = N_PREDICTORS_G7
+          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE
-          Predictor%n_CP = N_PREDICTORS_G3
+          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         END IF
 
         !  ----------------------
@@ -1395,7 +1352,7 @@ CONTAINS
       Tzp_TL(k)  = Tzp_sum_TL/PAFV%Tzp_ref(k)
 
       ! absorbers
-      DO j = 1, N_ABSORBERS_G(Group_ID)
+      DO j = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
         GAz_sum_TL(j)   = GAz_sum_TL(j) + Absorber_TL(k, j)
         GAz_TL(k, j)    = GAz_sum_TL(j) / PAFV%GAz_ref(k,j)
         GAzp_sum_TL(j)  = GAzp_sum_TL(j) + PAFV%PDP(k)*Absorber_TL(k, j)
@@ -1574,11 +1531,11 @@ CONTAINS
           CH4_ACH4zp_TL = SECANG(k)*GAzp_TL(k, ABS_CH4_IR)
 
           ! set number of predictors
-          Predictor_TL%n_CP = N_PREDICTORS_G1
+          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE IF( Group_ID == GROUP_UV_NO2 )THEN
-          Predictor_TL%n_CP = N_PREDICTORS_G8
+          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE
-          Predictor_TL%n_CP = N_PREDICTORS_G2
+          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         END IF
 
        !#-------------------------------------------------------------------#
@@ -1810,9 +1767,9 @@ CONTAINS
 
        ! set number of predictors
         IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor_TL%n_CP = N_PREDICTORS_G7
+          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE
-          Predictor_TL%n_CP = N_PREDICTORS_G3
+          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         END IF
 
         !  ----------------------
@@ -2057,7 +2014,7 @@ CONTAINS
     Adjoint_Layer_Loop : DO k = n_Layers, 1, -1
 
       ! absorbers
-      DO j = N_ABSORBERS_G(Group_ID), 1, -1
+      DO j = GROUP_REGISTRY(Group_ID)%n_Absorbers, 1, -1
 
         GATzp_sum_AD(j) = GATzp_sum_AD(j) + GATzp_AD(k, j)/PAFV%GATzp_ref(k,j)
         GAzp_sum_AD(j) = GAzp_sum_AD(j) + GAzp_AD(k, j)/PAFV%GAzp_ref(k,j)
@@ -2750,9 +2707,9 @@ CONTAINS
 
        ! set number of predictors
         IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor_AD%n_CP = N_PREDICTORS_G7
+          Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         ELSE
-          Predictor_AD%n_CP = N_PREDICTORS_G3
+          Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
         END IF
 
         !  ----------------------
@@ -3515,24 +3472,40 @@ CONTAINS
   END SUBROUTINE ODPS_Compute_Predictor_ODAS_AD
 
 
+  ! Registry accessors. Out-of-range or Zeeman-reserved group queries return
+  ! 0 (dimensions) or ODPS_INVALID_ID (IDs); ODPS_Validate_Group is the
+  ! load-time gate that makes such queries unreachable in normal operation.
+
   PURE FUNCTION ODPS_Get_max_n_Predictors( Group_Index ) RESULT( max_n_Predictors )
     INTEGER, INTENT( IN ) :: Group_Index
     INTEGER :: max_n_Predictors
-    max_n_Predictors = MAX_N_PREDICTORS_G( Group_Index )
+    IF ( Group_Index >= 1 .AND. Group_Index <= N_G ) THEN
+      max_n_Predictors = GROUP_REGISTRY(Group_Index)%Max_n_Predictors
+    ELSE
+      max_n_Predictors = 0
+    END IF
   END FUNCTION ODPS_Get_max_n_Predictors
 
 
   PURE FUNCTION ODPS_Get_n_Components( Group_Index ) RESULT( n_Components )
     INTEGER, INTENT( IN ) :: Group_Index
     INTEGER :: n_Components
-    n_Components = N_COMPONENTS_G( Group_Index )
+    IF ( Group_Index >= 1 .AND. Group_Index <= N_G ) THEN
+      n_Components = GROUP_REGISTRY(Group_Index)%n_Components
+    ELSE
+      n_Components = 0
+    END IF
   END FUNCTION ODPS_Get_n_Components
 
 
   PURE FUNCTION ODPS_Get_n_Absorbers( Group_Index ) RESULT( n_Absorbers )
     INTEGER, INTENT( IN ) :: Group_Index
     INTEGER :: n_Absorbers
-    n_Absorbers = N_ABSORBERS_G( Group_Index )
+    IF ( Group_Index >= 1 .AND. Group_Index <= N_G ) THEN
+      n_Absorbers = GROUP_REGISTRY(Group_Index)%n_Absorbers
+    ELSE
+      n_Absorbers = 0
+    END IF
   END FUNCTION ODPS_Get_n_Absorbers
 
 
@@ -3540,20 +3513,14 @@ CONTAINS
     INTEGER, INTENT( IN ) :: Component_Index
     INTEGER, INTENT( IN ) :: Group_Index
     INTEGER :: Component_ID
-    SELECT CASE( Group_Index )
-      CASE( GROUP_1 )
-         Component_ID = COMPONENT_ID_MAP_G1(Component_Index)
-      CASE( GROUP_2 )
-         Component_ID = COMPONENT_ID_MAP_G2(Component_Index)
-      CASE( GROUP_3 )
-         Component_ID = COMPONENT_ID_MAP_G3(Component_Index)
-      CASE( GROUP_MW_O3 )
-         Component_ID = COMPONENT_ID_MAP_G7(Component_Index)
-      CASE( GROUP_UV_NO2 )
-         Component_ID = COMPONENT_ID_MAP_G8(Component_Index)
-      CASE DEFAULT
-         Component_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
-    END SELECT
+    IF ( Group_Index >= 1 .AND. Group_Index <= N_G ) THEN
+      IF ( Component_Index >= 1 .AND. &
+           Component_Index <= GROUP_REGISTRY(Group_Index)%n_Components ) THEN
+        Component_ID = GROUP_REGISTRY(Group_Index)%Component_ID(Component_Index)
+        RETURN
+      END IF
+    END IF
+    Component_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
   END FUNCTION ODPS_Get_Component_ID
 
 
@@ -3561,20 +3528,14 @@ CONTAINS
     INTEGER, INTENT( IN ) :: Absorber_Index
     INTEGER, INTENT( IN ) :: Group_Index
     INTEGER :: Absorber_ID
-    SELECT CASE( Group_Index )
-      CASE( GROUP_1 )
-          Absorber_ID = ABSORBER_ID_MAP_G1(Absorber_Index)
-      CASE( GROUP_2 )
-          Absorber_ID = ABSORBER_ID_MAP_G2(Absorber_Index)
-      CASE( GROUP_3 )
-          Absorber_ID = ABSORBER_ID_MAP_G3(Absorber_Index)
-      CASE( GROUP_MW_O3 )
-          Absorber_ID = ABSORBER_ID_MAP_G7(Absorber_Index)
-      CASE( GROUP_UV_NO2 )
-          Absorber_ID = ABSORBER_ID_MAP_G8(Absorber_Index)
-      CASE DEFAULT
-          Absorber_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
-      END SELECT
+    IF ( Group_Index >= 1 .AND. Group_Index <= N_G ) THEN
+      IF ( Absorber_Index >= 1 .AND. &
+           Absorber_Index <= GROUP_REGISTRY(Group_Index)%n_Absorbers ) THEN
+        Absorber_ID = GROUP_REGISTRY(Group_Index)%Absorber_ID(Absorber_Index)
+        RETURN
+      END IF
+    END IF
+    Absorber_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
   END FUNCTION ODPS_Get_Absorber_ID
 
 
@@ -3658,29 +3619,11 @@ CONTAINS
       RETURN
     END IF
 
-    ! Fetch the expected rosters for this group
-    SELECT CASE ( Group_Index )
-      CASE ( GROUP_1 )
-        nc = SIZE(COMPONENT_ID_MAP_G1); na = SIZE(ABSORBER_ID_MAP_G1)
-        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G1
-        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G1
-      CASE ( GROUP_2 )
-        nc = SIZE(COMPONENT_ID_MAP_G2); na = SIZE(ABSORBER_ID_MAP_G2)
-        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G2
-        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G2
-      CASE ( GROUP_3 )
-        nc = SIZE(COMPONENT_ID_MAP_G3); na = SIZE(ABSORBER_ID_MAP_G3)
-        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G3
-        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G3
-      CASE ( GROUP_MW_O3 )
-        nc = SIZE(COMPONENT_ID_MAP_G7); na = SIZE(ABSORBER_ID_MAP_G7)
-        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G7
-        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G7
-      CASE ( GROUP_UV_NO2 )
-        nc = SIZE(COMPONENT_ID_MAP_G8); na = SIZE(ABSORBER_ID_MAP_G8)
-        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G8
-        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G8
-    END SELECT
+    ! Fetch the expected rosters for this group from the registry
+    nc = GROUP_REGISTRY(Group_Index)%n_Components
+    na = GROUP_REGISTRY(Group_Index)%n_Absorbers
+    Expected_Component_ID(1:nc) = GROUP_REGISTRY(Group_Index)%Component_ID(1:nc)
+    Expected_Absorber_ID(1:na)  = GROUP_REGISTRY(Group_Index)%Absorber_ID(1:na)
 
     ! Roster sizes
     IF ( SIZE(Component_ID) /= nc .OR. SIZE(Absorber_ID) /= na ) THEN

--- a/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
+++ b/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
@@ -68,6 +68,8 @@ MODULE ODPS_Predictor
   PUBLIC :: ODPS_Get_Ozone_Component_ID
   PUBLIC :: ODPS_Get_SaveFWVFlag
   PUBLIC :: ODPS_Validate_Group
+  PUBLIC :: ODPS_Kernel_n_Predictors
+  PUBLIC :: ODPS_Max_n_Predictors_For
   ! Parameters
   PUBLIC :: TOT_ComID
   PUBLIC :: WLO_ComID
@@ -182,6 +184,9 @@ MODULE ODPS_Predictor
   INTEGER, PARAMETER ::    CO_ID =  5
   INTEGER, PARAMETER ::   CH4_ID =  6
   INTEGER, PARAMETER ::   NO2_ID = 10
+  ! All gases CRTM's ODPS kernels know how to consume
+  INTEGER, PARAMETER :: KNOWN_GAS_IDS(7) = &
+    (/ H2O_ID, CO2_ID, O3_ID, N2O_ID, CO_ID, CH4_ID, NO2_ID /)
 
   ! Absorber (Molecule) indexes for accessing absorber profile array
   INTEGER,  PARAMETER :: ABS_H2O_IR = 1
@@ -377,6 +382,8 @@ CONTAINS
     ! Compute predictor
     CALL ODPS_Compute_Predictor( &
       TC%Group_index         , &
+      TC%Component_ID        , &
+      TC%Absorber_ID         , &
       Temperature            , &
       Absorber               , &
       TC%Ref_Level_Pressure  , &
@@ -484,6 +491,8 @@ CONTAINS
     ! Compute predictor
     CALL ODPS_Compute_Predictor_TL( &
       TC%Group_index            , &
+      TC%Component_ID           , &
+      TC%Absorber_ID            , &
       Predictor%PAFV%Temperature, &
       Predictor%PAFV%Absorber   , &
       TC%Ref_Temperature        , &
@@ -599,6 +608,8 @@ CONTAINS
     ! ...The main ODPS predictor
     CALL ODPS_Compute_Predictor_AD( &
       TC%Group_index            , &
+      TC%Component_ID           , &
+      TC%Absorber_ID            , &
       Predictor%PAFV%Temperature, &
       Predictor%PAFV%Absorber   , &
       TC%Ref_Temperature        , &
@@ -695,6 +706,8 @@ CONTAINS
 
   SUBROUTINE ODPS_Compute_Predictor( &
     Group_ID,           &
+    Component_ID,       &
+    Absorber_ID,        &
     Temperature,        &
     Absorber,           &
     Ref_Level_Pressure, &
@@ -704,6 +717,8 @@ CONTAINS
     Predictor )
 
     INTEGER,                   INTENT(IN)     :: Group_ID
+    INTEGER,                   INTENT(IN)     :: Component_ID(:)
+    INTEGER,                   INTENT(IN)     :: Absorber_ID(:)
     REAL(fp),                  INTENT(IN)     :: Temperature(:)
     REAL(fp),                  INTENT(IN)     :: Absorber(:, :)
     REAL(fp),                  INTENT(IN)     :: Ref_Level_Pressure(0:)
@@ -788,7 +803,7 @@ CONTAINS
       Tzp(k)  = Tzp_sum/Tzp_ref
 
       ! absorbers
-      DO j = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
+      DO j = 1, SIZE(Absorber, DIM=2)
         GAz_ref(j)   = GAz_ref(j) + Ref_absorber(k, j)
         GAz_sum(j)   = GAz_sum(j) + Absorber(k, j)
         GAz(k, j)    = GAz_sum(j) / GAz_ref(j)
@@ -827,8 +842,13 @@ CONTAINS
     ! so kernel order does not affect results.
     !----------------------------------------------------------------
 
-    ! Number of predictors per component, from the registry roster
-    Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+    ! Number of predictors per component (kernel capability). has_trace
+    ! selects the group-1 style WLO/CO2 variants and must be set first.
+    has_trace = ANY( Component_ID == CO_ComID )   ! validation guarantees the trio
+    DO ic = 1, SIZE(Component_ID)
+      Predictor%n_CP(ic) = ODPS_Kernel_n_Predictors( &
+        GROUP_REGISTRY(Group_ID)%Basis, Component_ID(ic), has_trace )
+    END DO
 
     ! Resolve each gas's position in this group's absorber roster
     ! (0 when the gas is not carried; its kernel is then never dispatched)
@@ -839,7 +859,6 @@ CONTAINS
     ja_co  = Absorber_Position(CO_ID)
     ja_ch4 = Absorber_Position(CH4_ID)
     ja_no2 = Absorber_Position(NO2_ID)
-    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
 
     ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
     N2O_S       = HUGE(N2O_S)
@@ -868,22 +887,26 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
-        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
+        IF ( ja_h2o > 0 ) H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        IF ( ja_o3  > 0 ) O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+        IF ( ja_co2 > 0 ) CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
 
         ! Combinations of variables common to all predictor groups
         T2   = T*T
         DT2  = DT*ABS( DT )
 
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O_A = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
+        END IF
 
-        O3_A = SECANG(k)*O3
-        O3_R = SQRT( O3_A )
+        IF ( ja_o3 > 0 ) THEN
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
+        END IF
 
         IF( has_trace )THEN
           CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
@@ -904,9 +927,9 @@ CONTAINS
           CH4_ACH4zp = SECANG(k)*GAzp(k, ja_ch4)
         END IF
 
-        IR_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+        IR_Component_Loop : DO ic = 1, SIZE(Component_ID)
           np = Predictor%n_CP(ic)
-          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+          SELECT CASE ( Component_ID(ic) )
             CASE ( DRY_ComID_G1, DRY_ComID_G2 )
               CALL FWD_Kernel_DRY(k, ic)
             CASE ( WLO_ComID )
@@ -943,17 +966,18 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-
         ! Combinations of variables common to all predictor groups
         T2  = T*T
         DT2 = DT*ABS( DT )
 
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+          H2O_A = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
+        END IF
 
         IF ( ja_o3 > 0 ) THEN
           O3   = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
@@ -961,9 +985,9 @@ CONTAINS
           O3_R = SQRT( O3_A )
         END IF
 
-        MW_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+        MW_Component_Loop : DO ic = 1, SIZE(Component_ID)
           np = Predictor%n_CP(ic)
-          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+          SELECT CASE ( Component_ID(ic) )
             CASE ( EDRY_ComID )
               CALL FWD_Kernel_DRY(k, ic)
             CASE ( WET_ComID )
@@ -979,14 +1003,14 @@ CONTAINS
 
 CONTAINS
 
-    ! Position of a HITRAN absorber ID in this group's absorber roster
-    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
-      INTEGER, INTENT(IN) :: Absorber_ID
+    ! Position of a HITRAN absorber ID in the file's absorber roster
+    PURE FUNCTION Absorber_Position( Gas_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Gas_ID
       INTEGER :: Position
       INTEGER :: ja
       Position = 0
-      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
-        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+      DO ja = 1, SIZE(Absorber_ID)
+        IF ( Absorber_ID(ja) == Gas_ID ) THEN
           Position = ja
           RETURN
         END IF
@@ -1273,6 +1297,8 @@ CONTAINS
 
   SUBROUTINE ODPS_Compute_Predictor_TL( &
     Group_ID,           &
+    Component_ID,       &
+    Absorber_ID,        &
     Temperature,        &
     Absorber,           &
     Ref_Temperature,    &
@@ -1284,6 +1310,8 @@ CONTAINS
     Predictor_TL )
 
     INTEGER,                           INTENT(IN)     :: Group_ID
+    INTEGER,                           INTENT(IN)     :: Component_ID(:)
+    INTEGER,                           INTENT(IN)     :: Absorber_ID(:)
     REAL(fp),                          INTENT(IN)     :: Temperature(:)
     REAL(fp),                          INTENT(IN)     :: Absorber(:, :)
     REAL(fp),                          INTENT(IN)     :: Ref_Temperature(:)
@@ -1358,7 +1386,7 @@ CONTAINS
       Tzp_TL(k)  = Tzp_sum_TL/PAFV%Tzp_ref(k)
 
       ! absorbers
-      DO j = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
+      DO j = 1, SIZE(Absorber, DIM=2)
         GAz_sum_TL(j)   = GAz_sum_TL(j) + Absorber_TL(k, j)
         GAz_TL(k, j)    = GAz_sum_TL(j) / PAFV%GAz_ref(k,j)
         GAzp_sum_TL(j)  = GAzp_sum_TL(j) + PAFV%PDP(k)*Absorber_TL(k, j)
@@ -1376,8 +1404,13 @@ CONTAINS
     ! another, so kernel order does not affect results).
     !----------------------------------------------------------------
 
-    ! Number of predictors per component, from the registry roster
-    Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+    ! Number of predictors per component (kernel capability). has_trace
+    ! selects the group-1 style WLO/CO2 variants and must be set first.
+    has_trace = ANY( Component_ID == CO_ComID )   ! validation guarantees the trio
+    DO ic = 1, SIZE(Component_ID)
+      Predictor_TL%n_CP(ic) = ODPS_Kernel_n_Predictors( &
+        GROUP_REGISTRY(Group_ID)%Basis, Component_ID(ic), has_trace )
+    END DO
 
     ! Resolve each gas's position in this group's absorber roster
     ja_h2o = Absorber_Position(H2O_ID)
@@ -1387,7 +1420,6 @@ CONTAINS
     ja_co  = Absorber_Position(CO_ID)
     ja_ch4 = Absorber_Position(CH4_ID)
     ja_no2 = Absorber_Position(NO2_ID)
-    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
 
     ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
     N2O_TL        = HUGE(N2O_TL)
@@ -1430,13 +1462,18 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
-        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
-
-        H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-        O3_TL  = Absorber_TL(k,ja_o3)/Ref_absorber(k,ja_o3)
-        CO2_TL = Absorber_TL(k,ja_co2)/Ref_absorber(k,ja_co2)
+        IF ( ja_h2o > 0 ) THEN
+          H2O    = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+          H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        END IF
+        IF ( ja_o3 > 0 ) THEN
+          O3    = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+          O3_TL = Absorber_TL(k,ja_o3)/Ref_absorber(k,ja_o3)
+        END IF
+        IF ( ja_co2 > 0 ) THEN
+          CO2    = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
+          CO2_TL = Absorber_TL(k,ja_co2)/Ref_absorber(k,ja_co2)
+        END IF
 
         ! Combinations of variables common to all predictor groups
         T2   = T*T
@@ -1449,24 +1486,28 @@ CONTAINS
           DT2_TL = - TWO*DT*DT_TL
         ENDIF
 
-        H2O_A  = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O_A  = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
 
-        H2O_A_TL  = SECANG(k)*H2O_TL
-        H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
-        H2O_S_TL  = TWO * H2O_A * H2O_A_TL
-        H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
-        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
-                        H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
+          H2O_A_TL  = SECANG(k)*H2O_TL
+          H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
+          H2O_S_TL  = TWO * H2O_A * H2O_A_TL
+          H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
+          H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
+                          H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
+        END IF
 
-        O3_A = SECANG(k)*O3
-        O3_R = SQRT( O3_A )
+        IF ( ja_o3 > 0 ) THEN
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
 
-        O3_A_TL = SECANG(k)*O3_TL
-        O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
+          O3_A_TL = SECANG(k)*O3_TL
+          O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
+        END IF
 
         IF( has_trace )THEN
           CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
@@ -1505,9 +1546,9 @@ CONTAINS
           CH4_ACH4zp_TL = SECANG(k)*GAzp_TL(k, ja_ch4)
         END IF
 
-        IR_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+        IR_Component_Loop : DO ic = 1, SIZE(Component_ID)
           np = Predictor_TL%n_CP(ic)
-          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+          SELECT CASE ( Component_ID(ic) )
             CASE ( DRY_ComID_G1, DRY_ComID_G2 )
               CALL TL_Kernel_DRY(k, ic)
             CASE ( WLO_ComID )
@@ -1547,8 +1588,10 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-        H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+          H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        END IF
 
         ! Combinations of variables common to all predictor groups
         T2  = T*T
@@ -1561,18 +1604,20 @@ CONTAINS
           DT2_TL = - TWO*DT*DT_TL
         ENDIF
 
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O_A = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
 
-        H2O_A_TL  = SECANG(k)*H2O_TL
-        H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
-        H2O_S_TL  = TWO * H2O_A * H2O_A_TL
-        H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
-        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
-                        H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
+          H2O_A_TL  = SECANG(k)*H2O_TL
+          H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
+          H2O_S_TL  = TWO * H2O_A * H2O_A_TL
+          H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
+          H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
+                          H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
+        END IF
 
         IF ( ja_o3 > 0 ) THEN
           O3      = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
@@ -1583,9 +1628,9 @@ CONTAINS
           O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
         END IF
 
-        MW_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+        MW_Component_Loop : DO ic = 1, SIZE(Component_ID)
           np = Predictor_TL%n_CP(ic)
-          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+          SELECT CASE ( Component_ID(ic) )
             CASE ( EDRY_ComID )
               CALL TL_Kernel_DRY(k, ic)
               Predictor_TL%X(:, 8:, ic) = ZERO
@@ -1604,14 +1649,14 @@ CONTAINS
 
 CONTAINS
 
-    ! Position of a HITRAN absorber ID in this group's absorber roster
-    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
-      INTEGER, INTENT(IN) :: Absorber_ID
+    ! Position of a HITRAN absorber ID in the file's absorber roster
+    PURE FUNCTION Absorber_Position( Gas_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Gas_ID
       INTEGER :: Position
       INTEGER :: ja
       Position = 0
-      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
-        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+      DO ja = 1, SIZE(Absorber_ID)
+        IF ( Absorber_ID(ja) == Gas_ID ) THEN
           Position = ja
           RETURN
         END IF
@@ -1913,6 +1958,8 @@ CONTAINS
 
   SUBROUTINE ODPS_Compute_Predictor_AD( &
     Group_ID,           &
+    Component_ID,       &
+    Absorber_ID,        &
     Temperature,        &
     Absorber,           &
     Ref_Temperature,    &
@@ -1924,6 +1971,8 @@ CONTAINS
     Absorber_AD )
 
     INTEGER,                           INTENT(IN)     :: Group_ID
+    INTEGER,                           INTENT(IN)     :: Component_ID(:)
+    INTEGER,                           INTENT(IN)     :: Absorber_ID(:)
     REAL(fp),                          INTENT(IN)     :: Temperature(:)
     REAL(fp),                          INTENT(IN)     :: Absorber(:, :)
     REAL(fp),                          INTENT(IN)     :: Ref_Temperature(:)
@@ -1952,6 +2001,7 @@ CONTAINS
     REAL(fp) ::    GATzp_sum_AD(SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_AD(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
     ! Kernel dispatch bookkeeping and shared per-layer variables
+    INTEGER  :: ic
     INTEGER  :: ic_dry, ic_wlo, ic_wco, ic_ozo, ic_co2
     INTEGER  :: ic_n2o, ic_co, ic_ch4, ic_no2, ic_wet
     INTEGER  :: ja_h2o, ja_o3, ja_co2, ja_n2o, ja_co, ja_ch4, ja_no2
@@ -2014,7 +2064,7 @@ CONTAINS
     ja_co  = Absorber_Position(CO_ID)
     ja_ch4 = Absorber_Position(CH4_ID)
     ja_no2 = Absorber_Position(NO2_ID)
-    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
+    has_trace = ANY( Component_ID == CO_ComID )   ! validation guarantees the trio
 
     ! Resolve each component's position in this group's roster
     ic_dry = Component_Position(DRY_ComID_G1)
@@ -2074,22 +2124,26 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
-        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
+        IF ( ja_h2o > 0 ) H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        IF ( ja_o3  > 0 ) O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+        IF ( ja_co2 > 0 ) CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
 
         ! Combinations of variables common to all predictor groups
         T2   = T*T
         DT2  = DT*ABS( DT )
 
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O_A = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        END IF
 
-        O3_A = SECANG(k)*O3
-        O3_R = SQRT( O3_A )
+        IF ( ja_o3 > 0 ) THEN
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
+        END IF
 
         IF( has_trace )THEN
           CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
@@ -2112,12 +2166,13 @@ CONTAINS
         END IF
 
         ! Adjoint kernels in the heritage monolith order (see note above)
-        CALL AD_Kernel_DRY(k, ic_dry)
-        CALL AD_Kernel_WCO(k, ic_wco)
+        IF ( ic_dry > 0 ) CALL AD_Kernel_DRY(k, ic_dry)
+        IF ( ic_wco > 0 ) CALL AD_Kernel_WCO(k, ic_wco)
         IF ( ic_no2 > 0 ) CALL AD_Kernel_NO2(k, ic_no2)
-        CALL AD_Kernel_OZO_IR(k, ic_ozo)
-        CALL AD_Kernel_CO2(k, ic_co2)
-        CALL AD_Kernel_WLO(k, ic_wlo, GROUP_REGISTRY(Group_ID)%n_Predictors(ic_wlo))
+        IF ( ic_ozo > 0 ) CALL AD_Kernel_OZO_IR(k, ic_ozo)
+        IF ( ic_co2 > 0 ) CALL AD_Kernel_CO2(k, ic_co2)
+        IF ( ic_wlo > 0 ) CALL AD_Kernel_WLO(k, ic_wlo, ODPS_Kernel_n_Predictors( &
+          GROUP_REGISTRY(Group_ID)%Basis, WLO_ComID, has_trace ))
         IF ( has_trace ) THEN
           CALL AD_Kernel_CO(k, ic_co)
           CALL AD_Kernel_CH4(k, ic_ch4)
@@ -2164,24 +2219,28 @@ CONTAINS
 
         ! Combinations of variables common to all predictor groups
 
-        O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
-        O3_AD = O3_AD + O3_A_AD * SECANG(k)
-        O3_A_AD = ZERO
-        O3_R_AD = ZERO
+        IF ( ja_o3 > 0 ) THEN
+          O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
+          O3_AD = O3_AD + O3_A_AD * SECANG(k)
+          O3_A_AD = ZERO
+          O3_R_AD = ZERO
+        END IF
 
-        GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                    &
-                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
-        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
-        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
-                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
-        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
-               + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                  &
+                                  - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
+          H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
+          H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                               &
+                   + H2O_R_AD * POINT_5 / SQRT(H2O_A)
+          H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                     &
+                 + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
 
-        H2O_A_AD      = ZERO
-        H2O_R_AD      = ZERO
-        H2O_S_AD      = ZERO
-        H2O_R4_AD     = ZERO
-        H2OdH2OTzp_AD = ZERO
+          H2O_A_AD      = ZERO
+          H2O_R_AD      = ZERO
+          H2O_S_AD      = ZERO
+          H2O_R4_AD     = ZERO
+          H2OdH2OTzp_AD = ZERO
+        END IF
 
         IF( DT > ZERO) THEN
           DT_AD = DT_AD + DT2_AD*TWO*DT
@@ -2195,12 +2254,18 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        Absorber_AD(k,ja_co2) = Absorber_AD(k,ja_co2)            &
-                                  + CO2_AD / Ref_absorber(k,ja_co2)
-        Absorber_AD(k,ja_o3)  = Absorber_AD(k,ja_o3)             &
-                                  + O3_AD / Ref_absorber(k,ja_o3)
-        Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
-                                  + H2O_AD / Ref_Absorber(k, ja_h2o)
+        IF ( ja_co2 > 0 ) THEN
+          Absorber_AD(k,ja_co2) = Absorber_AD(k,ja_co2)            &
+                                    + CO2_AD / Ref_absorber(k,ja_co2)
+        END IF
+        IF ( ja_o3 > 0 ) THEN
+          Absorber_AD(k,ja_o3)  = Absorber_AD(k,ja_o3)             &
+                                    + O3_AD / Ref_absorber(k,ja_o3)
+        END IF
+        IF ( ja_h2o > 0 ) THEN
+          Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
+                                    + H2O_AD / Ref_Absorber(k, ja_h2o)
+        END IF
         H2O_AD = ZERO
         O3_AD  = ZERO
         CO2_AD = ZERO
@@ -2218,7 +2283,10 @@ CONTAINS
     ELSE Basis_Select   ! BASIS_MW
 
       ! set number of predictors
-      Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+      DO ic = 1, SIZE(Component_ID)
+        Predictor_AD%n_CP(ic) = ODPS_Kernel_n_Predictors( &
+          GROUP_REGISTRY(Group_ID)%Basis, Component_ID(ic), has_trace )
+      END DO
 
       MW_Layer_Loop : DO k = n_Layers, 1, -1
 
@@ -2231,17 +2299,18 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
-
         ! Combinations of variables common to all predictor groups
         T2  = T*T
         DT2 = DT*ABS( DT )
 
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+          H2O_A = SECANG(k)*H2O
+          H2O_R  = SQRT( H2O_A )
+          H2O_S  = H2O_A*H2O_A
+          H2O_R4 = SQRT( H2O_R )
+          H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+        END IF
 
         IF ( ja_o3 > 0 ) THEN
           O3   = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
@@ -2250,8 +2319,8 @@ CONTAINS
         END IF
 
         ! Adjoint kernels in the heritage monolith order (see note above)
-        CALL AD_Kernel_DRY(k, ic_dry)
-        CALL AD_Kernel_WET_MW(k, ic_wet)
+        IF ( ic_dry > 0 ) CALL AD_Kernel_DRY(k, ic_dry)
+        IF ( ic_wet > 0 ) CALL AD_Kernel_WET_MW(k, ic_wet)
         IF ( ic_ozo > 0 ) CALL AD_Kernel_OZO_MW(k, ic_ozo)
 
         !-------------------------------------------
@@ -2260,18 +2329,20 @@ CONTAINS
 
         ! Combinations of variables common to all predictor groups
 
-        GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                    &
-                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
-        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
-        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
-                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
-        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
-               + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
-        H2O_A_AD      = ZERO
-        H2O_R_AD      = ZERO
-        H2O_S_AD      = ZERO
-        H2O_R4_AD     = ZERO
-        H2OdH2OTzp_AD = ZERO
+        IF ( ja_h2o > 0 ) THEN
+          GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                  &
+                                  - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
+          H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
+          H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                               &
+                   + H2O_R_AD * POINT_5 / SQRT(H2O_A)
+          H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                     &
+                 + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
+          H2O_A_AD      = ZERO
+          H2O_R_AD      = ZERO
+          H2O_S_AD      = ZERO
+          H2O_R4_AD     = ZERO
+          H2OdH2OTzp_AD = ZERO
+        END IF
 
         IF( DT > ZERO) THEN
           DT_AD = DT_AD + DT2_AD*TWO*DT
@@ -2282,8 +2353,10 @@ CONTAINS
         T2_AD   = ZERO
         DT2_AD  = ZERO
 
-        Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
-                                  + H2O_AD / Ref_Absorber(k, ja_h2o)
+        IF ( ja_h2o > 0 ) THEN
+          Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
+                                    + H2O_AD / Ref_Absorber(k, ja_h2o)
+        END IF
         H2O_AD = ZERO
 
         !------------------------------------------
@@ -2301,7 +2374,7 @@ CONTAINS
     Adjoint_Layer_Loop : DO k = n_Layers, 1, -1
 
       ! absorbers
-      DO j = GROUP_REGISTRY(Group_ID)%n_Absorbers, 1, -1
+      DO j = SIZE(Absorber, DIM=2), 1, -1
 
         GATzp_sum_AD(j) = GATzp_sum_AD(j) + GATzp_AD(k, j)/PAFV%GATzp_ref(k,j)
         GAzp_sum_AD(j) = GAzp_sum_AD(j) + GAzp_AD(k, j)/PAFV%GAzp_ref(k,j)
@@ -2328,28 +2401,28 @@ CONTAINS
 
 CONTAINS
 
-    ! Position of a HITRAN absorber ID in this group's absorber roster
-    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
-      INTEGER, INTENT(IN) :: Absorber_ID
+    ! Position of a HITRAN absorber ID in the file's absorber roster
+    PURE FUNCTION Absorber_Position( Gas_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Gas_ID
       INTEGER :: Position
       INTEGER :: ja
       Position = 0
-      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
-        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+      DO ja = 1, SIZE(Absorber_ID)
+        IF ( Absorber_ID(ja) == Gas_ID ) THEN
           Position = ja
           RETURN
         END IF
       END DO
     END FUNCTION Absorber_Position
 
-    ! Position of a component ID in this group's component roster
-    PURE FUNCTION Component_Position( Component_ID ) RESULT( Position )
-      INTEGER, INTENT(IN) :: Component_ID
+    ! Position of a component ID in the file's component roster
+    PURE FUNCTION Component_Position( Com_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Com_ID
       INTEGER :: Position
       INTEGER :: jc
       Position = 0
-      DO jc = 1, GROUP_REGISTRY(Group_ID)%n_Components
-        IF ( GROUP_REGISTRY(Group_ID)%Component_ID(jc) == Component_ID ) THEN
+      DO jc = 1, SIZE(Component_ID)
+        IF ( Component_ID(jc) == Com_ID ) THEN
           Position = jc
           RETURN
         END IF
@@ -3581,9 +3654,8 @@ CONTAINS
     CHARACTER(*), INTENT(OUT) :: Message
     LOGICAL :: Is_Valid
     ! Local variables
-    INTEGER :: Expected_Component_ID(MAX_COMPONENTS_ANY_GROUP)
-    INTEGER :: Expected_Absorber_ID(MAX_ABSORBERS_ANY_GROUP)
-    INTEGER :: nc, na
+    INTEGER :: nc, na, i, n_trace
+    LOGICAL :: Has_Trace
 
     Is_Valid = .FALSE.
     Message  = ''
@@ -3606,36 +3678,188 @@ CONTAINS
       RETURN
     END IF
 
-    ! Fetch the expected rosters for this group from the registry
-    nc = GROUP_REGISTRY(Group_Index)%n_Components
-    na = GROUP_REGISTRY(Group_Index)%n_Absorbers
-    Expected_Component_ID(1:nc) = GROUP_REGISTRY(Group_Index)%Component_ID(1:nc)
-    Expected_Absorber_ID(1:na)  = GROUP_REGISTRY(Group_Index)%Absorber_ID(1:na)
-
-    ! Roster sizes
-    IF ( SIZE(Component_ID) /= nc .OR. SIZE(Absorber_ID) /= na ) THEN
-      WRITE( Message, '("Group ",i0," expects ",i0," components and ",i0, &
-        &" absorbers; file has ",i0," and ",i0,".")' ) &
-        Group_Index, nc, na, SIZE(Component_ID), SIZE(Absorber_ID)
+    ! Kernel-capability validation. A file's roster is valid when every
+    ! component ID maps to a compiled predictor kernel for this group's
+    ! basis and every gas those kernels consume is present in the file's
+    ! absorber roster. Order and subsetting are free: the compute path
+    ! dispatches by the file's own roster. Unknown component IDs (for
+    ! example raw molecule-set 13/14 from externally trained files) are
+    ! rejected: a kernel is a trained CRTM predictor formulation, not
+    ! just a gas label.
+    nc = SIZE(Component_ID)
+    na = SIZE(Absorber_ID)
+    IF ( nc < 1 .OR. na < 1 ) THEN
+      WRITE( Message, '("Empty roster: ",i0," components, ",i0, &
+        &" absorbers.")' ) nc, na
       RETURN
     END IF
 
-    ! Roster content and order (the predictor code is positional)
-    IF ( ANY( Component_ID /= Expected_Component_ID(1:nc) ) ) THEN
-      WRITE( Message, '("Group ",i0," Component_ID mismatch: expected ", &
-        &8(i0,:,", "))' ) Group_Index, Expected_Component_ID(1:nc)
-      Message = TRIM(Message)//'; file order must match exactly.'
+    ! Duplicates
+    DO i = 1, nc
+      IF ( ANY( Component_ID(1:i-1) == Component_ID(i) ) ) THEN
+        WRITE( Message, '("Duplicate Component_ID ",i0,".")' ) Component_ID(i)
+        RETURN
+      END IF
+    END DO
+    DO i = 1, na
+      IF ( ANY( Absorber_ID(1:i-1) == Absorber_ID(i) ) ) THEN
+        WRITE( Message, '("Duplicate Absorber_ID ",i0,".")' ) Absorber_ID(i)
+        RETURN
+      END IF
+    END DO
+
+    ! Known absorbers only
+    DO i = 1, na
+      IF ( .NOT. ANY( KNOWN_GAS_IDS == Absorber_ID(i) ) ) THEN
+        WRITE( Message, '("Absorber_ID ",i0," is not a gas CRTM knows ", &
+          &"(known HITRAN IDs: 1, 2, 3, 4, 5, 6, 10).")' ) Absorber_ID(i)
+        RETURN
+      END IF
+    END DO
+
+    ! The group-1 trace components travel together, and their extension
+    ! predictors live in the WLO and CO2 kernels
+    n_trace = COUNT( (/ ANY(Component_ID == CO_ComID),  &
+                        ANY(Component_ID == CH4_ComID), &
+                        ANY(Component_ID == N2O_ComID) /) )
+    Has_Trace = ( n_trace == 3 )
+    IF ( n_trace > 0 .AND. .NOT. Has_Trace ) THEN
+      Message = 'The trace components (CO 119, CH4 118, N2O 120) must '// &
+                'appear together or not at all.'
       RETURN
     END IF
-    IF ( ANY( Absorber_ID /= Expected_Absorber_ID(1:na) ) ) THEN
-      WRITE( Message, '("Group ",i0," Absorber_ID mismatch: expected ", &
-        &6(i0,:,", "))' ) Group_Index, Expected_Absorber_ID(1:na)
-      Message = TRIM(Message)//'; file order must match exactly.'
+    IF ( Has_Trace .AND. .NOT. ( ANY(Component_ID == WLO_ComID) .AND. &
+                                 ANY(Component_ID == CO2_ComID) ) ) THEN
+      Message = 'A roster with the trace components also requires the '// &
+                'WLO (101) and CO2 (121) components (their kernels carry '// &
+                'the trace cross-term predictors).'
       RETURN
     END IF
+
+    ! Every component must have a kernel for this basis, and every gas its
+    ! kernel consumes must be in the absorber roster
+    DO i = 1, nc
+      IF ( ODPS_Kernel_n_Predictors( GROUP_REGISTRY(Group_Index)%Basis, &
+                                     Component_ID(i), Has_Trace ) == 0 ) THEN
+        WRITE( Message, '("Component_ID ",i0," has no predictor kernel for ", &
+          &"the ",a," basis (supported IR: 7, 20, 101, 15, 114, 121, 120, ", &
+          &"119, 118, 122; MW: 113, 12, 114).")' ) Component_ID(i), &
+          TRIM(Basis_Name(GROUP_REGISTRY(Group_Index)%Basis))
+        RETURN
+      END IF
+      IF ( .NOT. Required_Gases_Present( Component_ID(i), Absorber_ID ) ) THEN
+        WRITE( Message, '("Component_ID ",i0," requires a gas that is not ", &
+          &"in the file''s absorber roster.")' ) Component_ID(i)
+        RETURN
+      END IF
+    END DO
 
     Is_Valid = .TRUE.
+
+  CONTAINS
+
+    PURE FUNCTION Basis_Name( Basis ) RESULT( Name )
+      INTEGER, INTENT(IN) :: Basis
+      CHARACTER(8) :: Name
+      SELECT CASE ( Basis )
+        CASE ( BASIS_IR ); Name = 'IR/UV'
+        CASE ( BASIS_MW ); Name = 'MW'
+        CASE DEFAULT;      Name = 'RESERVED'
+      END SELECT
+    END FUNCTION Basis_Name
+
+    PURE FUNCTION Required_Gases_Present( Com_ID, Gases ) RESULT( Present )
+      INTEGER, INTENT(IN) :: Com_ID
+      INTEGER, INTENT(IN) :: Gases(:)
+      LOGICAL :: Present
+      SELECT CASE ( Com_ID )
+        CASE ( WLO_ComID )
+          Present = ANY(Gases == H2O_ID) .AND. ANY(Gases == CO2_ID)
+        CASE ( WCO_ComID, WET_ComID )
+          Present = ANY(Gases == H2O_ID)
+        CASE ( OZO_ComID )
+          Present = ANY(Gases == O3_ID)
+        CASE ( CO2_ComID )
+          Present = ANY(Gases == CO2_ID)
+        CASE ( N2O_ComID )
+          Present = ANY(Gases == N2O_ID) .AND. ANY(Gases == CH4_ID) &
+                    .AND. ANY(Gases == CO_ID)
+        CASE ( CO_ComID )
+          Present = ANY(Gases == CO_ID)
+        CASE ( CH4_ComID )
+          Present = ANY(Gases == CH4_ID)
+        CASE ( NO2_ComID )
+          Present = ANY(Gases == NO2_ID)
+        CASE DEFAULT   ! dry components consume no variable gas
+          Present = .TRUE.
+      END SELECT
+    END FUNCTION Required_Gases_Present
+
   END FUNCTION ODPS_Validate_Group
+
+
+!------------------------------------------------------------------------------
+! Kernel capability: the number of predictors CRTM's compiled kernel
+! computes for a component ID under a given basis (0 = no kernel; the
+! component is unsupported). Has_Trace selects the group-1 style variants
+! (WLO 18 vs 15, CO2 11 vs 10) that add trace-gas cross terms.
+!------------------------------------------------------------------------------
+  PURE FUNCTION ODPS_Kernel_n_Predictors( Basis, Component_ID, Has_Trace ) &
+    RESULT( n_Predictors )
+    INTEGER, INTENT(IN) :: Basis
+    INTEGER, INTENT(IN) :: Component_ID
+    LOGICAL, INTENT(IN) :: Has_Trace
+    INTEGER :: n_Predictors
+    n_Predictors = 0
+    SELECT CASE ( Basis )
+      CASE ( BASIS_IR )
+        SELECT CASE ( Component_ID )
+          CASE ( DRY_ComID_G1, DRY_ComID_G2 ); n_Predictors = 7
+          CASE ( WLO_ComID );  n_Predictors = MERGE( 18, 15, Has_Trace )
+          CASE ( WCO_ComID );  n_Predictors = 7
+          CASE ( OZO_ComID );  n_Predictors = 11
+          CASE ( CO2_ComID );  n_Predictors = MERGE( 11, 10, Has_Trace )
+          CASE ( N2O_ComID );  n_Predictors = 14
+          CASE ( CO_ComID );   n_Predictors = 10
+          CASE ( CH4_ComID );  n_Predictors = 11
+          CASE ( NO2_ComID );  n_Predictors = 3
+        END SELECT
+      CASE ( BASIS_MW )
+        SELECT CASE ( Component_ID )
+          CASE ( EDRY_ComID ); n_Predictors = 7
+          CASE ( WET_ComID );  n_Predictors = 14
+          CASE ( OZO_ComID );  n_Predictors = 11
+        END SELECT
+    END SELECT
+  END FUNCTION ODPS_Kernel_n_Predictors
+
+
+!------------------------------------------------------------------------------
+! The predictor-array capacity a file's roster needs: the maximum kernel
+! predictor count over its components. Returns 0 for an unsupported group
+! or any unsupported component (the load-time validation reports the
+! specific reason).
+!------------------------------------------------------------------------------
+  PURE FUNCTION ODPS_Max_n_Predictors_For( Group_Index, Component_ID ) &
+    RESULT( Max_n_Predictors )
+    INTEGER, INTENT(IN) :: Group_Index
+    INTEGER, INTENT(IN) :: Component_ID(:)
+    INTEGER :: Max_n_Predictors
+    INTEGER :: i, np
+    LOGICAL :: Has_Trace
+    Max_n_Predictors = 0
+    IF ( Group_Index < 1 .OR. Group_Index > N_G ) RETURN
+    Has_Trace = ANY( Component_ID == CO_ComID )
+    DO i = 1, SIZE(Component_ID)
+      np = ODPS_Kernel_n_Predictors( GROUP_REGISTRY(Group_Index)%Basis, &
+                                     Component_ID(i), Has_Trace )
+      IF ( np == 0 ) THEN
+        Max_n_Predictors = 0
+        RETURN
+      END IF
+      Max_n_Predictors = MAX( Max_n_Predictors, np )
+    END DO
+  END FUNCTION ODPS_Max_n_Predictors_For
 
 
   ! This function gets a flag (true or false) indicating the

--- a/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
+++ b/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
@@ -735,6 +735,17 @@ CONTAINS
     REAL(fp) ::    GATzp_ref(SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_sum (SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
+    ! Kernel dispatch bookkeeping and shared per-layer variables
+    INTEGER  :: ic, np
+    INTEGER  :: ja_h2o, ja_o3, ja_co2, ja_n2o, ja_co, ja_ch4, ja_no2
+    LOGICAL  :: has_trace
+    REAL(fp) :: DT, T, T2, DT2
+    REAL(fp) :: H2O, H2O_A, H2O_R, H2O_S, H2O_R4, H2OdH2OTzp
+    REAL(fp) :: CO2, O3, O3_A, O3_R
+    REAL(fp) :: NO2, NO2_A
+    REAL(fp) :: CO, CO_A, CO_R, CO_S, CO_ACOdCOzp
+    REAL(fp) :: N2O, N2O_A, N2O_R, N2O_S
+    REAL(fp) :: CH4, CH4_A, CH4_R, CH4_ACH4zp
 
     n_Layers = Predictor%n_Layers
 
@@ -810,70 +821,43 @@ CONTAINS
     END DO Layer_Loop
 
     !----------------------------------------------------------------
-    ! Call the group specific routine for remaining computation; all
-    ! variables defined above are passed to the called routine
+    ! Per-component predictor computation. The registry supplies the
+    ! roster; kernels are dispatched per component ID within the basis
+    ! layer loop. Forward X assignments are independent of one another,
+    ! so kernel order does not affect results.
     !----------------------------------------------------------------
 
-    SELECT CASE( Group_ID )
-      CASE( GROUP_1, GROUP_2, GROUP_UV_NO2 )
-         CALL ODPS_Compute_Predictor_IR()
-      CASE( GROUP_3, GROUP_MW_O3 )
-         CALL ODPS_Compute_Predictor_MW()
-    END SELECT
+    ! Number of predictors per component, from the registry roster
+    Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
 
-CONTAINS
+    ! Resolve each gas's position in this group's absorber roster
+    ! (0 when the gas is not carried; its kernel is then never dispatched)
+    ja_h2o = Absorber_Position(H2O_ID)
+    ja_o3  = Absorber_Position(O3_ID)
+    ja_co2 = Absorber_Position(CO2_ID)
+    ja_n2o = Absorber_Position(N2O_ID)
+    ja_co  = Absorber_Position(CO_ID)
+    ja_ch4 = Absorber_Position(CH4_ID)
+    ja_no2 = Absorber_Position(NO2_ID)
+    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
 
-    SUBROUTINE ODPS_Compute_Predictor_IR()
+    ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
+    N2O_S       = HUGE(N2O_S)
+    N2O_R       = HUGE(N2O_R)
+    N2O_A       = HUGE(N2O_A)
+    N2O         = HUGE(N2O)
+    CO_S        = HUGE(CO_S)
+    CO_R        = HUGE(CO_R)
+    CO_ACOdCOzp = HUGE(CO_ACOdCOzp)
+    CO_A        = HUGE(CO_A)
+    CH4_R       = HUGE(CH4_R)
+    CH4_ACH4zp  = HUGE(CH4_ACH4zp)
+    CH4_A       = HUGE(CH4_A)
+    CH4         = HUGE(CH4)
 
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER    ::    k ! n_Layers, n_Levels
-      REAL(fp) ::    DT
-      REAL(fp) ::    T
-      REAL(fp) ::    T2
-      REAL(fp) ::    DT2
-      REAL(fp) ::    H2O
-      REAL(fp) ::    H2O_A
-      REAL(fp) ::    H2O_R
-      REAL(fp) ::    H2O_S
-      REAL(fp) ::    H2O_R4
-      REAL(fp) ::    H2OdH2OTzp
-      REAL(fp) ::    CO2
-      REAL(fp) ::    O3
-      REAL(fp) ::    O3_A
-      REAL(fp) ::    O3_R
-      REAL(fp) ::    NO2
-      REAL(fp) ::    NO2_A
-      REAL(fp) ::    CO
-      REAL(fp) ::    CO_A
-      REAL(fp) ::    CO_R
-      REAL(fp) ::    CO_S
-      REAL(fp) ::    CO_ACOdCOzp
-      REAL(fp) ::    N2O
-      REAL(fp) ::    N2O_A
-      REAL(fp) ::    N2O_R
-      REAL(fp) ::    N2O_S
-      REAL(fp) ::    CH4
-      REAL(fp) ::    CH4_A
-      REAL(fp) ::    CH4_R
-      REAL(fp) ::    CH4_ACH4zp
+    Basis_Select: IF ( GROUP_REGISTRY(Group_ID)%Basis == BASIS_IR ) THEN
 
-      ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
-      N2O_S       = HUGE(N2O_S)
-      N2O_R       = HUGE(N2O_R)
-      N2O_A       = HUGE(N2O_A)
-      N2O         = HUGE(N2O)
-      CO_S        = HUGE(CO_S)
-      CO_R        = HUGE(CO_R)
-      CO_ACOdCOzp = HUGE(CO_ACOdCOzp)
-      CO_A        = HUGE(CO_A)
-      CH4_R       = HUGE(CH4_R)
-      CH4_ACH4zp  = HUGE(CH4_ACH4zp)
-      CH4_A       = HUGE(CH4_A)
-      CH4         = HUGE(CH4)
-
-      Layer_Loop : DO k = 1, n_Layers
+      IR_Layer_Loop : DO k = 1, n_Layers
 
         !------------------------------------------
         !  Relative Temperature
@@ -884,9 +868,9 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_IR)/Ref_Absorber(k, ABS_H2O_IR)
-        O3  = Absorber(k,ABS_O3_IR)/Ref_absorber(k,ABS_O3_IR)
-        CO2 = Absorber(k,ABS_CO2_IR)/Ref_absorber(k,ABS_CO2_IR)
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
 
         ! Combinations of variables common to all predictor groups
         T2   = T*T
@@ -896,15 +880,15 @@ CONTAINS
         H2O_R  = SQRT( H2O_A )
         H2O_S  = H2O_A*H2O_A
         H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/GATzp(k, ABS_H2O_IR)
+        H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
 
         O3_A = SECANG(k)*O3
         O3_R = SQRT( O3_A )
 
-        IF( Group_ID == GROUP_1 )THEN
-          CO  = Absorber(k,ABS_CO_IR)/Ref_absorber(k, ABS_CO_IR)
-          N2O = Absorber(k,ABS_N2O_IR)/Ref_absorber(k,ABS_N2O_IR)
-          CH4 = Absorber(k,ABS_CH4_IR)/Ref_absorber(k,ABS_CH4_IR)
+        IF( has_trace )THEN
+          CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
+          N2O = Absorber(k,ja_n2o)/Ref_absorber(k,ja_n2o)
+          CH4 = Absorber(k,ja_ch4)/Ref_absorber(k,ja_ch4)
 
           N2O_A = SECANG(k)*N2O
           N2O_R = SQRT( N2O_A )
@@ -913,195 +897,42 @@ CONTAINS
           CO_A = SECANG(k)*CO
           CO_R = SQRT( CO_A )
           CO_S = CO_A*CO_A
-          CO_ACOdCOzp = CO_A*CO/GAzp(k, ABS_CO_IR)
+          CO_ACOdCOzp = CO_A*CO/GAzp(k, ja_co)
 
           CH4_A = SECANG(k)*CH4
           CH4_R = SQRT(CH4_A)
-          CH4_ACH4zp = SECANG(k)*GAzp(k, ABS_CH4_IR)
-
-          ! set number of predictors
-          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE IF( Group_ID == GROUP_UV_NO2 )THEN
-          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE
-          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+          CH4_ACH4zp = SECANG(k)*GAzp(k, ja_ch4)
         END IF
 
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
+        IR_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+          np = Predictor%n_CP(ic)
+          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+            CASE ( DRY_ComID_G1, DRY_ComID_G2 )
+              CALL FWD_Kernel_DRY(k, ic)
+            CASE ( WLO_ComID )
+              CALL FWD_Kernel_WLO(k, ic, np)
+            CASE ( WCO_ComID )
+              CALL FWD_Kernel_WCO(k, ic)
+            CASE ( OZO_ComID )
+              CALL FWD_Kernel_OZO(k, ic)
+            CASE ( CO2_ComID )
+              CALL FWD_Kernel_CO2(k, ic, np)
+            CASE ( N2O_ComID )
+              CALL FWD_Kernel_N2O(k, ic)
+            CASE ( CO_ComID )
+              CALL FWD_Kernel_CO(k, ic)
+            CASE ( CH4_ComID )
+              CALL FWD_Kernel_CH4(k, ic)
+            CASE ( NO2_ComID )
+              CALL FWD_Kernel_NO2(k, ic)
+          END SELECT
+        END DO IR_Component_Loop
 
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-        Predictor%X(k, 1, COMP_DRY_IR)  = SECANG(k)
-        Predictor%X(k, 2, COMP_DRY_IR)  = SECANG(k) * T
-        Predictor%X(k, 3, COMP_DRY_IR)  = SECANG(k) * T2
-        Predictor%X(k, 4, COMP_DRY_IR)  = T
-        Predictor%X(k, 5, COMP_DRY_IR)  = SECANG(k) * SECANG(k)
-        Predictor%X(k, 6, COMP_DRY_IR)  = T2
-        Predictor%X(k, 7, COMP_DRY_IR)  = Tz(k)
+      END DO IR_Layer_Loop
 
-       !  --------------------------
-       !  Water vapor continuum predictors
-       !  --------------------------
-        Predictor%X(k, 1, COMP_WCO_IR) = H2O_A/T
-        Predictor%X(k, 2, COMP_WCO_IR) = H2O_A/T * H2O
-        Predictor%X(k, 3, COMP_WCO_IR) = H2O_A/T2 * H2O/T2
-        Predictor%X(k, 4, COMP_WCO_IR) = H2O_A/T2
-        Predictor%X(k, 5, COMP_WCO_IR) = H2O_A/T2 * H2O
-        Predictor%X(k, 6, COMP_WCO_IR) = H2O_A/T2**2
-        Predictor%X(k, 7, COMP_WCO_IR) = H2O_A
+    ELSE Basis_Select   ! BASIS_MW
 
-        !  -----------------------
-        !  Ozone predictors
-        !  -----------------------
-        Predictor%X(k, 1, COMP_OZO_IR)  = O3_A
-        Predictor%X(k, 2, COMP_OZO_IR)  = O3_A*DT
-        Predictor%X(k, 3, COMP_OZO_IR)  = O3_A*O3*GAzp(k,ABS_O3_IR)
-        Predictor%X(k, 4, COMP_OZO_IR)  = O3_A*O3_A
-        Predictor%X(k, 5, COMP_OZO_IR)  = O3_A*GAzp(k,ABS_O3_IR)
-        Predictor%X(k, 6, COMP_OZO_IR)  = O3_A*SQRT(SECANG(k)*GAzp(k,ABS_O3_IR))
-        Predictor%X(k, 7, COMP_OZO_IR)  = O3_R*DT   !T*T*T
-        Predictor%X(k, 8, COMP_OZO_IR)  = O3_R
-        Predictor%X(k, 9, COMP_OZO_IR)  = O3_R*O3/GAzp(k,ABS_O3_IR)
-        Predictor%X(k,10, COMP_OZO_IR)  = SECANG(k)*GAzp(k,ABS_O3_IR)
-        Predictor%X(k,11, COMP_OZO_IR)  = (SECANG(k)*GAzp(k,ABS_O3_IR))**2
-
-!        Predictor%X(k, 12, COMP_OZO_IR)  = H2O_A
-!        Predictor%X(k, 13, COMP_OZO_IR)  = SECANG(k)*GAzp(k,ABS_H2O_IR)
-
-        !  -----------------------
-        !  Carbon dioxide predictors
-        !  -----------------------
-        Predictor%X(k, 1, COMP_CO2_IR)  = SECANG(k) * T
-        Predictor%X(k, 2, COMP_CO2_IR)  = SECANG(k) * T2
-        Predictor%X(k, 3, COMP_CO2_IR)  = T
-        Predictor%X(k, 4, COMP_CO2_IR)  = T2
-        Predictor%X(k, 5, COMP_CO2_IR)  = SECANG(k)
-        Predictor%X(k, 6, COMP_CO2_IR)  = SECANG(k)*CO2
-        Predictor%X(k, 7, COMP_CO2_IR)  = SECANG(k) * Tzp(k)
-        Predictor%X(k, 8, COMP_CO2_IR)  = (SECANG(k) * GAzp(k, ABS_CO2_IR))**2
-        Predictor%X(k, 9, COMP_CO2_IR)  = Tzp(k)**3
-        Predictor%X(k, 10, COMP_CO2_IR) = SECANG(k) * Tzp(k) * SQRT(T)
-
-        !  --------------------------
-        !  Water-line predictors
-        !  --------------------------
-        Predictor%X(k, 1, COMP_WLO_IR) = H2O_A
-        Predictor%X(k, 2, COMP_WLO_IR) = H2O_A*DT
-        Predictor%X(k, 3, COMP_WLO_IR) = H2O_S
-        Predictor%X(k, 4, COMP_WLO_IR) = H2O_A*DT2
-        Predictor%X(k, 5, COMP_WLO_IR) = H2O_R4
-        Predictor%X(k, 6, COMP_WLO_IR) = H2O_S*H2O_A
-        Predictor%X(k, 7, COMP_WLO_IR) = H2O_R
-        Predictor%X(k, 8, COMP_WLO_IR) = H2O_R*DT
-        Predictor%X(k, 9, COMP_WLO_IR) = H2O_S*H2O_S
-        Predictor%X(k,10, COMP_WLO_IR) = H2OdH2OTzp
-        Predictor%X(k,11, COMP_WLO_IR) = H2O_R*H2OdH2OTzp
-        Predictor%X(k,12, COMP_WLO_IR) = (SECANG(k)*GAzp(k,ABS_H2O_IR))**2
-        Predictor%X(k,13, COMP_WLO_IR) = SECANG(k)*GAzp(k,ABS_H2O_IR)
-        Predictor%X(k,14, COMP_WLO_IR) = SECANG(k)
-        Predictor%X(k,15, COMP_WLO_IR) = SECANG(k) * CO2
-
-        ! Addtional predictors for group 1
-        IF_Group1: IF( Group_ID == GROUP_1 )THEN
-
-          Predictor%X(k, 11, COMP_CO2_IR)  = CO_A
-
-          Predictor%X(k, 16, COMP_WLO_IR) = CH4_A
-          Predictor%X(k, 17, COMP_WLO_IR) = CH4_A*CH4_A*DT
-          Predictor%X(k, 18, COMP_WLO_IR) = CO_A
-
-          !  -----------------------
-          !  Carbon monoxide
-          !  -----------------------
-          Predictor%X(k, 1,  COMP_CO_IR)   = CO_A
-          Predictor%X(k, 2,  COMP_CO_IR)   = CO_A*DT
-          Predictor%X(k, 3,  COMP_CO_IR)   = SQRT( CO_R )
-          Predictor%X(k, 4,  COMP_CO_IR)   = CO_R*DT
-          Predictor%X(k, 5,  COMP_CO_IR)   = CO_S
-          Predictor%X(k, 6,  COMP_CO_IR)   = CO_R
-          Predictor%X(k, 7,  COMP_CO_IR)   = CO_A*DT2
-          Predictor%X(k, 8,  COMP_CO_IR)   = CO_ACOdCOzp
-          Predictor%X(k, 9,  COMP_CO_IR)   = CO_ACOdCOzp/CO_R
-          Predictor%X(k, 10, COMP_CO_IR)   = CO_ACOdCOzp * SQRT( GAzp(k, ABS_CO_IR) )
-
-          !  -----------------------
-          !  Methane predictors
-          !  -----------------------
-          Predictor%X(k, 1,  COMP_CH4_IR)  = CH4_A*DT
-          Predictor%X(k, 2,  COMP_CH4_IR)  = CH4_R
-          Predictor%X(k, 3,  COMP_CH4_IR)  = CH4_A*CH4_A
-          Predictor%X(k, 4,  COMP_CH4_IR)  = CH4_A
-          Predictor%X(k, 5,  COMP_CH4_IR)  = CH4*DT
-          Predictor%X(k, 6,  COMP_CH4_IR)  = CH4_ACH4zp
-          Predictor%X(k, 7,  COMP_CH4_IR)  = CH4_ACH4zp**2
-          Predictor%X(k, 8,  COMP_CH4_IR)  = SQRT(CH4_R)
-          Predictor%X(k, 9,  COMP_CH4_IR)  = GATzp(k, ABS_CH4_IR)
-          Predictor%X(k, 10, COMP_CH4_IR)  = SECANG(k)*GATzp(k, ABS_CH4_IR)
-          Predictor%X(k, 11, COMP_CH4_IR)  = CH4_R * CH4/GAzp(k, ABS_CH4_IR)
-
-          !  -----------------------
-          !    N2O predictors
-          !  -----------------------
-          Predictor%X(k, 1, COMP_N2O_IR)   = N2O_A*DT
-          Predictor%X(k, 2, COMP_N2O_IR)   = N2O_R
-          Predictor%X(k, 3, COMP_N2O_IR)   = N2O*DT
-          Predictor%X(k, 4, COMP_N2O_IR)   = N2O_A**POINT_25
-          Predictor%X(k, 5, COMP_N2O_IR)   = N2O_A
-          Predictor%X(k, 6, COMP_N2O_IR)   = SECANG(k) * GAzp(k, ABS_N2O_IR)
-          Predictor%X(k, 7, COMP_N2O_IR)   = SECANG(k) * GATzp(k, ABS_N2O_IR)
-          Predictor%X(k, 8, COMP_N2O_IR)   = N2O_S
-          Predictor%X(k, 9, COMP_N2O_IR)   = GATzp(k, ABS_N2O_IR)
-          Predictor%X(k,10, COMP_N2O_IR)   = N2O_R*N2O / GAzp(k, ABS_N2O_IR)
-
-          Predictor%X(k,11, COMP_N2O_IR)   = CH4_A
-          Predictor%X(k,12, COMP_N2O_IR)   = CH4_A*GAzp(k, ABS_CH4_IR)
-          Predictor%X(k,13, COMP_N2O_IR)   = CO_A
-          Predictor%X(k,14, COMP_N2O_IR)   = CO_A*SECANG(k)*GAzp(k, ABS_CO_IR)
-
-        END IF IF_Group1
-
-        !  -----------------------
-        !  NO2 predictors (GROUP_UV_NO2 only). Scene NO2 in the UV/VIS is pure
-        !  Beer-Lambert electronic-cross-section extinction: layer OD = sigma(T)*N,
-        !  exactly linear in amount. A compact set suffices: amount*secant, plus
-        !  DT and DT2 terms for the smooth (~3-12%) sigma(T) temperature dependence.
-        !  -----------------------
-        IF( Group_ID == GROUP_UV_NO2 )THEN
-          NO2   = Absorber(k,ABS_NO2_G8)/Ref_Absorber(k, ABS_NO2_G8)
-          NO2_A = SECANG(k)*NO2
-          Predictor%X(k, 1, COMP_NO2_G8) = NO2_A
-          Predictor%X(k, 2, COMP_NO2_G8) = NO2_A*DT
-          Predictor%X(k, 3, COMP_NO2_G8) = NO2_A*DT2
-        END IF
-
-      END DO Layer_Loop
-
-    END SUBROUTINE ODPS_Compute_Predictor_IR
-
-    SUBROUTINE ODPS_Compute_Predictor_MW()
-
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER    ::    k ! n_Layers, n_Levels
-      REAL(fp) ::    DT
-      REAL(fp) ::    T
-      REAL(fp) ::    T2
-      REAL(fp) ::    DT2
-      REAL(fp) ::    H2O
-      REAL(fp) ::    H2O_A
-      REAL(fp) ::    H2O_R
-      REAL(fp) ::    H2O_S
-      REAL(fp) ::    H2O_R4
-      REAL(fp) ::    H2OdH2OTzp
-      REAL(fp) ::    O3
-      REAL(fp) ::    O3_A
-      REAL(fp) ::    O3_R
-
-      Layer_Loop : DO k = 1, n_Layers
+      MW_Layer_Loop : DO k = 1, n_Layers
 
         !------------------------------------------
         !  Relative Temperature
@@ -1112,7 +943,7 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_MW)/Ref_Absorber(k, ABS_H2O_MW)
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
 
         ! Combinations of variables common to all predictor groups
         T2  = T*T
@@ -1122,71 +953,232 @@ CONTAINS
         H2O_R  = SQRT( H2O_A )
         H2O_S  = H2O_A*H2O_A
         H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/GATzp(k, ABS_H2O_MW)
+        H2OdH2OTzp = H2O/GATzp(k, ja_h2o)
 
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
-
-       ! set number of predictors
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE
-          Predictor%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        END IF
-
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-        Predictor%X(k, 1, COMP_DRY_MW)  = SECANG(k)
-        Predictor%X(k, 2, COMP_DRY_MW)  = SECANG(k) * T
-        Predictor%X(k, 3, COMP_DRY_MW)  = SECANG(k) * T2
-        Predictor%X(k, 4, COMP_DRY_MW)  = T
-        Predictor%X(k, 5, COMP_DRY_MW)  = SECANG(k) * SECANG(k)
-        Predictor%X(k, 6, COMP_DRY_MW)  = T2
-        Predictor%X(k, 7, COMP_DRY_MW)  = Tz(k)
-
-       !  --------------------------------
-       !  Water vapor (line and continuum)
-       !  --------------------------------
-        Predictor%X(k, 1, COMP_WET_MW) = H2O_A/T
-        Predictor%X(k, 2, COMP_WET_MW) = H2O_A/T * H2O
-        Predictor%X(k, 3, COMP_WET_MW) = H2O_A/T2 * H2O/T2
-        Predictor%X(k, 4, COMP_WET_MW) = H2O_A/T2
-        Predictor%X(k, 5, COMP_WET_MW) = H2O_A/T2 * H2O
-        Predictor%X(k, 6, COMP_WET_MW) = H2O_A/T2**2
-        Predictor%X(k, 7, COMP_WET_MW) = H2O_A
-        Predictor%X(k, 8, COMP_WET_MW) = H2O_A*DT
-        Predictor%X(k, 9, COMP_WET_MW) = (SECANG(k)*GAzp(k,ABS_H2O_MW))**2
-        Predictor%X(k, 10,COMP_WET_MW) = SECANG(k)*GAzp(k,ABS_H2O_MW)
-        Predictor%X(k, 11,COMP_WET_MW) = SECANG(k)
-        Predictor%X(k, 12,COMP_WET_MW) = H2O_S*H2O_A
-        Predictor%X(k, 13,COMP_WET_MW) = H2O_S*H2O_S
-        Predictor%X(k, 14,COMP_WET_MW) = H2OdH2OTzp
-
-        !  -----------------------
-        !  Ozone predictors (GROUP_MW_O3 only; same formulation as IR)
-        !  -----------------------
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          O3   = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+        IF ( ja_o3 > 0 ) THEN
+          O3   = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
           O3_A = SECANG(k)*O3
           O3_R = SQRT( O3_A )
-          Predictor%X(k, 1, COMP_OZO_MW)  = O3_A
-          Predictor%X(k, 2, COMP_OZO_MW)  = O3_A*DT
-          Predictor%X(k, 3, COMP_OZO_MW)  = O3_A*O3*GAzp(k,ABS_O3_MW)
-          Predictor%X(k, 4, COMP_OZO_MW)  = O3_A*O3_A
-          Predictor%X(k, 5, COMP_OZO_MW)  = O3_A*GAzp(k,ABS_O3_MW)
-          Predictor%X(k, 6, COMP_OZO_MW)  = O3_A*SQRT(SECANG(k)*GAzp(k,ABS_O3_MW))
-          Predictor%X(k, 7, COMP_OZO_MW)  = O3_R*DT
-          Predictor%X(k, 8, COMP_OZO_MW)  = O3_R
-          Predictor%X(k, 9, COMP_OZO_MW)  = O3_R*O3/GAzp(k,ABS_O3_MW)
-          Predictor%X(k,10, COMP_OZO_MW)  = SECANG(k)*GAzp(k,ABS_O3_MW)
-          Predictor%X(k,11, COMP_OZO_MW)  = (SECANG(k)*GAzp(k,ABS_O3_MW))**2
         END IF
 
-      END DO Layer_Loop
+        MW_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+          np = Predictor%n_CP(ic)
+          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+            CASE ( EDRY_ComID )
+              CALL FWD_Kernel_DRY(k, ic)
+            CASE ( WET_ComID )
+              CALL FWD_Kernel_WET_MW(k, ic)
+            CASE ( OZO_ComID )
+              CALL FWD_Kernel_OZO(k, ic)
+          END SELECT
+        END DO MW_Component_Loop
 
-    END SUBROUTINE ODPS_Compute_Predictor_MW
+      END DO MW_Layer_Loop
+
+    END IF Basis_Select
+
+CONTAINS
+
+    ! Position of a HITRAN absorber ID in this group's absorber roster
+    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Absorber_ID
+      INTEGER :: Position
+      INTEGER :: ja
+      Position = 0
+      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
+        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+          Position = ja
+          RETURN
+        END IF
+      END DO
+    END FUNCTION Absorber_Position
+
+    !  ----------------------
+    !   Fixed (Dry) predictors (IR and MW use the same formulation)
+    !  ----------------------
+    SUBROUTINE FWD_Kernel_DRY( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1, ic)  = SECANG(k)
+      Predictor%X(k, 2, ic)  = SECANG(k) * T
+      Predictor%X(k, 3, ic)  = SECANG(k) * T2
+      Predictor%X(k, 4, ic)  = T
+      Predictor%X(k, 5, ic)  = SECANG(k) * SECANG(k)
+      Predictor%X(k, 6, ic)  = T2
+      Predictor%X(k, 7, ic)  = Tz(k)
+    END SUBROUTINE FWD_Kernel_DRY
+
+    !  --------------------------
+    !  Water vapor continuum predictors
+    !  --------------------------
+    SUBROUTINE FWD_Kernel_WCO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1, ic) = H2O_A/T
+      Predictor%X(k, 2, ic) = H2O_A/T * H2O
+      Predictor%X(k, 3, ic) = H2O_A/T2 * H2O/T2
+      Predictor%X(k, 4, ic) = H2O_A/T2
+      Predictor%X(k, 5, ic) = H2O_A/T2 * H2O
+      Predictor%X(k, 6, ic) = H2O_A/T2**2
+      Predictor%X(k, 7, ic) = H2O_A
+    END SUBROUTINE FWD_Kernel_WCO
+
+    !  -----------------------
+    !  Ozone predictors (same formulation for the IR and MW_O3 groups)
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_OZO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1, ic)  = O3_A
+      Predictor%X(k, 2, ic)  = O3_A*DT
+      Predictor%X(k, 3, ic)  = O3_A*O3*GAzp(k,ja_o3)
+      Predictor%X(k, 4, ic)  = O3_A*O3_A
+      Predictor%X(k, 5, ic)  = O3_A*GAzp(k,ja_o3)
+      Predictor%X(k, 6, ic)  = O3_A*SQRT(SECANG(k)*GAzp(k,ja_o3))
+      Predictor%X(k, 7, ic)  = O3_R*DT   !T*T*T
+      Predictor%X(k, 8, ic)  = O3_R
+      Predictor%X(k, 9, ic)  = O3_R*O3/GAzp(k,ja_o3)
+      Predictor%X(k,10, ic)  = SECANG(k)*GAzp(k,ja_o3)
+      Predictor%X(k,11, ic)  = (SECANG(k)*GAzp(k,ja_o3))**2
+    END SUBROUTINE FWD_Kernel_OZO
+
+    !  -----------------------
+    !  Carbon dioxide predictors; predictor 11 (CO amount) is carried only
+    !  by rosters that request 11 predictors for CO2 (group 1)
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_CO2( k, ic, np )
+      INTEGER, INTENT(IN) :: k, ic, np
+      Predictor%X(k, 1, ic)  = SECANG(k) * T
+      Predictor%X(k, 2, ic)  = SECANG(k) * T2
+      Predictor%X(k, 3, ic)  = T
+      Predictor%X(k, 4, ic)  = T2
+      Predictor%X(k, 5, ic)  = SECANG(k)
+      Predictor%X(k, 6, ic)  = SECANG(k)*CO2
+      Predictor%X(k, 7, ic)  = SECANG(k) * Tzp(k)
+      Predictor%X(k, 8, ic)  = (SECANG(k) * GAzp(k, ja_co2))**2
+      Predictor%X(k, 9, ic)  = Tzp(k)**3
+      Predictor%X(k, 10, ic) = SECANG(k) * Tzp(k) * SQRT(T)
+      IF ( np >= 11 ) THEN
+        Predictor%X(k, 11, ic) = CO_A
+      END IF
+    END SUBROUTINE FWD_Kernel_CO2
+
+    !  --------------------------
+    !  Water-line predictors; predictors 16 - 18 (CH4/CO cross terms) are
+    !  carried only by rosters that request 18 predictors for WLO (group 1)
+    !  --------------------------
+    SUBROUTINE FWD_Kernel_WLO( k, ic, np )
+      INTEGER, INTENT(IN) :: k, ic, np
+      Predictor%X(k, 1, ic) = H2O_A
+      Predictor%X(k, 2, ic) = H2O_A*DT
+      Predictor%X(k, 3, ic) = H2O_S
+      Predictor%X(k, 4, ic) = H2O_A*DT2
+      Predictor%X(k, 5, ic) = H2O_R4
+      Predictor%X(k, 6, ic) = H2O_S*H2O_A
+      Predictor%X(k, 7, ic) = H2O_R
+      Predictor%X(k, 8, ic) = H2O_R*DT
+      Predictor%X(k, 9, ic) = H2O_S*H2O_S
+      Predictor%X(k,10, ic) = H2OdH2OTzp
+      Predictor%X(k,11, ic) = H2O_R*H2OdH2OTzp
+      Predictor%X(k,12, ic) = (SECANG(k)*GAzp(k,ja_h2o))**2
+      Predictor%X(k,13, ic) = SECANG(k)*GAzp(k,ja_h2o)
+      Predictor%X(k,14, ic) = SECANG(k)
+      Predictor%X(k,15, ic) = SECANG(k) * CO2
+      IF ( np >= 18 ) THEN
+        Predictor%X(k,16, ic) = CH4_A
+        Predictor%X(k,17, ic) = CH4_A*CH4_A*DT
+        Predictor%X(k,18, ic) = CO_A
+      END IF
+    END SUBROUTINE FWD_Kernel_WLO
+
+    !  -----------------------
+    !  Carbon monoxide
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_CO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1,  ic)   = CO_A
+      Predictor%X(k, 2,  ic)   = CO_A*DT
+      Predictor%X(k, 3,  ic)   = SQRT( CO_R )
+      Predictor%X(k, 4,  ic)   = CO_R*DT
+      Predictor%X(k, 5,  ic)   = CO_S
+      Predictor%X(k, 6,  ic)   = CO_R
+      Predictor%X(k, 7,  ic)   = CO_A*DT2
+      Predictor%X(k, 8,  ic)   = CO_ACOdCOzp
+      Predictor%X(k, 9,  ic)   = CO_ACOdCOzp/CO_R
+      Predictor%X(k, 10, ic)   = CO_ACOdCOzp * SQRT( GAzp(k, ja_co) )
+    END SUBROUTINE FWD_Kernel_CO
+
+    !  -----------------------
+    !  Methane predictors
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_CH4( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1,  ic)  = CH4_A*DT
+      Predictor%X(k, 2,  ic)  = CH4_R
+      Predictor%X(k, 3,  ic)  = CH4_A*CH4_A
+      Predictor%X(k, 4,  ic)  = CH4_A
+      Predictor%X(k, 5,  ic)  = CH4*DT
+      Predictor%X(k, 6,  ic)  = CH4_ACH4zp
+      Predictor%X(k, 7,  ic)  = CH4_ACH4zp**2
+      Predictor%X(k, 8,  ic)  = SQRT(CH4_R)
+      Predictor%X(k, 9,  ic)  = GATzp(k, ja_ch4)
+      Predictor%X(k, 10, ic)  = SECANG(k)*GATzp(k, ja_ch4)
+      Predictor%X(k, 11, ic)  = CH4_R * CH4/GAzp(k, ja_ch4)
+    END SUBROUTINE FWD_Kernel_CH4
+
+    !  -----------------------
+    !    N2O predictors
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_N2O( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1, ic)   = N2O_A*DT
+      Predictor%X(k, 2, ic)   = N2O_R
+      Predictor%X(k, 3, ic)   = N2O*DT
+      Predictor%X(k, 4, ic)   = N2O_A**POINT_25
+      Predictor%X(k, 5, ic)   = N2O_A
+      Predictor%X(k, 6, ic)   = SECANG(k) * GAzp(k, ja_n2o)
+      Predictor%X(k, 7, ic)   = SECANG(k) * GATzp(k, ja_n2o)
+      Predictor%X(k, 8, ic)   = N2O_S
+      Predictor%X(k, 9, ic)   = GATzp(k, ja_n2o)
+      Predictor%X(k,10, ic)   = N2O_R*N2O / GAzp(k, ja_n2o)
+      Predictor%X(k,11, ic)   = CH4_A
+      Predictor%X(k,12, ic)   = CH4_A*GAzp(k, ja_ch4)
+      Predictor%X(k,13, ic)   = CO_A
+      Predictor%X(k,14, ic)   = CO_A*SECANG(k)*GAzp(k, ja_co)
+    END SUBROUTINE FWD_Kernel_N2O
+
+    !  -----------------------
+    !  NO2 predictors (GROUP_UV_NO2). Scene NO2 in the UV/VIS is pure
+    !  Beer-Lambert electronic-cross-section extinction: layer OD = sigma(T)*N,
+    !  exactly linear in amount. A compact set suffices: amount*secant, plus
+    !  DT and DT2 terms for the smooth (~3-12%) sigma(T) temperature dependence.
+    !  -----------------------
+    SUBROUTINE FWD_Kernel_NO2( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      NO2   = Absorber(k,ja_no2)/Ref_Absorber(k, ja_no2)
+      NO2_A = SECANG(k)*NO2
+      Predictor%X(k, 1, ic) = NO2_A
+      Predictor%X(k, 2, ic) = NO2_A*DT
+      Predictor%X(k, 3, ic) = NO2_A*DT2
+    END SUBROUTINE FWD_Kernel_NO2
+
+    !  --------------------------------
+    !  Water vapor, MW (line and continuum together)
+    !  --------------------------------
+    SUBROUTINE FWD_Kernel_WET_MW( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor%X(k, 1, ic) = H2O_A/T
+      Predictor%X(k, 2, ic) = H2O_A/T * H2O
+      Predictor%X(k, 3, ic) = H2O_A/T2 * H2O/T2
+      Predictor%X(k, 4, ic) = H2O_A/T2
+      Predictor%X(k, 5, ic) = H2O_A/T2 * H2O
+      Predictor%X(k, 6, ic) = H2O_A/T2**2
+      Predictor%X(k, 7, ic) = H2O_A
+      Predictor%X(k, 8, ic) = H2O_A*DT
+      Predictor%X(k, 9, ic) = (SECANG(k)*GAzp(k,ja_h2o))**2
+      Predictor%X(k, 10,ic) = SECANG(k)*GAzp(k,ja_h2o)
+      Predictor%X(k, 11,ic) = SECANG(k)
+      Predictor%X(k, 12,ic) = H2O_S*H2O_A
+      Predictor%X(k, 13,ic) = H2O_S*H2O_S
+      Predictor%X(k, 14,ic) = H2OdH2OTzp
+    END SUBROUTINE FWD_Kernel_WET_MW
 
   END SUBROUTINE  ODPS_Compute_Predictor
 
@@ -1319,6 +1311,20 @@ CONTAINS
     REAL(fp) ::    GAzp_TL(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_sum_TL(SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_TL(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
+    ! Kernel dispatch bookkeeping and shared per-layer variables
+    INTEGER  :: ic, np
+    INTEGER  :: ja_h2o, ja_o3, ja_co2, ja_n2o, ja_co, ja_ch4, ja_no2
+    LOGICAL  :: has_trace
+    REAL(fp) :: DT, DT_TL, T, T_TL, T2, T2_TL, DT2, DT2_TL
+    REAL(fp) :: H2O, H2O_TL, H2O_A, H2O_A_TL, H2O_R, H2O_R_TL
+    REAL(fp) :: H2O_S, H2O_S_TL, H2O_R4, H2O_R4_TL, H2OdH2OTzp, H2OdH2OTzp_TL
+    REAL(fp) :: CO2, CO2_TL, O3, O3_TL, O3_A, O3_A_TL, O3_R, O3_R_TL
+    REAL(fp) :: NO2, NO2_TL, NO2_A, NO2_A_TL
+    REAL(fp) :: CO, CO_TL, CO_A, CO_A_TL, CO_R, CO_R_TL, CO_S, CO_S_TL
+    REAL(fp) :: CO_ACOdCOzp, CO_ACOdCOzp_TL
+    REAL(fp) :: N2O, N2O_TL, N2O_A, N2O_A_TL, N2O_R, N2O_R_TL, N2O_S, N2O_S_TL
+    REAL(fp) :: CH4, CH4_TL, CH4_A, CH4_A_TL, CH4_R, CH4_R_TL
+    REAL(fp) :: CH4_ACH4zp, CH4_ACH4zp_TL
 !JR Static initialization means only 1 copy of the variable. OpenMP over profiles
 !JR means $OPENMP_NUM_THREADS copies are needed. So change to run-time initialization
 !JR    TYPE(PAFV_type), POINTER  :: PAFV => NULL()
@@ -1365,85 +1371,53 @@ CONTAINS
     END DO Layer_Loop
 
     !----------------------------------------------------------------
-    ! Call the group specific routine for remaining computation; all
-    ! variables defined above are passed to the called routine
+    ! Per-component tangent-linear predictor computation; mirrors the
+    ! forward kernel dispatch (TL X assignments are independent of one
+    ! another, so kernel order does not affect results).
     !----------------------------------------------------------------
 
-    SELECT CASE( Group_ID )
-      CASE( GROUP_1, GROUP_2, GROUP_UV_NO2 )
-         CALL ODPS_Compute_Predictor_IR_TL()
-      CASE( GROUP_3, GROUP_MW_O3 )
-         CALL ODPS_Compute_Predictor_MW_TL()
-    END SELECT
+    ! Number of predictors per component, from the registry roster
+    Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
 
-    NULLIFY(PAFV)
+    ! Resolve each gas's position in this group's absorber roster
+    ja_h2o = Absorber_Position(H2O_ID)
+    ja_o3  = Absorber_Position(O3_ID)
+    ja_co2 = Absorber_Position(CO2_ID)
+    ja_n2o = Absorber_Position(N2O_ID)
+    ja_co  = Absorber_Position(CO_ID)
+    ja_ch4 = Absorber_Position(CH4_ID)
+    ja_no2 = Absorber_Position(NO2_ID)
+    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
 
-CONTAINS
+    ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
+    N2O_TL        = HUGE(N2O_TL)
+    N2O_S_TL      = HUGE(N2O_S_TL)
+    N2O_S         = HUGE(N2O_S)
+    N2O_R         = HUGE(N2O_R)
+    N2O_R_TL      = HUGE(N2O_R_TL)
+    N2O           = HUGE(N2O)
+    N2O_A         = HUGE(N2O_A)
+    N2O_A_TL      = HUGE(N2O_A_TL)
+    CO_S_TL       = HUGE(CO_S_TL)
+    CO_S          = HUGE(CO_S)
+    CO_R          = HUGE(CO_R)
+    CO_R_TL       = HUGE(CO_R_TL)
+    CO_A_TL       = HUGE(CO_A_TL)
+    CO_A          = HUGE(CO_A)
+    CO_ACODCOZP_TL= HUGE(CO_ACODCOZP_TL)
+    CO_ACODCOZP   = HUGE(CO_ACODCOZP)
+    CH4_TL        = HUGE(CH4_TL)
+    CH4_R_TL      = HUGE(CH4_R_TL)
+    CH4_A_TL      = HUGE(CH4_A_TL)
+    CH4_A         = HUGE(CH4_A)
+    CH4_R         = HUGE(CH4_R)
+    CH4           = HUGE(CH4)
+    CH4_ACH4ZP_TL = HUGE(CH4_ACH4ZP_TL)
+    CH4_ACH4ZP    = HUGE(CH4_ACH4ZP)
 
-    SUBROUTINE ODPS_Compute_Predictor_IR_TL()
+    Basis_Select: IF ( GROUP_REGISTRY(Group_ID)%Basis == BASIS_IR ) THEN
 
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER    ::    k ! n_Layers, n_Levels
-      REAL(fp) ::    DT,           DT_TL
-      REAL(fp) ::    T,            T_TL
-      REAL(fp) ::    T2,           T2_TL
-      REAL(fp) ::    DT2,          DT2_TL
-      REAL(fp) ::    H2O,          H2O_TL
-      REAL(fp) ::    H2O_A,        H2O_A_TL
-      REAL(fp) ::    H2O_R,        H2O_R_TL
-      REAL(fp) ::    H2O_S,        H2O_S_TL
-      REAL(fp) ::    H2O_R4,       H2O_R4_TL
-      REAL(fp) ::    H2OdH2OTzp,   H2OdH2OTzp_TL
-      REAL(fp) ::    CO2,          CO2_TL
-      REAL(fp) ::    O3,           O3_TL
-      REAL(fp) ::    O3_A,         O3_A_TL
-      REAL(fp) ::    O3_R,         O3_R_TL
-      REAL(fp) ::    NO2,          NO2_TL
-      REAL(fp) ::    NO2_A,        NO2_A_TL
-      REAL(fp) ::    CO,           CO_TL
-      REAL(fp) ::    CO_A,         CO_A_TL
-      REAL(fp) ::    CO_R,         CO_R_TL
-      REAL(fp) ::    CO_S,         CO_S_TL
-      REAL(fp) ::    CO_ACOdCOzp,  CO_ACOdCOzp_TL
-      REAL(fp) ::    N2O,          N2O_TL
-      REAL(fp) ::    N2O_A,        N2O_A_TL
-      REAL(fp) ::    N2O_R,        N2O_R_TL
-      REAL(fp) ::    N2O_S,        N2O_S_TL
-      REAL(fp) ::    CH4,          CH4_TL
-      REAL(fp) ::    CH4_A,        CH4_A_TL
-      REAL(fp) ::    CH4_R,        CH4_R_TL
-      REAL(fp) ::    CH4_ACH4zp,   CH4_ACH4zp_TL
-
-      ! Silence gfortran complaints about maybe-used-uninit by init to HUGE()
-      N2O_TL        = HUGE(N2O_TL)
-      N2O_S_TL      = HUGE(N2O_S_TL)
-      N2O_S         = HUGE(N2O_S)
-      N2O_R         = HUGE(N2O_R)
-      N2O_R_TL      = HUGE(N2O_R_TL)
-      N2O           = HUGE(N2O)
-      N2O_A         = HUGE(N2O_A)
-      N2O_A_TL      = HUGE(N2O_A_TL)
-      CO_S_TL       = HUGE(CO_S_TL)
-      CO_S          = HUGE(CO_S)
-      CO_R          = HUGE(CO_R)
-      CO_R_TL       = HUGE(CO_R_TL)
-      CO_A_TL       = HUGE(CO_A_TL)
-      CO_A          = HUGE(CO_A)
-      CO_R          = HUGE(CO_R)
-      CO_ACODCOZP_TL= HUGE(CO_ACODCOZP_TL)
-      CO_ACODCOZP   = HUGE(CO_ACODCOZP)
-      CH4_TL        = HUGE(CH4_TL)
-      CH4_R_TL      = HUGE(CH4_R_TL)
-      CH4_A_TL      = HUGE(CH4_A_TL)
-      CH4_A         = HUGE(CH4_A)
-      CH4_R         = HUGE(CH4_R)
-      CH4           = HUGE(CH4)
-      CH4_ACH4ZP_TL = HUGE(CH4_ACH4ZP_TL)
-      CH4_ACH4ZP    = HUGE(CH4_ACH4ZP)
-      
-      Layer_Loop : DO k = 1, n_Layers
+      IR_Layer_Loop : DO k = 1, n_Layers
 
         !------------------------------------------
         !  Relative Temperature
@@ -1456,13 +1430,13 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_IR)/Ref_Absorber(k, ABS_H2O_IR)
-        O3  = Absorber(k,ABS_O3_IR)/Ref_absorber(k,ABS_O3_IR)
-        CO2 = Absorber(k,ABS_CO2_IR)/Ref_absorber(k,ABS_CO2_IR)
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
 
-        H2O_TL = Absorber_TL(k,ABS_H2O_IR)/Ref_Absorber(k, ABS_H2O_IR)
-        O3_TL  = Absorber_TL(k,ABS_O3_IR)/Ref_absorber(k,ABS_O3_IR)
-        CO2_TL = Absorber_TL(k,ABS_CO2_IR)/Ref_absorber(k,ABS_CO2_IR)
+        H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        O3_TL  = Absorber_TL(k,ja_o3)/Ref_absorber(k,ja_o3)
+        CO2_TL = Absorber_TL(k,ja_co2)/Ref_absorber(k,ja_co2)
 
         ! Combinations of variables common to all predictor groups
         T2   = T*T
@@ -1479,14 +1453,14 @@ CONTAINS
         H2O_R  = SQRT( H2O_A )
         H2O_S  = H2O_A*H2O_A
         H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ABS_H2O_IR)
+        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
 
         H2O_A_TL  = SECANG(k)*H2O_TL
         H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
         H2O_S_TL  = TWO * H2O_A * H2O_A_TL
         H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
-        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ABS_H2O_IR) - &
-                        H2O * GATzp_TL(k, ABS_H2O_IR)/PAFV%GATzp(k, ABS_H2O_IR)**2
+        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
+                        H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
 
         O3_A = SECANG(k)*O3
         O3_R = SQRT( O3_A )
@@ -1494,14 +1468,14 @@ CONTAINS
         O3_A_TL = SECANG(k)*O3_TL
         O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
 
-        IF( Group_ID == GROUP_1 )THEN
-          CO  = Absorber(k,ABS_CO_IR)/Ref_absorber(k, ABS_CO_IR)
-          N2O = Absorber(k,ABS_N2O_IR)/Ref_absorber(k,ABS_N2O_IR)
-          CH4 = Absorber(k,ABS_CH4_IR)/Ref_absorber(k,ABS_CH4_IR)
+        IF( has_trace )THEN
+          CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
+          N2O = Absorber(k,ja_n2o)/Ref_absorber(k,ja_n2o)
+          CH4 = Absorber(k,ja_ch4)/Ref_absorber(k,ja_ch4)
 
-          CO_TL  = Absorber_TL(k,ABS_CO_IR)/Ref_absorber(k, ABS_CO_IR)
-          N2O_TL = Absorber_TL(k,ABS_N2O_IR)/Ref_absorber(k,ABS_N2O_IR)
-          CH4_TL = Absorber_TL(k,ABS_CH4_IR)/Ref_absorber(k,ABS_CH4_IR)
+          CO_TL  = Absorber_TL(k,ja_co)/Ref_absorber(k, ja_co)
+          N2O_TL = Absorber_TL(k,ja_n2o)/Ref_absorber(k,ja_n2o)
+          CH4_TL = Absorber_TL(k,ja_ch4)/Ref_absorber(k,ja_ch4)
 
           N2O_A = SECANG(k)*N2O
           N2O_R = SQRT( N2O_A )
@@ -1514,213 +1488,52 @@ CONTAINS
           CO_A = SECANG(k)*CO
           CO_R = SQRT( CO_A )
           CO_S = CO_A*CO_A
-          CO_ACOdCOzp = CO_A*CO/PAFV%GAzp(k, ABS_CO_IR)
+          CO_ACOdCOzp = CO_A*CO/PAFV%GAzp(k, ja_co)
 
           CO_A_TL = SECANG(k)*CO_TL
           CO_R_TL = (POINT_5 / SQRT(CO_A)) * CO_A_TL
           CO_S_TL = TWO * CO_A * CO_A_TL
-          CO_ACOdCOzp_TL = CO_A_TL*CO/PAFV%GAzp(k, ABS_CO_IR) + CO_A*CO_TL/PAFV%GAzp(k, ABS_CO_IR) &
-                           - CO_A*CO*GAzp_TL(k, ABS_CO_IR)/PAFV%GAzp(k, ABS_CO_IR)**2
+          CO_ACOdCOzp_TL = CO_A_TL*CO/PAFV%GAzp(k, ja_co) + CO_A*CO_TL/PAFV%GAzp(k, ja_co) &
+                           - CO_A*CO*GAzp_TL(k, ja_co)/PAFV%GAzp(k, ja_co)**2
 
           CH4_A = SECANG(k)*CH4
           CH4_R = SQRT(CH4_A)
-          CH4_ACH4zp = SECANG(k)*PAFV%GAzp(k, ABS_CH4_IR)
+          CH4_ACH4zp = SECANG(k)*PAFV%GAzp(k, ja_ch4)
 
           CH4_A_TL = SECANG(k)*CH4_TL
           CH4_R_TL = (POINT_5 / SQRT(CH4_A)) * CH4_A_TL
-          CH4_ACH4zp_TL = SECANG(k)*GAzp_TL(k, ABS_CH4_IR)
-
-          ! set number of predictors
-          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE IF( Group_ID == GROUP_UV_NO2 )THEN
-          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE
-          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+          CH4_ACH4zp_TL = SECANG(k)*GAzp_TL(k, ja_ch4)
         END IF
 
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
+        IR_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+          np = Predictor_TL%n_CP(ic)
+          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+            CASE ( DRY_ComID_G1, DRY_ComID_G2 )
+              CALL TL_Kernel_DRY(k, ic)
+            CASE ( WLO_ComID )
+              CALL TL_Kernel_WLO(k, ic, np)
+            CASE ( WCO_ComID )
+              CALL TL_Kernel_WCO(k, ic)
+            CASE ( OZO_ComID )
+              CALL TL_Kernel_OZO(k, ic)
+            CASE ( CO2_ComID )
+              CALL TL_Kernel_CO2(k, ic, np)
+            CASE ( N2O_ComID )
+              CALL TL_Kernel_N2O(k, ic)
+            CASE ( CO_ComID )
+              CALL TL_Kernel_CO(k, ic)
+            CASE ( CH4_ComID )
+              CALL TL_Kernel_CH4(k, ic)
+            CASE ( NO2_ComID )
+              CALL TL_Kernel_NO2(k, ic)
+          END SELECT
+        END DO IR_Component_Loop
 
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-        Predictor_TL%X(k, 1, COMP_DRY_IR)  = ZERO
-        Predictor_TL%X(k, 2, COMP_DRY_IR)  = SECANG(k) * T_TL
-        Predictor_TL%X(k, 3, COMP_DRY_IR)  = SECANG(k) * T2_TL
-        Predictor_TL%X(k, 4, COMP_DRY_IR)  = T_TL
-        Predictor_TL%X(k, 5, COMP_DRY_IR)  = ZERO
-        Predictor_TL%X(k, 6, COMP_DRY_IR)  = T2_TL
-        Predictor_TL%X(k, 7, COMP_DRY_IR)  = Tz_TL(k)
+      END DO IR_Layer_Loop
 
-       !  --------------------------
-       !  Water vapor continuum predictors
-       !  --------------------------
-        Predictor_TL%X(k, 1, COMP_WCO_IR) = H2O_A_TL/T - H2O_A * T_TL/T**2
-        Predictor_TL%X(k, 2, COMP_WCO_IR) = H2O_A_TL*H2O/T + H2O_A*H2O_TL/T - H2O_A*H2O*T_TL/T**2
-        Predictor_TL%X(k, 3, COMP_WCO_IR) = H2O_A_TL*H2O/T2**2 + H2O_A*H2O_TL/T2**2 - &
-                                            Two*H2O_A*H2O*T2_TL/T2**3
-        Predictor_TL%X(k, 4, COMP_WCO_IR) = H2O_A_TL/T2 - H2O_A * T2_TL/T2**2
-        Predictor_TL%X(k, 5, COMP_WCO_IR) = H2O_A_TL*H2O/T2 + H2O_A*H2O_TL/T2 - H2O_A*H2O*T2_TL/T2**2
-        Predictor_TL%X(k, 6, COMP_WCO_IR) = H2O_A_TL/T2**2 - TWO*H2O_A*T2_TL/T2**3
-        Predictor_TL%X(k, 7, COMP_WCO_IR) = H2O_A_TL
+    ELSE Basis_Select   ! BASIS_MW
 
-        !  -----------------------
-        !  Ozone predictors
-        !  -----------------------
-        Predictor_TL%X(k, 1, COMP_OZO_IR)  = O3_A_TL
-        Predictor_TL%X(k, 2, COMP_OZO_IR)  = O3_A_TL*DT + O3_A*DT_TL
-        Predictor_TL%X(k, 3, COMP_OZO_IR)  = O3_A_TL*O3*PAFV%GAzp(k,ABS_O3_IR) + O3_A*O3_TL*PAFV%GAzp(k,ABS_O3_IR) &
-                                             + O3_A*O3*GAzp_TL(k,ABS_O3_IR)
-        Predictor_TL%X(k, 4, COMP_OZO_IR)  = TWO*O3_A*O3_A_TL
-        Predictor_TL%X(k, 5, COMP_OZO_IR)  = O3_A_TL*PAFV%GAzp(k,ABS_O3_IR) + O3_A*GAzp_TL(k,ABS_O3_IR)
-        Predictor_TL%X(k, 6, COMP_OZO_IR)  = O3_A_TL*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_IR)) + &
-                                             POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_IR))* &
-                                             GAzp_TL(k,ABS_O3_IR)
-        Predictor_TL%X(k, 7, COMP_OZO_IR)  = O3_R_TL*DT + O3_R*DT_TL  !T*T*T
-        Predictor_TL%X(k, 8, COMP_OZO_IR)  = O3_R_TL
-        Predictor_TL%X(k, 9, COMP_OZO_IR)  = O3_R_TL*O3/PAFV%GAzp(k,ABS_O3_IR) + O3_R*O3_TL/PAFV%GAzp(k,ABS_O3_IR) &
-                                             - O3_R*O3*GAzp_TL(k,ABS_O3_IR)/PAFV%GAzp(k,ABS_O3_IR)**2
-        Predictor_TL%X(k,10, COMP_OZO_IR)  = SECANG(k)*GAzp_TL(k,ABS_O3_IR)
-        Predictor_TL%X(k,11, COMP_OZO_IR)  = TWO*SECANG(k)**2 * PAFV%GAzp(k,ABS_O3_IR)*GAzp_TL(k,ABS_O3_IR)
-!        Predictor_TL%X(k, 12, COMP_OZO_IR)  = H2O_A_TL
-!        Predictor_TL%X(k, 13, COMP_OZO_IR)  = SECANG(k)*GAzp_TL(k,ABS_H2O_IR)
-
-        !  -----------------------
-        !  Carbon dioxide predictors
-        !  -----------------------
-        Predictor_TL%X(k, 1, COMP_CO2_IR)  = SECANG(k) * T_TL
-        Predictor_TL%X(k, 2, COMP_CO2_IR)  = SECANG(k) * T2_TL
-        Predictor_TL%X(k, 3, COMP_CO2_IR)  = T_TL
-        Predictor_TL%X(k, 4, COMP_CO2_IR)  = T2_TL
-        Predictor_TL%X(k, 5, COMP_CO2_IR)  = ZERO
-        Predictor_TL%X(k, 6, COMP_CO2_IR)  = SECANG(k)*CO2_TL
-        Predictor_TL%X(k, 7, COMP_CO2_IR)  = SECANG(k)*Tzp_TL(k)
-        Predictor_TL%X(k, 8, COMP_CO2_IR)  = TWO*SECANG(k)**2 * PAFV%GAzp(k, ABS_CO2_IR)* GAzp_TL(k, ABS_CO2_IR)
-        Predictor_TL%X(k, 9, COMP_CO2_IR)  = THREE*PAFV%Tzp(k)**2*Tzp_TL(k)
-        Predictor_TL%X(k, 10, COMP_CO2_IR) = SECANG(k)*( SQRT(T)*Tzp_TL(k) + (POINT_5*PAFV%Tzp(k)/SQRT(T))*T_TL )
-
-        !  --------------------------
-        !  Water-line predictors
-        !  --------------------------
-        Predictor_TL%X(k, 1, COMP_WLO_IR) = H2O_A_TL
-        Predictor_TL%X(k, 2, COMP_WLO_IR) = H2O_A_TL*DT + H2O_A*DT_TL
-        Predictor_TL%X(k, 3, COMP_WLO_IR) = H2O_S_TL
-        Predictor_TL%X(k, 4, COMP_WLO_IR) = H2O_A_TL*DT2 + H2O_A*DT2_TL
-        Predictor_TL%X(k, 5, COMP_WLO_IR) = H2O_R4_TL
-        Predictor_TL%X(k, 6, COMP_WLO_IR) = H2O_S_TL*H2O_A + H2O_S*H2O_A_TL
-        Predictor_TL%X(k, 7, COMP_WLO_IR) = H2O_R_TL
-        Predictor_TL%X(k, 8, COMP_WLO_IR) = H2O_R_TL*DT + H2O_R*DT_TL
-        Predictor_TL%X(k, 9, COMP_WLO_IR) = TWO*H2O_S*H2O_S_TL
-        Predictor_TL%X(k,10, COMP_WLO_IR) = H2OdH2OTzp_TL
-        Predictor_TL%X(k,11, COMP_WLO_IR) = H2O_R_TL*H2OdH2OTzp + H2O_R*H2OdH2OTzp_TL
-        Predictor_TL%X(k,12, COMP_WLO_IR) = TWO*SECANG(k)**2 * PAFV%GAzp(k,ABS_H2O_IR)*GAzp_TL(k,ABS_H2O_IR)
-        Predictor_TL%X(k,13, COMP_WLO_IR) = SECANG(k)*GAzp_TL(k,ABS_H2O_IR)
-        Predictor_TL%X(k,14, COMP_WLO_IR) = ZERO
-        Predictor_TL%X(k,15, COMP_WLO_IR) = SECANG(k)*CO2_TL
-
-        ! Addtional predictors for group 1
-        IF_Group1: IF( Group_ID == GROUP_1 )THEN
-
-          Predictor_TL%X(k, 11, COMP_CO2_IR) = CO_A_TL
-
-          Predictor_TL%X(k, 16, COMP_WLO_IR) = CH4_A_TL
-          Predictor_TL%X(k, 17, COMP_WLO_IR) = TWO*CH4_A*CH4_A_TL*DT + CH4_A*CH4_A*DT_TL
-          Predictor_TL%X(k, 18, COMP_WLO_IR) = CO_A_TL
-
-          !  -----------------------
-          !  Carbon monoxide
-          !  -----------------------
-          Predictor_TL%X(k, 1,  COMP_CO_IR)   = CO_A_TL
-          Predictor_TL%X(k, 2,  COMP_CO_IR)   = CO_A_TL*DT + CO_A*DT_TL
-          Predictor_TL%X(k, 3,  COMP_CO_IR)   = (POINT_5/SQRT(CO_R))*CO_R_TL
-          Predictor_TL%X(k, 4,  COMP_CO_IR)   = CO_R_TL*DT + CO_R*DT_TL
-          Predictor_TL%X(k, 5,  COMP_CO_IR)   = CO_S_TL
-          Predictor_TL%X(k, 6,  COMP_CO_IR)   = CO_R_TL
-          Predictor_TL%X(k, 7,  COMP_CO_IR)   = CO_A_TL*DT2 + CO_A*DT2_TL
-          Predictor_TL%X(k, 8,  COMP_CO_IR)   = CO_ACOdCOzp_TL
-          Predictor_TL%X(k, 9,  COMP_CO_IR)   = CO_ACOdCOzp_TL/CO_R - CO_ACOdCOzp*CO_R_TL/CO_R**2
-          Predictor_TL%X(k, 10, COMP_CO_IR)   = CO_ACOdCOzp_TL * SQRT( PAFV%GAzp(k, ABS_CO_IR) ) + &
-                                                (POINT_5*CO_ACOdCOzp/SQRT(PAFV%GAzp(k, ABS_CO_IR))) * &
-                                                GAzp_TL(k, ABS_CO_IR)
-
-          !  -----------------------
-          !  Methane predictors
-          !  -----------------------
-          Predictor_TL%X(k, 1,  COMP_CH4_IR)  = CH4_A_TL*DT + CH4_A*DT_TL
-          Predictor_TL%X(k, 2,  COMP_CH4_IR)  = CH4_R_TL
-          Predictor_TL%X(k, 3,  COMP_CH4_IR)  = TWO*CH4_A*CH4_A_TL
-          Predictor_TL%X(k, 4,  COMP_CH4_IR)  = CH4_A_TL
-          Predictor_TL%X(k, 5,  COMP_CH4_IR)  = CH4_TL*DT + CH4*DT_TL
-          Predictor_TL%X(k, 6,  COMP_CH4_IR)  = CH4_ACH4zp_TL
-          Predictor_TL%X(k, 7,  COMP_CH4_IR)  = TWO*CH4_ACH4zp*CH4_ACH4zp_TL
-          Predictor_TL%X(k, 8,  COMP_CH4_IR)  = (POINT_5/SQRT(CH4_R))*CH4_R_TL
-          Predictor_TL%X(k, 9,  COMP_CH4_IR)  = GATzp_TL(k, ABS_CH4_IR)
-          Predictor_TL%X(k, 10, COMP_CH4_IR)  = SECANG(k)*GATzp_TL(k, ABS_CH4_IR)
-          Predictor_TL%X(k, 11, COMP_CH4_IR)  = CH4_R_TL*CH4/PAFV%GAzp(k, ABS_CH4_IR) + &
-                                                CH4_R*CH4_TL/PAFV%GAzp(k, ABS_CH4_IR) - &
-                                                CH4_R*CH4*GAzp_TL(k, ABS_CH4_IR)/PAFV%GAzp(k, ABS_CH4_IR)**2
-          !  -----------------------
-          !    N2O predictors
-          !  -----------------------
-          Predictor_TL%X(k, 1, COMP_N2O_IR)   = N2O_A_TL*DT + N2O_A*DT_TL
-          Predictor_TL%X(k, 2, COMP_N2O_IR)   = N2O_R_TL
-          Predictor_TL%X(k, 3, COMP_N2O_IR)   = N2O_TL*DT + N2O*DT_TL
-          Predictor_TL%X(k, 4, COMP_N2O_IR)   = POINT_25*N2O_A**(-POINT_75) * N2O_A_TL
-          Predictor_TL%X(k, 5, COMP_N2O_IR)   = N2O_A_TL
-          Predictor_TL%X(k, 6, COMP_N2O_IR)   = SECANG(k) * GAzp_TL(k, ABS_N2O_IR)
-          Predictor_TL%X(k, 7, COMP_N2O_IR)   = SECANG(k) * GATzp_TL(k, ABS_N2O_IR)
-          Predictor_TL%X(k, 8, COMP_N2O_IR)   = N2O_S_TL
-          Predictor_TL%X(k, 9, COMP_N2O_IR)   = GATzp_TL(k, ABS_N2O_IR)
-          Predictor_TL%X(k,10, COMP_N2O_IR)   = N2O_R_TL*N2O / PAFV%GAzp(k, ABS_N2O_IR) + &
-                                                N2O_R*N2O_TL / PAFV%GAzp(k, ABS_N2O_IR) - &
-                                                N2O_R*N2O*GAzp_TL(k, ABS_N2O_IR)/PAFV%GAzp(k, ABS_N2O_IR)**2
-          Predictor_TL%X(k,11, COMP_N2O_IR)   = CH4_A_TL
-          Predictor_TL%X(k,12, COMP_N2O_IR)   = CH4_A_TL*PAFV%GAzp(k, ABS_CH4_IR) + CH4_A*GAzp_TL(k, ABS_CH4_IR)
-          Predictor_TL%X(k,13, COMP_N2O_IR)   = CO_A_TL
-          Predictor_TL%X(k,14, COMP_N2O_IR)   = CO_A_TL*SECANG(k)*PAFV%GAzp(k, ABS_CO_IR) + &
-                                                CO_A*SECANG(k)*GAzp_TL(k, ABS_CO_IR)
-
-        END IF IF_Group1
-
-        !  -----------------------
-        !  NO2 predictors TL (GROUP_UV_NO2 only)
-        !  -----------------------
-        IF( Group_ID == GROUP_UV_NO2 )THEN
-          NO2      = Absorber(k,ABS_NO2_G8)/Ref_Absorber(k, ABS_NO2_G8)
-          NO2_TL   = Absorber_TL(k,ABS_NO2_G8)/Ref_Absorber(k, ABS_NO2_G8)
-          NO2_A    = SECANG(k)*NO2
-          NO2_A_TL = SECANG(k)*NO2_TL
-          Predictor_TL%X(k, 1, COMP_NO2_G8) = NO2_A_TL
-          Predictor_TL%X(k, 2, COMP_NO2_G8) = NO2_A_TL*DT + NO2_A*DT_TL
-          Predictor_TL%X(k, 3, COMP_NO2_G8) = NO2_A_TL*DT2 + NO2_A*DT2_TL
-        END IF
-
-      END DO Layer_Loop
-
-    END SUBROUTINE ODPS_Compute_Predictor_IR_TL
-
-    SUBROUTINE ODPS_Compute_Predictor_MW_TL()
-
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER    ::    k ! n_Layers, n_Levels
-      REAL(fp) ::    DT,           DT_TL
-      REAL(fp) ::    T,            T_TL
-      REAL(fp) ::    T2,           T2_TL
-      REAL(fp) ::    DT2,          DT2_TL
-      REAL(fp) ::    H2O,          H2O_TL
-      REAL(fp) ::    H2O_A,        H2O_A_TL
-      REAL(fp) ::    H2O_R,        H2O_R_TL
-      REAL(fp) ::    H2O_S,        H2O_S_TL
-      REAL(fp) ::    H2O_R4,       H2O_R4_TL
-      REAL(fp) ::    H2OdH2OTzp,   H2OdH2OTzp_TL
-      REAL(fp) ::    O3,           O3_TL
-      REAL(fp) ::    O3_A,         O3_A_TL
-      REAL(fp) ::    O3_R,         O3_R_TL
-
-      Layer_Loop : DO k = 1, n_Layers
+      MW_Layer_Loop : DO k = 1, n_Layers
 
         !------------------------------------------
         !  Relative Temperature
@@ -1734,8 +1547,8 @@ CONTAINS
         !-------------------------------------------
         !  Abosrber amount scalled by the reference
         !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_MW)/Ref_Absorber(k, ABS_H2O_MW)
-        H2O_TL = Absorber_TL(k,ABS_H2O_MW)/Ref_Absorber(k, ABS_H2O_MW)
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        H2O_TL = Absorber_TL(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
 
         ! Combinations of variables common to all predictor groups
         T2  = T*T
@@ -1752,89 +1565,257 @@ CONTAINS
         H2O_R  = SQRT( H2O_A )
         H2O_S  = H2O_A*H2O_A
         H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ABS_H2O_MW)
+        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
 
         H2O_A_TL  = SECANG(k)*H2O_TL
         H2O_R_TL  = (POINT_5 / SQRT(H2O_A)) * H2O_A_TL
         H2O_S_TL  = TWO * H2O_A * H2O_A_TL
         H2O_R4_TL = (POINT_5 / SQRT(H2O_R)) * H2O_R_TL
-        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ABS_H2O_MW) - &
-                        H2O * GATzp_TL(k, ABS_H2O_IR)/PAFV%GATzp(k, ABS_H2O_MW)**2
+        H2OdH2OTzp_TL = H2O_TL/PAFV%GATzp(k, ja_h2o) - &
+                        H2O * GATzp_TL(k, ja_h2o)/PAFV%GATzp(k, ja_h2o)**2
 
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
-
-       ! set number of predictors
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE
-          Predictor_TL%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        END IF
-
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-        Predictor_TL%X(k, 1, COMP_DRY_MW)  = ZERO
-        Predictor_TL%X(k, 2, COMP_DRY_MW)  = SECANG(k) * T_TL
-        Predictor_TL%X(k, 3, COMP_DRY_MW)  = SECANG(k) * T2_TL
-        Predictor_TL%X(k, 4, COMP_DRY_MW)  = T_TL
-        Predictor_TL%X(k, 5, COMP_DRY_MW)  = ZERO
-        Predictor_TL%X(k, 6, COMP_DRY_MW)  = T2_TL
-        Predictor_TL%X(k, 7, COMP_DRY_MW)  = Tz_TL(k)
-        Predictor_TL%X(:, 8:, COMP_DRY_MW) = ZERO
-       !  --------------------------------
-       !  Water vapor (line and continuum)
-       !  --------------------------------
-        Predictor_TL%X(k, 1, COMP_WET_MW) = H2O_A_TL/T - H2O_A*T_TL/T**2
-        Predictor_TL%X(k, 2, COMP_WET_MW) = H2O_A_TL*H2O/T + H2O_A*H2O_TL/T - H2O_A*H2O*T_TL/T**2
-        Predictor_TL%X(k, 3, COMP_WET_MW) = H2O_A_TL*H2O/T2**2 + H2O_A*H2O_TL/T2**2 - &
-                                            Two*H2O_A*H2O*T2_TL/T2**3
-        Predictor_TL%X(k, 4, COMP_WET_MW) = H2O_A_TL/T2 - H2O_A * T2_TL/T2**2
-        Predictor_TL%X(k, 5, COMP_WET_MW) = H2O_A_TL*H2O/T2 + H2O_A*H2O_TL/T2 - H2O_A*H2O*T2_TL/T2**2
-        Predictor_TL%X(k, 6, COMP_WET_MW) = H2O_A_TL/T2**2 - TWO*H2O_A*T2_TL/T2**3
-        Predictor_TL%X(k, 7, COMP_WET_MW) = H2O_A_TL
-        Predictor_TL%X(k, 8, COMP_WET_MW) = H2O_A_TL*DT + H2O_A*DT_TL
-        Predictor_TL%X(k, 9, COMP_WET_MW) = TWO*SECANG(k)**2 * PAFV%GAzp(k,ABS_H2O_MW)*GAzp_TL(k,ABS_H2O_MW)
-        Predictor_TL%X(k, 10,COMP_WET_MW) = SECANG(k)*GAzp_TL(k,ABS_H2O_MW)
-        Predictor_TL%X(k, 11,COMP_WET_MW) = ZERO
-        Predictor_TL%X(k, 12,COMP_WET_MW) = H2O_S_TL*H2O_A + H2O_S*H2O_A_TL
-        Predictor_TL%X(k, 13,COMP_WET_MW) = TWO*H2O_S*H2O_S_TL
-        Predictor_TL%X(k, 14,COMP_WET_MW) = H2OdH2OTzp_TL
-
-        !  -----------------------
-        !  Ozone predictors (GROUP_MW_O3 only)
-        !  -----------------------
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          O3      = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
-          O3_TL   = Absorber_TL(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
+        IF ( ja_o3 > 0 ) THEN
+          O3      = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
+          O3_TL   = Absorber_TL(k,ja_o3)/Ref_Absorber(k, ja_o3)
           O3_A    = SECANG(k)*O3
           O3_A_TL = SECANG(k)*O3_TL
           O3_R    = SQRT( O3_A )
           O3_R_TL = (POINT_5 / SQRT(O3_A)) * O3_A_TL
-          Predictor_TL%X(k, 1, COMP_OZO_MW)  = O3_A_TL
-          Predictor_TL%X(k, 2, COMP_OZO_MW)  = O3_A_TL*DT + O3_A*DT_TL
-          Predictor_TL%X(k, 3, COMP_OZO_MW)  = O3_A_TL*O3*PAFV%GAzp(k,ABS_O3_MW) &
-                                             + O3_A*O3_TL*PAFV%GAzp(k,ABS_O3_MW) &
-                                             + O3_A*O3*GAzp_TL(k,ABS_O3_MW)
-          Predictor_TL%X(k, 4, COMP_OZO_MW)  = TWO*O3_A*O3_A_TL
-          Predictor_TL%X(k, 5, COMP_OZO_MW)  = O3_A_TL*PAFV%GAzp(k,ABS_O3_MW) &
-                                             + O3_A*GAzp_TL(k,ABS_O3_MW)
-          Predictor_TL%X(k, 6, COMP_OZO_MW)  = O3_A_TL*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_MW)) &
-                                             + O3_A*POINT_5*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_MW)) &
-                                              *GAzp_TL(k,ABS_O3_MW)
-          Predictor_TL%X(k, 7, COMP_OZO_MW)  = O3_R_TL*DT + O3_R*DT_TL
-          Predictor_TL%X(k, 8, COMP_OZO_MW)  = O3_R_TL
-          Predictor_TL%X(k, 9, COMP_OZO_MW)  = O3_R_TL*O3/PAFV%GAzp(k,ABS_O3_MW) &
-                                             + O3_R*O3_TL/PAFV%GAzp(k,ABS_O3_MW) &
-                                             - O3_R*O3*GAzp_TL(k,ABS_O3_MW)/PAFV%GAzp(k,ABS_O3_MW)**2
-          Predictor_TL%X(k,10, COMP_OZO_MW)  = SECANG(k)*GAzp_TL(k,ABS_O3_MW)
-          Predictor_TL%X(k,11, COMP_OZO_MW)  = TWO*SECANG(k)**2 * PAFV%GAzp(k,ABS_O3_MW)*GAzp_TL(k,ABS_O3_MW)
         END IF
 
-      END DO Layer_Loop
+        MW_Component_Loop : DO ic = 1, GROUP_REGISTRY(Group_ID)%n_Components
+          np = Predictor_TL%n_CP(ic)
+          SELECT CASE ( GROUP_REGISTRY(Group_ID)%Component_ID(ic) )
+            CASE ( EDRY_ComID )
+              CALL TL_Kernel_DRY(k, ic)
+              Predictor_TL%X(:, 8:, ic) = ZERO
+            CASE ( WET_ComID )
+              CALL TL_Kernel_WET_MW(k, ic)
+            CASE ( OZO_ComID )
+              CALL TL_Kernel_OZO(k, ic)
+          END SELECT
+        END DO MW_Component_Loop
 
-    END SUBROUTINE ODPS_Compute_Predictor_MW_TL
+      END DO MW_Layer_Loop
+
+    END IF Basis_Select
+
+    NULLIFY(PAFV)
+
+CONTAINS
+
+    ! Position of a HITRAN absorber ID in this group's absorber roster
+    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Absorber_ID
+      INTEGER :: Position
+      INTEGER :: ja
+      Position = 0
+      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
+        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+          Position = ja
+          RETURN
+        END IF
+      END DO
+    END FUNCTION Absorber_Position
+
+    !  ----------------------
+    !   Fixed (Dry) predictors (IR and MW use the same formulation)
+    !  ----------------------
+    SUBROUTINE TL_Kernel_DRY( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1, ic)  = ZERO
+      Predictor_TL%X(k, 2, ic)  = SECANG(k) * T_TL
+      Predictor_TL%X(k, 3, ic)  = SECANG(k) * T2_TL
+      Predictor_TL%X(k, 4, ic)  = T_TL
+      Predictor_TL%X(k, 5, ic)  = ZERO
+      Predictor_TL%X(k, 6, ic)  = T2_TL
+      Predictor_TL%X(k, 7, ic)  = Tz_TL(k)
+    END SUBROUTINE TL_Kernel_DRY
+
+    !  --------------------------
+    !  Water vapor continuum predictors
+    !  --------------------------
+    SUBROUTINE TL_Kernel_WCO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1, ic) = H2O_A_TL/T - H2O_A * T_TL/T**2
+      Predictor_TL%X(k, 2, ic) = H2O_A_TL*H2O/T + H2O_A*H2O_TL/T - H2O_A*H2O*T_TL/T**2
+      Predictor_TL%X(k, 3, ic) = H2O_A_TL*H2O/T2**2 + H2O_A*H2O_TL/T2**2 - &
+                                 Two*H2O_A*H2O*T2_TL/T2**3
+      Predictor_TL%X(k, 4, ic) = H2O_A_TL/T2 - H2O_A * T2_TL/T2**2
+      Predictor_TL%X(k, 5, ic) = H2O_A_TL*H2O/T2 + H2O_A*H2O_TL/T2 - H2O_A*H2O*T2_TL/T2**2
+      Predictor_TL%X(k, 6, ic) = H2O_A_TL/T2**2 - TWO*H2O_A*T2_TL/T2**3
+      Predictor_TL%X(k, 7, ic) = H2O_A_TL
+    END SUBROUTINE TL_Kernel_WCO
+
+    !  -----------------------
+    !  Ozone predictors (same formulation for the IR and MW_O3 groups)
+    !  -----------------------
+    SUBROUTINE TL_Kernel_OZO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1, ic)  = O3_A_TL
+      Predictor_TL%X(k, 2, ic)  = O3_A_TL*DT + O3_A*DT_TL
+      Predictor_TL%X(k, 3, ic)  = O3_A_TL*O3*PAFV%GAzp(k,ja_o3) + O3_A*O3_TL*PAFV%GAzp(k,ja_o3) &
+                                   + O3_A*O3*GAzp_TL(k,ja_o3)
+      Predictor_TL%X(k, 4, ic)  = TWO*O3_A*O3_A_TL
+      Predictor_TL%X(k, 5, ic)  = O3_A_TL*PAFV%GAzp(k,ja_o3) + O3_A*GAzp_TL(k,ja_o3)
+      Predictor_TL%X(k, 6, ic)  = O3_A_TL*SQRT(SECANG(k)*PAFV%GAzp(k,ja_o3)) + &
+                                   POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ja_o3))* &
+                                   GAzp_TL(k,ja_o3)
+      Predictor_TL%X(k, 7, ic)  = O3_R_TL*DT + O3_R*DT_TL  !T*T*T
+      Predictor_TL%X(k, 8, ic)  = O3_R_TL
+      Predictor_TL%X(k, 9, ic)  = O3_R_TL*O3/PAFV%GAzp(k,ja_o3) + O3_R*O3_TL/PAFV%GAzp(k,ja_o3) &
+                                   - O3_R*O3*GAzp_TL(k,ja_o3)/PAFV%GAzp(k,ja_o3)**2
+      Predictor_TL%X(k,10, ic)  = SECANG(k)*GAzp_TL(k,ja_o3)
+      Predictor_TL%X(k,11, ic)  = TWO*SECANG(k)**2 * PAFV%GAzp(k,ja_o3)*GAzp_TL(k,ja_o3)
+    END SUBROUTINE TL_Kernel_OZO
+
+    !  -----------------------
+    !  Carbon dioxide predictors; predictor 11 (CO amount) is carried only
+    !  by rosters that request 11 predictors for CO2 (group 1)
+    !  -----------------------
+    SUBROUTINE TL_Kernel_CO2( k, ic, np )
+      INTEGER, INTENT(IN) :: k, ic, np
+      Predictor_TL%X(k, 1, ic)  = SECANG(k) * T_TL
+      Predictor_TL%X(k, 2, ic)  = SECANG(k) * T2_TL
+      Predictor_TL%X(k, 3, ic)  = T_TL
+      Predictor_TL%X(k, 4, ic)  = T2_TL
+      Predictor_TL%X(k, 5, ic)  = ZERO
+      Predictor_TL%X(k, 6, ic)  = SECANG(k)*CO2_TL
+      Predictor_TL%X(k, 7, ic)  = SECANG(k)*Tzp_TL(k)
+      Predictor_TL%X(k, 8, ic)  = TWO*SECANG(k)**2 * PAFV%GAzp(k, ja_co2)* GAzp_TL(k, ja_co2)
+      Predictor_TL%X(k, 9, ic)  = THREE*PAFV%Tzp(k)**2*Tzp_TL(k)
+      Predictor_TL%X(k, 10, ic) = SECANG(k)*( SQRT(T)*Tzp_TL(k) + (POINT_5*PAFV%Tzp(k)/SQRT(T))*T_TL )
+      IF ( np >= 11 ) THEN
+        Predictor_TL%X(k, 11, ic) = CO_A_TL
+      END IF
+    END SUBROUTINE TL_Kernel_CO2
+
+    !  --------------------------
+    !  Water-line predictors; predictors 16 - 18 (CH4/CO cross terms) are
+    !  carried only by rosters that request 18 predictors for WLO (group 1)
+    !  --------------------------
+    SUBROUTINE TL_Kernel_WLO( k, ic, np )
+      INTEGER, INTENT(IN) :: k, ic, np
+      Predictor_TL%X(k, 1, ic) = H2O_A_TL
+      Predictor_TL%X(k, 2, ic) = H2O_A_TL*DT + H2O_A*DT_TL
+      Predictor_TL%X(k, 3, ic) = H2O_S_TL
+      Predictor_TL%X(k, 4, ic) = H2O_A_TL*DT2 + H2O_A*DT2_TL
+      Predictor_TL%X(k, 5, ic) = H2O_R4_TL
+      Predictor_TL%X(k, 6, ic) = H2O_S_TL*H2O_A + H2O_S*H2O_A_TL
+      Predictor_TL%X(k, 7, ic) = H2O_R_TL
+      Predictor_TL%X(k, 8, ic) = H2O_R_TL*DT + H2O_R*DT_TL
+      Predictor_TL%X(k, 9, ic) = TWO*H2O_S*H2O_S_TL
+      Predictor_TL%X(k,10, ic) = H2OdH2OTzp_TL
+      Predictor_TL%X(k,11, ic) = H2O_R_TL*H2OdH2OTzp + H2O_R*H2OdH2OTzp_TL
+      Predictor_TL%X(k,12, ic) = TWO*SECANG(k)**2 * PAFV%GAzp(k,ja_h2o)*GAzp_TL(k,ja_h2o)
+      Predictor_TL%X(k,13, ic) = SECANG(k)*GAzp_TL(k,ja_h2o)
+      Predictor_TL%X(k,14, ic) = ZERO
+      Predictor_TL%X(k,15, ic) = SECANG(k)*CO2_TL
+      IF ( np >= 18 ) THEN
+        Predictor_TL%X(k,16, ic) = CH4_A_TL
+        Predictor_TL%X(k,17, ic) = TWO*CH4_A*CH4_A_TL*DT + CH4_A*CH4_A*DT_TL
+        Predictor_TL%X(k,18, ic) = CO_A_TL
+      END IF
+    END SUBROUTINE TL_Kernel_WLO
+
+    !  -----------------------
+    !  Carbon monoxide
+    !  -----------------------
+    SUBROUTINE TL_Kernel_CO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1,  ic)   = CO_A_TL
+      Predictor_TL%X(k, 2,  ic)   = CO_A_TL*DT + CO_A*DT_TL
+      Predictor_TL%X(k, 3,  ic)   = (POINT_5/SQRT(CO_R))*CO_R_TL
+      Predictor_TL%X(k, 4,  ic)   = CO_R_TL*DT + CO_R*DT_TL
+      Predictor_TL%X(k, 5,  ic)   = CO_S_TL
+      Predictor_TL%X(k, 6,  ic)   = CO_R_TL
+      Predictor_TL%X(k, 7,  ic)   = CO_A_TL*DT2 + CO_A*DT2_TL
+      Predictor_TL%X(k, 8,  ic)   = CO_ACOdCOzp_TL
+      Predictor_TL%X(k, 9,  ic)   = CO_ACOdCOzp_TL/CO_R - CO_ACOdCOzp*CO_R_TL/CO_R**2
+      Predictor_TL%X(k, 10, ic)   = CO_ACOdCOzp_TL * SQRT( PAFV%GAzp(k, ja_co) ) + &
+                                    (POINT_5*CO_ACOdCOzp/SQRT(PAFV%GAzp(k, ja_co))) * &
+                                    GAzp_TL(k, ja_co)
+    END SUBROUTINE TL_Kernel_CO
+
+    !  -----------------------
+    !  Methane predictors
+    !  -----------------------
+    SUBROUTINE TL_Kernel_CH4( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1,  ic)  = CH4_A_TL*DT + CH4_A*DT_TL
+      Predictor_TL%X(k, 2,  ic)  = CH4_R_TL
+      Predictor_TL%X(k, 3,  ic)  = TWO*CH4_A*CH4_A_TL
+      Predictor_TL%X(k, 4,  ic)  = CH4_A_TL
+      Predictor_TL%X(k, 5,  ic)  = CH4_TL*DT + CH4*DT_TL
+      Predictor_TL%X(k, 6,  ic)  = CH4_ACH4zp_TL
+      Predictor_TL%X(k, 7,  ic)  = TWO*CH4_ACH4zp*CH4_ACH4zp_TL
+      Predictor_TL%X(k, 8,  ic)  = (POINT_5/SQRT(CH4_R))*CH4_R_TL
+      Predictor_TL%X(k, 9,  ic)  = GATzp_TL(k, ja_ch4)
+      Predictor_TL%X(k, 10, ic)  = SECANG(k)*GATzp_TL(k, ja_ch4)
+      Predictor_TL%X(k, 11, ic)  = CH4_R_TL*CH4/PAFV%GAzp(k, ja_ch4) + &
+                                   CH4_R*CH4_TL/PAFV%GAzp(k, ja_ch4) - &
+                                   CH4_R*CH4*GAzp_TL(k, ja_ch4)/PAFV%GAzp(k, ja_ch4)**2
+    END SUBROUTINE TL_Kernel_CH4
+
+    !  -----------------------
+    !    N2O predictors
+    !  -----------------------
+    SUBROUTINE TL_Kernel_N2O( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1, ic)   = N2O_A_TL*DT + N2O_A*DT_TL
+      Predictor_TL%X(k, 2, ic)   = N2O_R_TL
+      Predictor_TL%X(k, 3, ic)   = N2O_TL*DT + N2O*DT_TL
+      Predictor_TL%X(k, 4, ic)   = POINT_25*N2O_A**(-POINT_75) * N2O_A_TL
+      Predictor_TL%X(k, 5, ic)   = N2O_A_TL
+      Predictor_TL%X(k, 6, ic)   = SECANG(k) * GAzp_TL(k, ja_n2o)
+      Predictor_TL%X(k, 7, ic)   = SECANG(k) * GATzp_TL(k, ja_n2o)
+      Predictor_TL%X(k, 8, ic)   = N2O_S_TL
+      Predictor_TL%X(k, 9, ic)   = GATzp_TL(k, ja_n2o)
+      Predictor_TL%X(k,10, ic)   = N2O_R_TL*N2O / PAFV%GAzp(k, ja_n2o) + &
+                                   N2O_R*N2O_TL / PAFV%GAzp(k, ja_n2o) - &
+                                   N2O_R*N2O*GAzp_TL(k, ja_n2o)/PAFV%GAzp(k, ja_n2o)**2
+      Predictor_TL%X(k,11, ic)   = CH4_A_TL
+      Predictor_TL%X(k,12, ic)   = CH4_A_TL*PAFV%GAzp(k, ja_ch4) + CH4_A*GAzp_TL(k, ja_ch4)
+      Predictor_TL%X(k,13, ic)   = CO_A_TL
+      Predictor_TL%X(k,14, ic)   = CO_A_TL*SECANG(k)*PAFV%GAzp(k, ja_co) + &
+                                   CO_A*SECANG(k)*GAzp_TL(k, ja_co)
+    END SUBROUTINE TL_Kernel_N2O
+
+    !  -----------------------
+    !  NO2 predictors TL (GROUP_UV_NO2)
+    !  -----------------------
+    SUBROUTINE TL_Kernel_NO2( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      NO2      = Absorber(k,ja_no2)/Ref_Absorber(k, ja_no2)
+      NO2_TL   = Absorber_TL(k,ja_no2)/Ref_Absorber(k, ja_no2)
+      NO2_A    = SECANG(k)*NO2
+      NO2_A_TL = SECANG(k)*NO2_TL
+      Predictor_TL%X(k, 1, ic) = NO2_A_TL
+      Predictor_TL%X(k, 2, ic) = NO2_A_TL*DT + NO2_A*DT_TL
+      Predictor_TL%X(k, 3, ic) = NO2_A_TL*DT2 + NO2_A*DT2_TL
+    END SUBROUTINE TL_Kernel_NO2
+
+    !  --------------------------------
+    !  Water vapor, MW (line and continuum together)
+    !  --------------------------------
+    SUBROUTINE TL_Kernel_WET_MW( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      Predictor_TL%X(k, 1, ic) = H2O_A_TL/T - H2O_A*T_TL/T**2
+      Predictor_TL%X(k, 2, ic) = H2O_A_TL*H2O/T + H2O_A*H2O_TL/T - H2O_A*H2O*T_TL/T**2
+      Predictor_TL%X(k, 3, ic) = H2O_A_TL*H2O/T2**2 + H2O_A*H2O_TL/T2**2 - &
+                                 Two*H2O_A*H2O*T2_TL/T2**3
+      Predictor_TL%X(k, 4, ic) = H2O_A_TL/T2 - H2O_A * T2_TL/T2**2
+      Predictor_TL%X(k, 5, ic) = H2O_A_TL*H2O/T2 + H2O_A*H2O_TL/T2 - H2O_A*H2O*T2_TL/T2**2
+      Predictor_TL%X(k, 6, ic) = H2O_A_TL/T2**2 - TWO*H2O_A*T2_TL/T2**3
+      Predictor_TL%X(k, 7, ic) = H2O_A_TL
+      Predictor_TL%X(k, 8, ic) = H2O_A_TL*DT + H2O_A*DT_TL
+      Predictor_TL%X(k, 9, ic) = TWO*SECANG(k)**2 * PAFV%GAzp(k,ja_h2o)*GAzp_TL(k,ja_h2o)
+      Predictor_TL%X(k, 10,ic) = SECANG(k)*GAzp_TL(k,ja_h2o)
+      Predictor_TL%X(k, 11,ic) = ZERO
+      Predictor_TL%X(k, 12,ic) = H2O_S_TL*H2O_A + H2O_S*H2O_A_TL
+      Predictor_TL%X(k, 13,ic) = TWO*H2O_S*H2O_S_TL
+      Predictor_TL%X(k, 14,ic) = H2OdH2OTzp_TL
+    END SUBROUTINE TL_Kernel_WET_MW
 
   END SUBROUTINE  ODPS_Compute_Predictor_TL
 
@@ -1970,6 +1951,21 @@ CONTAINS
     REAL(fp) ::    GAzp_AD(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_sum_AD(SIZE(Absorber, DIM=2))
     REAL(fp) ::    GATzp_AD(SIZE(Absorber, DIM=1), SIZE(Absorber, DIM=2))
+    ! Kernel dispatch bookkeeping and shared per-layer variables
+    INTEGER  :: ic_dry, ic_wlo, ic_wco, ic_ozo, ic_co2
+    INTEGER  :: ic_n2o, ic_co, ic_ch4, ic_no2, ic_wet
+    INTEGER  :: ja_h2o, ja_o3, ja_co2, ja_n2o, ja_co, ja_ch4, ja_no2
+    LOGICAL  :: has_trace
+    REAL(fp) :: DT, DT_AD, T, T_AD, T2, T2_AD, DT2, DT2_AD
+    REAL(fp) :: H2O, H2O_AD, H2O_A, H2O_A_AD, H2O_R, H2O_R_AD
+    REAL(fp) :: H2O_S, H2O_S_AD, H2O_R4, H2O_R4_AD, H2OdH2OTzp, H2OdH2OTzp_AD
+    REAL(fp) :: CO2, CO2_AD, O3, O3_AD, O3_A, O3_A_AD, O3_R, O3_R_AD
+    REAL(fp) :: NO2, NO2_AD, NO2_A, NO2_A_AD
+    REAL(fp) :: CO, CO_AD, CO_A, CO_A_AD, CO_R, CO_R_AD, CO_S, CO_S_AD
+    REAL(fp) :: CO_ACOdCOzp, CO_ACOdCOzp_AD
+    REAL(fp) :: N2O, N2O_AD, N2O_A, N2O_A_AD, N2O_R, N2O_R_AD, N2O_S, N2O_S_AD
+    REAL(fp) :: CH4, CH4_AD, CH4_A, CH4_A_AD, CH4_R, CH4_R_AD
+    REAL(fp) :: CH4_ACH4zp, CH4_ACH4zp_AD
 !JR Static initialization means only 1 copy of the variable. OpenMP over profiles
 !JR means $OPENMP_NUM_THREADS copies are needed. So change to run-time initialization
 !    TYPE(PAFV_type), POINTER  :: PAFV => NULL()
@@ -2000,16 +1996,307 @@ CONTAINS
     Tz_AD    = ZERO
 
     !----------------------------------------------------------------
-    ! Call the group specific routine for remaining computation; all
-    ! variables defined above are passed to the called routine
+    ! Per-component adjoint predictor computation. Unlike the forward
+    ! and tangent-linear cases, the ORDER of the adjoint kernels is
+    ! bit-significant: adjoint contributions accumulate into shared
+    ! variables, and floating-point sums depend on evaluation order.
+    ! The kernel call sequence below reproduces the heritage monolith
+    ! order exactly: DRY, WCO, NO2, OZO, CO2, WLO (with the group-1
+    ! extension), CO, CH4, N2O, then the trace-gas variable chains,
+    ! then the common variable chains. Do not reorder.
     !----------------------------------------------------------------
 
-    SELECT CASE( Group_ID )
-      CASE( GROUP_1, GROUP_2, GROUP_UV_NO2 )
-         CALL ODPS_Compute_Predictor_IR_AD()
-      CASE( GROUP_3, GROUP_MW_O3 )
-         CALL ODPS_Compute_Predictor_MW_AD()
-    END SELECT
+    ! Resolve each gas's position in this group's absorber roster
+    ja_h2o = Absorber_Position(H2O_ID)
+    ja_o3  = Absorber_Position(O3_ID)
+    ja_co2 = Absorber_Position(CO2_ID)
+    ja_n2o = Absorber_Position(N2O_ID)
+    ja_co  = Absorber_Position(CO_ID)
+    ja_ch4 = Absorber_Position(CH4_ID)
+    ja_no2 = Absorber_Position(NO2_ID)
+    has_trace = ( ja_co > 0 )   ! CO/CH4/N2O travel together (group 1)
+
+    ! Resolve each component's position in this group's roster
+    ic_dry = Component_Position(DRY_ComID_G1)
+    IF ( ic_dry == 0 ) ic_dry = Component_Position(DRY_ComID_G2)
+    IF ( ic_dry == 0 ) ic_dry = Component_Position(EDRY_ComID)
+    ic_wlo = Component_Position(WLO_ComID)
+    ic_wco = Component_Position(WCO_ComID)
+    ic_ozo = Component_Position(OZO_ComID)
+    ic_co2 = Component_Position(CO2_ComID)
+    ic_n2o = Component_Position(N2O_ComID)
+    ic_co  = Component_Position(CO_ComID)
+    ic_ch4 = Component_Position(CH4_ComID)
+    ic_no2 = Component_Position(NO2_ComID)
+    ic_wet = Component_Position(WET_ComID)
+
+    ! Zero the adjoint accumulators (once per call, as in the heritage code)
+    DT_AD          = ZERO
+    T_AD           = ZERO
+    T2_AD          = ZERO
+    DT2_AD         = ZERO
+    H2O_AD         = ZERO
+    H2O_A_AD       = ZERO
+    H2O_R_AD       = ZERO
+    H2O_S_AD       = ZERO
+    H2O_R4_AD      = ZERO
+    H2OdH2OTzp_AD  = ZERO
+    CO2_AD         = ZERO
+    O3_AD          = ZERO
+    O3_A_AD        = ZERO
+    O3_R_AD        = ZERO
+    NO2_AD         = ZERO
+    NO2_A_AD       = ZERO
+    CO_AD          = ZERO
+    CO_A_AD        = ZERO
+    CO_R_AD        = ZERO
+    CO_S_AD        = ZERO
+    CO_ACOdCOzp_AD = ZERO
+    N2O_AD         = ZERO
+    N2O_A_AD       = ZERO
+    N2O_R_AD       = ZERO
+    N2O_S_AD       = ZERO
+    CH4_AD         = ZERO
+    CH4_A_AD       = ZERO
+    CH4_R_AD       = ZERO
+    CH4_ACH4zp_AD  = ZERO
+
+    Basis_Select: IF ( GROUP_REGISTRY(Group_ID)%Basis == BASIS_IR ) THEN
+
+      IR_Layer_Loop : DO k = n_Layers, 1, -1
+
+        !------------------------------------------
+        !  Relative Temperature
+        !------------------------------------------
+        dT = Temperature(k) - Ref_Temperature(k)
+        T = Temperature(k) / Ref_Temperature(k)
+
+        !-------------------------------------------
+        !  Abosrber amount scalled by the reference
+        !-------------------------------------------
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+        O3  = Absorber(k,ja_o3)/Ref_absorber(k,ja_o3)
+        CO2 = Absorber(k,ja_co2)/Ref_absorber(k,ja_co2)
+
+        ! Combinations of variables common to all predictor groups
+        T2   = T*T
+        DT2  = DT*ABS( DT )
+
+        H2O_A = SECANG(k)*H2O
+        H2O_R  = SQRT( H2O_A )
+        H2O_S  = H2O_A*H2O_A
+        H2O_R4 = SQRT( H2O_R )
+        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+
+        O3_A = SECANG(k)*O3
+        O3_R = SQRT( O3_A )
+
+        IF( has_trace )THEN
+          CO  = Absorber(k,ja_co)/Ref_absorber(k, ja_co)
+          N2O = Absorber(k,ja_n2o)/Ref_absorber(k,ja_n2o)
+          CH4 = Absorber(k,ja_ch4)/Ref_absorber(k,ja_ch4)
+
+          N2O_A = SECANG(k)*N2O
+          N2O_R = SQRT( N2O_A )
+          N2O_S = N2O_A*N2O_A
+
+          CO_A = SECANG(k)*CO
+          CO_R = SQRT( CO_A )
+          CO_S = CO_A*CO_A
+          CO_ACOdCOzp = CO_A*CO/PAFV%GAzp(k, ja_co)
+
+          CH4_A = SECANG(k)*CH4
+          CH4_R = SQRT(CH4_A)
+          CH4_ACH4zp = SECANG(k)*PAFV%GAzp(k, ja_ch4)
+
+        END IF
+
+        ! Adjoint kernels in the heritage monolith order (see note above)
+        CALL AD_Kernel_DRY(k, ic_dry)
+        CALL AD_Kernel_WCO(k, ic_wco)
+        IF ( ic_no2 > 0 ) CALL AD_Kernel_NO2(k, ic_no2)
+        CALL AD_Kernel_OZO_IR(k, ic_ozo)
+        CALL AD_Kernel_CO2(k, ic_co2)
+        CALL AD_Kernel_WLO(k, ic_wlo, GROUP_REGISTRY(Group_ID)%n_Predictors(ic_wlo))
+        IF ( has_trace ) THEN
+          CALL AD_Kernel_CO(k, ic_co)
+          CALL AD_Kernel_CH4(k, ic_ch4)
+          CALL AD_Kernel_N2O(k, ic_n2o)
+
+          ! Trace-gas variable chains (group 1)
+          GAzp_AD(k, ja_ch4) = GAzp_AD(k, ja_ch4) + SECANG(k)*CH4_ACH4zp_AD
+          CH4_A_AD = CH4_A_AD + (POINT_5/SQRT(CH4_A)) * CH4_R_AD
+          CH4_AD = CH4_AD + SECANG(k)*CH4_A_AD
+          CH4_ACH4zp_AD = ZERO
+          CH4_R_AD =      ZERO
+          CH4_A_AD =      ZERO
+
+          GAzp_AD(k, ja_co) = GAzp_AD(k, ja_co)                                      &
+                              - CO_ACOdCOzp_AD*CO_A*CO/PAFV%GAzp(k, ja_co)**2
+          CO_A_AD = CO_A_AD + CO_ACOdCOzp_AD*CO/PAFV%GAzp(k, ja_co)                  &
+                            + CO_S_AD*TWO * CO_A                                     &
+                            + CO_R_AD*POINT_5/SQRT(CO_A)
+          CO_AD = CO_AD + CO_ACOdCOzp_AD*CO_A/PAFV%GAzp(k, ja_co)                    &
+                        + CO_A_AD*SECANG(k)
+          CO_ACOdCOzp_AD = ZERO
+          CO_S_AD        = ZERO
+          CO_R_AD        = ZERO
+          CO_A_AD        = ZERO
+
+          N2O_A_AD = N2O_A_AD + N2O_R_AD * POINT_5 / SQRT(N2O_A)                    &
+                              + N2O_S_AD * TWO * N2O_A
+          N2O_AD = N2O_AD + N2O_A_AD * SECANG(k)
+          N2O_A_AD = ZERO
+          N2O_R_AD = ZERO
+          N2O_S_AD = ZERO
+
+          Absorber_AD(k,ja_ch4) = Absorber_AD(k,ja_ch4)                              &
+                                    + CH4_AD/Ref_absorber(k,ja_ch4)
+          Absorber_AD(k,ja_n2o) = Absorber_AD(k,ja_n2o)                              &
+                                    + N2O_AD/Ref_absorber(k,ja_n2o)
+          Absorber_AD(k,ja_co)  = Absorber_AD(k,ja_co)                               &
+                                    + CO_AD/Ref_absorber(k, ja_co)
+          CO_AD  = ZERO
+          N2O_AD = ZERO
+          CH4_AD = ZERO
+
+        END IF
+
+        ! Combinations of variables common to all predictor groups
+
+        O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
+        O3_AD = O3_AD + O3_A_AD * SECANG(k)
+        O3_A_AD = ZERO
+        O3_R_AD = ZERO
+
+        GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                    &
+                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
+        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
+        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
+                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
+        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
+               + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
+
+        H2O_A_AD      = ZERO
+        H2O_R_AD      = ZERO
+        H2O_S_AD      = ZERO
+        H2O_R4_AD     = ZERO
+        H2OdH2OTzp_AD = ZERO
+
+        IF( DT > ZERO) THEN
+          DT_AD = DT_AD + DT2_AD*TWO*DT
+        ELSE
+          DT_AD = DT_AD - DT2_AD*TWO*DT
+        ENDIF
+        T_AD = T_AD + T2_AD*TWO*T
+        T2_AD   = ZERO
+        DT2_AD  = ZERO
+
+        !-------------------------------------------
+        !  Abosrber amount scalled by the reference
+        !-------------------------------------------
+        Absorber_AD(k,ja_co2) = Absorber_AD(k,ja_co2)            &
+                                  + CO2_AD / Ref_absorber(k,ja_co2)
+        Absorber_AD(k,ja_o3)  = Absorber_AD(k,ja_o3)             &
+                                  + O3_AD / Ref_absorber(k,ja_o3)
+        Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
+                                  + H2O_AD / Ref_Absorber(k, ja_h2o)
+        H2O_AD = ZERO
+        O3_AD  = ZERO
+        CO2_AD = ZERO
+
+        !------------------------------------------
+        !  Relative Temperature
+        !------------------------------------------
+        Temperature_AD(k) = Temperature_AD(k) + T_AD/Ref_Temperature(k) &
+                          + dT_AD
+        dT_AD = ZERO
+        T_AD  = ZERO
+
+      END DO IR_Layer_Loop
+
+    ELSE Basis_Select   ! BASIS_MW
+
+      ! set number of predictors
+      Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
+
+      MW_Layer_Loop : DO k = n_Layers, 1, -1
+
+        !------------------------------------------
+        !  Relative Temperature
+        !------------------------------------------
+        dT = Temperature(k) - Ref_Temperature(k)
+        T = Temperature(k) / Ref_Temperature(k)
+
+        !-------------------------------------------
+        !  Abosrber amount scalled by the reference
+        !-------------------------------------------
+        H2O = Absorber(k,ja_h2o)/Ref_Absorber(k, ja_h2o)
+
+        ! Combinations of variables common to all predictor groups
+        T2  = T*T
+        DT2 = DT*ABS( DT )
+
+        H2O_A = SECANG(k)*H2O
+        H2O_R  = SQRT( H2O_A )
+        H2O_S  = H2O_A*H2O_A
+        H2O_R4 = SQRT( H2O_R )
+        H2OdH2OTzp = H2O/PAFV%GATzp(k, ja_h2o)
+
+        IF ( ja_o3 > 0 ) THEN
+          O3   = Absorber(k,ja_o3)/Ref_Absorber(k, ja_o3)
+          O3_A = SECANG(k)*O3
+          O3_R = SQRT( O3_A )
+        END IF
+
+        ! Adjoint kernels in the heritage monolith order (see note above)
+        CALL AD_Kernel_DRY(k, ic_dry)
+        CALL AD_Kernel_WET_MW(k, ic_wet)
+        IF ( ic_ozo > 0 ) CALL AD_Kernel_OZO_MW(k, ic_ozo)
+
+        !-------------------------------------------
+        !  Abosrber amount scalled by the reference
+        !-------------------------------------------
+
+        ! Combinations of variables common to all predictor groups
+
+        GATzp_AD(k, ja_h2o) = GATzp_AD(k, ja_h2o)                                    &
+                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ja_h2o)**2
+        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
+        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
+                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
+        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
+               + H2OdH2OTzp_AD / PAFV%GATzp(k, ja_h2o)
+        H2O_A_AD      = ZERO
+        H2O_R_AD      = ZERO
+        H2O_S_AD      = ZERO
+        H2O_R4_AD     = ZERO
+        H2OdH2OTzp_AD = ZERO
+
+        IF( DT > ZERO) THEN
+          DT_AD = DT_AD + DT2_AD*TWO*DT
+        ELSE
+          DT_AD = DT_AD - DT2_AD*TWO*DT
+        ENDIF
+        T_AD = T_AD + T2_AD*TWO*T
+        T2_AD   = ZERO
+        DT2_AD  = ZERO
+
+        Absorber_AD(k,ja_h2o) = Absorber_AD(k,ja_h2o)            &
+                                  + H2O_AD / Ref_Absorber(k, ja_h2o)
+        H2O_AD = ZERO
+
+        !------------------------------------------
+        !  Relative Temperature
+        !------------------------------------------
+        Temperature_AD(k) = Temperature_AD(k) + T_AD/Ref_Temperature(k) &
+                          + dT_AD
+        dT_AD = ZERO
+        T_AD  = ZERO
+
+      END DO MW_Layer_Loop
+
+    END IF Basis_Select
 
     Adjoint_Layer_Loop : DO k = n_Layers, 1, -1
 
@@ -2041,845 +2328,545 @@ CONTAINS
 
 CONTAINS
 
-    SUBROUTINE ODPS_Compute_Predictor_IR_AD()
-
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER  :: k ! n_Layers, n_Levels
-      REAL(fp) :: DT,            DT_AD
-      REAL(fp) :: T,             T_AD
-      REAL(fp) :: T2,            T2_AD
-      REAL(fp) :: DT2,           DT2_AD
-      REAL(fp) :: H2O,           H2O_AD
-      REAL(fp) :: H2O_A,         H2O_A_AD
-      REAL(fp) :: H2O_R,         H2O_R_AD
-      REAL(fp) :: H2O_S,         H2O_S_AD
-      REAL(fp) :: H2O_R4,        H2O_R4_AD
-      REAL(fp) :: H2OdH2OTzp,    H2OdH2OTzp_AD
-      REAL(fp) :: CO2,           CO2_AD
-      REAL(fp) :: O3,            O3_AD
-      REAL(fp) :: O3_A,          O3_A_AD
-      REAL(fp) :: O3_R,          O3_R_AD
-      REAL(fp) :: NO2,           NO2_AD
-      REAL(fp) :: NO2_A,         NO2_A_AD
-      REAL(fp) :: CO,            CO_AD
-      REAL(fp) :: CO_A,          CO_A_AD
-      REAL(fp) :: CO_R,          CO_R_AD
-      REAL(fp) :: CO_S,          CO_S_AD
-      REAL(fp) :: CO_ACOdCOzp,   CO_ACOdCOzp_AD
-      REAL(fp) :: N2O,           N2O_AD
-      REAL(fp) :: N2O_A,         N2O_A_AD
-      REAL(fp) :: N2O_R,         N2O_R_AD
-      REAL(fp) :: N2O_S,         N2O_S_AD
-      REAL(fp) :: CH4,           CH4_AD
-      REAL(fp) :: CH4_A,         CH4_A_AD
-      REAL(fp) :: CH4_R,         CH4_R_AD
-      REAL(fp) :: CH4_ACH4zp,    CH4_ACH4zp_AD
-
-      DT_AD          = ZERO
-      T_AD           = ZERO
-      T2_AD          = ZERO
-      DT2_AD         = ZERO
-      H2O_AD         = ZERO
-      H2O_A_AD       = ZERO
-      H2O_R_AD       = ZERO
-      H2O_S_AD       = ZERO
-      H2O_R4_AD      = ZERO
-      H2OdH2OTzp_AD  = ZERO
-      CO2_AD         = ZERO
-      O3_AD          = ZERO
-      O3_A_AD        = ZERO
-      O3_R_AD        = ZERO
-      NO2_AD         = ZERO
-      NO2_A_AD       = ZERO
-      CO_AD          = ZERO
-      CO_A_AD        = ZERO
-      CO_R_AD        = ZERO
-      CO_S_AD        = ZERO
-      CO_ACOdCOzp_AD = ZERO
-      N2O_AD         = ZERO
-      N2O_A_AD       = ZERO
-      N2O_R_AD       = ZERO
-      N2O_S_AD       = ZERO
-      CH4_AD         = ZERO
-      CH4_A_AD       = ZERO
-      CH4_R_AD       = ZERO
-      CH4_ACH4zp_AD  = ZERO
-
-      Layer_Loop : DO k = n_Layers, 1, -1
-
-        !------------------------------------------
-        !  Relative Temperature
-        !------------------------------------------
-        dT = Temperature(k) - Ref_Temperature(k)
-        T = Temperature(k) / Ref_Temperature(k)
-
-        !-------------------------------------------
-        !  Abosrber amount scalled by the reference
-        !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_IR)/Ref_Absorber(k, ABS_H2O_IR)
-        O3  = Absorber(k,ABS_O3_IR)/Ref_absorber(k,ABS_O3_IR)
-        CO2 = Absorber(k,ABS_CO2_IR)/Ref_absorber(k,ABS_CO2_IR)
-
-        ! Combinations of variables common to all predictor groups
-        T2   = T*T
-        DT2  = DT*ABS( DT )
-
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ABS_H2O_IR)
-
-        O3_A = SECANG(k)*O3
-        O3_R = SQRT( O3_A )
-
-        IF( Group_ID == GROUP_1 )THEN
-          CO  = Absorber(k,ABS_CO_IR)/Ref_absorber(k, ABS_CO_IR)
-          N2O = Absorber(k,ABS_N2O_IR)/Ref_absorber(k,ABS_N2O_IR)
-          CH4 = Absorber(k,ABS_CH4_IR)/Ref_absorber(k,ABS_CH4_IR)
-
-          N2O_A = SECANG(k)*N2O
-          N2O_R = SQRT( N2O_A )
-          N2O_S = N2O_A*N2O_A
-
-          CO_A = SECANG(k)*CO
-          CO_R = SQRT( CO_A )
-          CO_S = CO_A*CO_A
-          CO_ACOdCOzp = CO_A*CO/PAFV%GAzp(k, ABS_CO_IR)
-
-          CH4_A = SECANG(k)*CH4
-          CH4_R = SQRT(CH4_A)
-          CH4_ACH4zp = SECANG(k)*PAFV%GAzp(k, ABS_CH4_IR)
-
+    ! Position of a HITRAN absorber ID in this group's absorber roster
+    PURE FUNCTION Absorber_Position( Absorber_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Absorber_ID
+      INTEGER :: Position
+      INTEGER :: ja
+      Position = 0
+      DO ja = 1, GROUP_REGISTRY(Group_ID)%n_Absorbers
+        IF ( GROUP_REGISTRY(Group_ID)%Absorber_ID(ja) == Absorber_ID ) THEN
+          Position = ja
+          RETURN
         END IF
+      END DO
+    END FUNCTION Absorber_Position
 
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
-
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-        T_AD     = T_AD                                            &
-                   + Predictor_AD%X(k, 2, COMP_DRY_IR) * SECANG(k) &
-                   + Predictor_AD%X(k, 4, COMP_DRY_IR)
-        T2_AD    = T2_AD                                           &
-                   + Predictor_AD%X(k, 3, COMP_DRY_IR) * SECANG(k) &
-                   + Predictor_AD%X(k, 6, COMP_DRY_IR)
-        Tz_AD(k) = Tz_AD(k) + Predictor_AD%X(k, 7, COMP_DRY_IR)
-
-        Predictor_AD%X(k, 1, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 2, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 3, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 4, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 5, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 6, COMP_DRY_IR)  = ZERO
-        Predictor_AD%X(k, 7, COMP_DRY_IR)  = ZERO
-
-       !  --------------------------
-       !  Water vapor continuum predictors
-       !  --------------------------
-        H2O_A_AD = H2O_A_AD                                         &
-                   + Predictor_AD%X(k, 1, COMP_WCO_IR)/T            &
-                   + Predictor_AD%X(k, 2, COMP_WCO_IR)*H2O/T        &
-                   + Predictor_AD%X(k, 3, COMP_WCO_IR)*H2O/T2**2    &
-                   + Predictor_AD%X(k, 4, COMP_WCO_IR)/T2           &
-                   + Predictor_AD%X(k, 5, COMP_WCO_IR)*H2O/T2       &
-                   + Predictor_AD%X(k, 6, COMP_WCO_IR)/T2**2        &
-                   + Predictor_AD%X(k, 7, COMP_WCO_IR)
-        T_AD     = T_AD                                                &
-                   - Predictor_AD%X(k, 1, COMP_WCO_IR)*H2O_A/T**2      &
-                   - Predictor_AD%X(k, 2, COMP_WCO_IR)*H2O_A*H2O/T**2
-        H2O_AD   = H2O_AD                                          &
-                   + Predictor_AD%X(k, 2, COMP_WCO_IR)*H2O_A/T     &
-                   + Predictor_AD%X(k, 3, COMP_WCO_IR)*H2O_A/T2**2 &
-                   + Predictor_AD%X(k, 5, COMP_WCO_IR)*H2O_A/T2
-        T2_AD    = T2_AD                                                   &
-                   - Predictor_AD%X(k, 3, COMP_WCO_IR)*TWO*H2O_A*H2O/T2**3 &
-                   - Predictor_AD%X(k, 4, COMP_WCO_IR)*H2O_A/T2**2         &
-                   - Predictor_AD%X(k, 5, COMP_WCO_IR)*H2O_A*H2O/T2**2     &
-                   - Predictor_AD%X(k, 6, COMP_WCO_IR)*TWO*H2O_A/T2**3
-
-        Predictor_AD%X(k, 1, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 2, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 3, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 4, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 5, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 6, COMP_WCO_IR) = ZERO
-        Predictor_AD%X(k, 7, COMP_WCO_IR) = ZERO
-
-        !  -----------------------
-        !  NO2 predictors AD (GROUP_UV_NO2 only); adjoint of the compact set
-        !  X1=NO2_A, X2=NO2_A*DT, X3=NO2_A*DT2, NO2_A=secang*NO2, NO2=Abs/Ref.
-        !  -----------------------
-        IF( Group_ID == GROUP_UV_NO2 )THEN
-          NO2   = Absorber(k,ABS_NO2_G8)/Ref_Absorber(k, ABS_NO2_G8)
-          NO2_A = SECANG(k)*NO2
-
-          NO2_A_AD = NO2_A_AD                                       &
-                     + Predictor_AD%X(k, 1, COMP_NO2_G8)            &
-                     + Predictor_AD%X(k, 2, COMP_NO2_G8)*DT         &
-                     + Predictor_AD%X(k, 3, COMP_NO2_G8)*DT2
-          DT_AD    = DT_AD  + Predictor_AD%X(k, 2, COMP_NO2_G8)*NO2_A
-          DT2_AD   = DT2_AD + Predictor_AD%X(k, 3, COMP_NO2_G8)*NO2_A
-          Predictor_AD%X(k, 1, COMP_NO2_G8) = ZERO
-          Predictor_AD%X(k, 2, COMP_NO2_G8) = ZERO
-          Predictor_AD%X(k, 3, COMP_NO2_G8) = ZERO
-
-          NO2_AD   = NO2_AD + NO2_A_AD*SECANG(k)
-          NO2_A_AD = ZERO
-          Absorber_AD(k,ABS_NO2_G8) = Absorber_AD(k,ABS_NO2_G8)     &
-                                    + NO2_AD/Ref_Absorber(k, ABS_NO2_G8)
-          NO2_AD   = ZERO
+    ! Position of a component ID in this group's component roster
+    PURE FUNCTION Component_Position( Component_ID ) RESULT( Position )
+      INTEGER, INTENT(IN) :: Component_ID
+      INTEGER :: Position
+      INTEGER :: jc
+      Position = 0
+      DO jc = 1, GROUP_REGISTRY(Group_ID)%n_Components
+        IF ( GROUP_REGISTRY(Group_ID)%Component_ID(jc) == Component_ID ) THEN
+          Position = jc
+          RETURN
         END IF
-
-        !  -----------------------
-        !  Ozone predictors
-        !  -----------------------
-
-        O3_A_AD = O3_A_AD                                                               &
-                  + Predictor_AD%X(k, 1, COMP_OZO_IR)                                   &
-                  + Predictor_AD%X(k, 2, COMP_OZO_IR)*DT                                &
-                  + Predictor_AD%X(k, 3, COMP_OZO_IR)*O3*PAFV%GAzp(k,ABS_O3_IR)         &
-                  + Predictor_AD%X(k, 4, COMP_OZO_IR)*TWO*O3_A                          &
-                  + Predictor_AD%X(k, 5, COMP_OZO_IR)*PAFV%GAzp(k,ABS_O3_IR)            &
-                  + Predictor_AD%X(k, 6, COMP_OZO_IR)*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_IR))
-
-        DT_AD   = DT_AD                                                                 &
-                  + Predictor_AD%X(k, 2, COMP_OZO_IR)*O3_A                              &
-                  + Predictor_AD%X(k, 7, COMP_OZO_IR)*O3_R
-
-        O3_AD   = O3_AD                                                                 &
-                  + Predictor_AD%X(k, 3, COMP_OZO_IR)*O3_A*PAFV%GAzp(k,ABS_O3_IR)       &
-                  + Predictor_AD%X(k, 9, COMP_OZO_IR)*O3_R/PAFV%GAzp(k,ABS_O3_IR)
-
-        GAzp_AD(k,ABS_O3_IR) = GAzp_AD(k,ABS_O3_IR)                                     &
-                  + Predictor_AD%X(k, 3, COMP_OZO_IR)*O3_A*O3                           &
-                  + Predictor_AD%X(k, 5, COMP_OZO_IR)*O3_A                              &
-                  + Predictor_AD%X(k, 6, COMP_OZO_IR)*POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_IR)) &
-                  - Predictor_AD%X(k, 9, COMP_OZO_IR)*O3_R*O3/PAFV%GAzp(k,ABS_O3_IR)**2 &
-                  + Predictor_AD%X(k,10, COMP_OZO_IR)*SECANG(k)                         &
-                  + Predictor_AD%X(k,11, COMP_OZO_IR)*TWO*SECANG(k)**2*PAFV%GAzp(k,ABS_O3_IR)
-
-        O3_R_AD = O3_R_AD                                                               &
-                  + Predictor_AD%X(k, 7, COMP_OZO_IR)*DT                                &
-                  + Predictor_AD%X(k, 8, COMP_OZO_IR)                                   &
-                  + Predictor_AD%X(k, 9, COMP_OZO_IR)*O3/PAFV%GAzp(k,ABS_O3_IR)
-
-!        H2O_A_AD= H2O_A_AD + Predictor_AD%X(k, 12, COMP_OZO_IR)
-
-!        GAzp_AD(k,ABS_H2O_IR) = GAzp_AD(k,ABS_H2O_IR)                                   &
-!                  + Predictor_AD%X(k, 13, COMP_OZO_IR)*SECANG(k)
-
-        Predictor_AD%X(k, 1, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 2, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 3, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 4, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 5, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 6, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 7, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 8, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k, 9, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k,10, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k,11, COMP_OZO_IR)  = ZERO
-
-        Predictor_AD%X(k,12, COMP_OZO_IR)  = ZERO
-        Predictor_AD%X(k,13, COMP_OZO_IR)  = ZERO
-
-        !  -----------------------
-        !  Carbon dioxide predictors
-        !  -----------------------
-        T_AD      = T_AD                                                &
-                    + Predictor_AD%X(k, 1, COMP_CO2_IR)*SECANG(k)       &
-                    + Predictor_AD%X(k, 3, COMP_CO2_IR)                 &
-                    + Predictor_AD%X(k, 10, COMP_CO2_IR)*SECANG(k)*(POINT_5*PAFV%Tzp(k)/SQRT(T))
-
-        T2_AD     = T2_AD                                               &
-                    + Predictor_AD%X(k, 2, COMP_CO2_IR)*SECANG(k)       &
-                    + Predictor_AD%X(k, 4, COMP_CO2_IR)
-
-        CO2_AD    = CO2_AD + Predictor_AD%X(k, 6, COMP_CO2_IR)*SECANG(k)
-
-        Tzp_AD(k) = Tzp_AD(k)                                           &
-                    + Predictor_AD%X(k, 7, COMP_CO2_IR)*SECANG(k)       &
-                    + Predictor_AD%X(k, 9, COMP_CO2_IR)*THREE*PAFV%Tzp(k)**2 &
-                    + Predictor_AD%X(k, 10, COMP_CO2_IR)*SECANG(k)*SQRT(T)
-
-        GAzp_AD(k, ABS_CO2_IR) = GAzp_AD(k, ABS_CO2_IR)                 &
-                    + Predictor_AD%X(k, 8, COMP_CO2_IR)*TWO*SECANG(k)**2*PAFV%GAzp(k, ABS_CO2_IR)
-
-
-        Predictor_AD%X(k, 1, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 2, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 3, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 4, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 5, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 6, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 7, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 8, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k, 9, COMP_CO2_IR)  = ZERO
-        Predictor_AD%X(k,10, COMP_CO2_IR)  = ZERO
-
-        !  --------------------------
-        !  Water-line predictors
-        !  --------------------------
-
-        H2O_A_AD = H2O_A_AD                                          &
-                   + Predictor_AD%X(k, 1, COMP_WLO_IR)               &
-                   + Predictor_AD%X(k, 2, COMP_WLO_IR)*DT            &
-                   + Predictor_AD%X(k, 4, COMP_WLO_IR)*DT2           &
-                   + Predictor_AD%X(k, 6, COMP_WLO_IR)*H2O_S
-
-        DT_AD    = DT_AD                                             &
-                   + Predictor_AD%X(k, 2, COMP_WLO_IR)*H2O_A         &
-                   + Predictor_AD%X(k, 8, COMP_WLO_IR)*H2O_R
-
-        H2O_S_AD = H2O_S_AD                                          &
-                   + Predictor_AD%X(k, 3, COMP_WLO_IR)               &
-                   + Predictor_AD%X(k, 6, COMP_WLO_IR)*H2O_A         &
-                   + Predictor_AD%X(k, 9, COMP_WLO_IR)*TWO*H2O_S
-
-        DT2_AD   = DT2_AD + Predictor_AD%X(k, 4, COMP_WLO_IR)*H2O_A
-
-        H2O_R4_AD= H2O_R4_AD + Predictor_AD%X(k, 5, COMP_WLO_IR)
-
-        H2O_R_AD = H2O_R_AD                                          &
-                   + Predictor_AD%X(k, 7, COMP_WLO_IR)               &
-                   + Predictor_AD%X(k, 8, COMP_WLO_IR)*DT            &
-                   + Predictor_AD%X(k,11, COMP_WLO_IR)*H2OdH2OTzp
-
-        H2OdH2OTzp_AD = H2OdH2OTzp_AD                                &
-                   + Predictor_AD%X(k,10, COMP_WLO_IR)               &
-                   + Predictor_AD%X(k,11, COMP_WLO_IR)*H2O_R
-
-        GAzp_AD(k,ABS_H2O_IR) = GAzp_AD(k,ABS_H2O_IR)                                            &
-                   + Predictor_AD%X(k,12, COMP_WLO_IR)*TWO*SECANG(k)**2*PAFV%GAzp(k,ABS_H2O_IR)  &
-                   + Predictor_AD%X(k,13, COMP_WLO_IR)*SECANG(k)
-
-        CO2_AD   = CO2_AD + Predictor_AD%X(k,15, COMP_WLO_IR)*SECANG(k)
-
-        Predictor_AD%X(k, 1, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 2, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 3, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 4, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 5, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 6, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 7, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 8, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k, 9, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,10, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,11, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,12, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,13, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,14, COMP_WLO_IR) = ZERO
-        Predictor_AD%X(k,15, COMP_WLO_IR) = ZERO
-
-        ! Addtional predictors for group 1
-        IF_Group1: IF( Group_ID == GROUP_1 )THEN
-
-          CO_A_AD  = CO_A_AD   + Predictor_AD%X(k, 18, COMP_WLO_IR)         &
-                               + Predictor_AD%X(k, 11, COMP_CO2_IR)
-          CH4_A_AD = CH4_A_AD                                               &
-                     + Predictor_AD%X(k, 16, COMP_WLO_IR)                   &
-                     + Predictor_AD%X(k, 17, COMP_WLO_IR)*TWO*CH4_A*DT
-          DT_AD    = DT_AD + Predictor_AD%X(k, 17, COMP_WLO_IR)*CH4_A*CH4_A
-
-          Predictor_AD%X(k, 16, COMP_WLO_IR) = ZERO
-          Predictor_AD%X(k, 17, COMP_WLO_IR) = ZERO
-          Predictor_AD%X(k, 18, COMP_WLO_IR) = ZERO
-          Predictor_AD%X(k, 11, COMP_CO2_IR) = ZERO
-
-          !  -----------------------
-          !  Carbon monoxide
-          !  -----------------------
-
-          CO_A_AD = CO_A_AD                                                      &
-                    + Predictor_AD%X(k, 1,  COMP_CO_IR)                          &
-                    + Predictor_AD%X(k, 2,  COMP_CO_IR)*DT                       &
-                    + Predictor_AD%X(k, 7,  COMP_CO_IR)*DT2
-
-          DT_AD   = DT_AD                                                        &
-                    + Predictor_AD%X(k, 2,  COMP_CO_IR)*CO_A                     &
-                    + Predictor_AD%X(k, 4,  COMP_CO_IR)*CO_R
-
-          CO_R_AD = CO_R_AD                                                      &
-                    + Predictor_AD%X(k, 3,  COMP_CO_IR)*POINT_5/SQRT(CO_R)       &
-                    + Predictor_AD%X(k, 4,  COMP_CO_IR)*DT                       &
-                    + Predictor_AD%X(k, 6,  COMP_CO_IR)                          &
-                    - Predictor_AD%X(k, 9,  COMP_CO_IR)*CO_ACOdCOzp/CO_R**2
-
-          CO_S_AD = CO_S_AD + Predictor_AD%X(k, 5,  COMP_CO_IR)
-
-          DT2_AD  = DT2_AD + Predictor_AD%X(k, 7,  COMP_CO_IR)*CO_A
-
-          CO_ACOdCOzp_AD = CO_ACOdCOzp_AD                                        &
-                     + Predictor_AD%X(k, 8,  COMP_CO_IR)                         &
-                     + Predictor_AD%X(k, 9,  COMP_CO_IR)/CO_R                    &
-                     + Predictor_AD%X(k,10,  COMP_CO_IR)*SQRT(PAFV%GAzp(k, ABS_CO_IR))
-
-          GAzp_AD(k, ABS_CO_IR) = GAzp_AD(k, ABS_CO_IR)                          &
-                     + Predictor_AD%X(k, 10, COMP_CO_IR)*                        &
-                       POINT_5*CO_ACOdCOzp/SQRT(PAFV%GAzp(k, ABS_CO_IR))
-
-          Predictor_AD%X(k, 1,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 2,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 3,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 4,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 5,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 6,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 7,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 8,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 9,  COMP_CO_IR)   = ZERO
-          Predictor_AD%X(k, 10, COMP_CO_IR)   = ZERO
-
-          !  -----------------------
-          !  Methane predictors
-          !  -----------------------
-
-          CH4_A_AD = CH4_A_AD                                                       &
-                     + Predictor_AD%X(k, 1,  COMP_CH4_IR)*DT                        &
-                     + Predictor_AD%X(k, 3,  COMP_CH4_IR)*TWO*CH4_A                 &
-                     + Predictor_AD%X(k, 4,  COMP_CH4_IR)
-
-          DT_AD    = DT_AD                                                          &
-                     + Predictor_AD%X(k, 1,  COMP_CH4_IR)*CH4_A                     &
-                     + Predictor_AD%X(k, 5,  COMP_CH4_IR)*CH4
-
-          CH4_R_AD = CH4_R_AD                                                       &
-                     + Predictor_AD%X(k, 2,  COMP_CH4_IR)                           &
-                     + Predictor_AD%X(k, 8,  COMP_CH4_IR)*POINT_5/SQRT(CH4_R)       &
-                     + Predictor_AD%X(k, 11, COMP_CH4_IR)*CH4/PAFV%GAzp(k, ABS_CH4_IR)
-
-          CH4_AD   = CH4_AD                                                         &
-                     + Predictor_AD%X(k, 5,  COMP_CH4_IR)*DT                        &
-                     + Predictor_AD%X(k, 11, COMP_CH4_IR)*CH4_R/PAFV%GAzp(k, ABS_CH4_IR)
-
-          CH4_ACH4zp_AD = CH4_ACH4zp_AD                                             &
-                     + Predictor_AD%X(k, 6,  COMP_CH4_IR)                           &
-                     + Predictor_AD%X(k, 7,  COMP_CH4_IR)*TWO*CH4_ACH4zp
-
-          GATzp_AD(k, ABS_CH4_IR) = GATzp_AD(k, ABS_CH4_IR)                         &
-                     + Predictor_AD%X(k, 9,  COMP_CH4_IR)                           &
-                     + Predictor_AD%X(k,10,  COMP_CH4_IR)*SECANG(k)
-
-          GAzp_AD(k, ABS_CH4_IR) = GAzp_AD(k, ABS_CH4_IR)                           &
-                     - Predictor_AD%X(k, 11, COMP_CH4_IR)*                          &
-                       CH4_R*CH4/PAFV%GAzp(k, ABS_CH4_IR)**2
-
-          Predictor_AD%X(k, 1,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 2,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 3,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 4,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 5,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 6,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 7,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 8,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 9,  COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 10, COMP_CH4_IR)  = ZERO
-          Predictor_AD%X(k, 11, COMP_CH4_IR)  = ZERO
-
-          !  -----------------------
-          !    N2O predictors
-          !  -----------------------
-
-          N2O_A_AD = N2O_A_AD                                                        &
-                     + Predictor_AD%X(k, 1, COMP_N2O_IR)*DT                          &
-                     + Predictor_AD%X(k, 4, COMP_N2O_IR)*POINT_25*N2O_A**(-POINT_75) &
-                     + Predictor_AD%X(k, 5, COMP_N2O_IR)
-
-          DT_AD    = DT_AD                                                           &
-                     + Predictor_AD%X(k, 1, COMP_N2O_IR)*N2O_A                       &
-                     + Predictor_AD%X(k, 3, COMP_N2O_IR)*N2O
-
-          N2O_R_AD = N2O_R_AD                                                        &
-                     + Predictor_AD%X(k, 2, COMP_N2O_IR)                             &
-                     + Predictor_AD%X(k,10, COMP_N2O_IR)*N2O/PAFV%GAzp(k, ABS_N2O_IR)
-
-          N2O_AD   = N2O_AD                                                          &
-                     + Predictor_AD%X(k, 3, COMP_N2O_IR)*DT                          &
-                     + Predictor_AD%X(k,10, COMP_N2O_IR)*N2O_R/PAFV%GAzp(k, ABS_N2O_IR)
-
-          GAzp_AD(k, ABS_N2O_IR) = GAzp_AD(k, ABS_N2O_IR)                            &
-                     + Predictor_AD%X(k, 6, COMP_N2O_IR)*SECANG(k)                   &
-                     - Predictor_AD%X(k,10, COMP_N2O_IR)*N2O_R*N2O/PAFV%GAzp(k, ABS_N2O_IR)**2
-
-          GATzp_AD(k, ABS_N2O_IR) = GATzp_AD(k, ABS_N2O_IR)                          &
-                     + Predictor_AD%X(k, 7, COMP_N2O_IR)*SECANG(k)                   &
-                     + Predictor_AD%X(k, 9, COMP_N2O_IR)
-
-          N2O_S_AD = N2O_S_AD + Predictor_AD%X(k, 8, COMP_N2O_IR)
-
-          CH4_A_AD = CH4_A_AD                                                        &
-                     + Predictor_AD%X(k,11, COMP_N2O_IR)                             &
-                     + Predictor_AD%X(k,12, COMP_N2O_IR)*PAFV%GAzp(k, ABS_CH4_IR)
-
-          GAzp_AD(k, ABS_CH4_IR) = GAzp_AD(k, ABS_CH4_IR)                            &
-                     + Predictor_AD%X(k,12, COMP_N2O_IR)*CH4_A
-
-          CO_A_AD = CO_A_AD                                                          &
-                    + Predictor_AD%X(k,13, COMP_N2O_IR)                              &
-                    + Predictor_AD%X(k,14, COMP_N2O_IR)*SECANG(k)*PAFV%GAzp(k, ABS_CO_IR)
-
-          GAzp_AD(k, ABS_CO_IR) = GAzp_AD(k, ABS_CO_IR)                              &
-                    + Predictor_AD%X(k,14, COMP_N2O_IR)*CO_A*SECANG(k)
-
-          Predictor_AD%X(k, 1, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 2, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 3, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 4, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 5, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 6, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 7, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 8, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k, 9, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k,10, COMP_N2O_IR)   = ZERO
-
-          Predictor_AD%X(k,11, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k,12, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k,13, COMP_N2O_IR)   = ZERO
-          Predictor_AD%X(k,14, COMP_N2O_IR)   = ZERO
-
-        END IF IF_Group1
-
-        IF( Group_ID == GROUP_1 )THEN
-
-          GAzp_AD(k, ABS_CH4_IR) = GAzp_AD(k, ABS_CH4_IR) + SECANG(k)*CH4_ACH4zp_AD
-          CH4_A_AD = CH4_A_AD + (POINT_5/SQRT(CH4_A)) * CH4_R_AD
-          CH4_AD = CH4_AD + SECANG(k)*CH4_A_AD
-          CH4_ACH4zp_AD = ZERO
-          CH4_R_AD =      ZERO
-          CH4_A_AD =      ZERO
-
-          GAzp_AD(k, ABS_CO_IR) = GAzp_AD(k, ABS_CO_IR)                              &
-                                  - CO_ACOdCOzp_AD*CO_A*CO/PAFV%GAzp(k, ABS_CO_IR)**2
-          CO_A_AD = CO_A_AD + CO_ACOdCOzp_AD*CO/PAFV%GAzp(k, ABS_CO_IR)              &
-                            + CO_S_AD*TWO * CO_A                                     &
-                            + CO_R_AD*POINT_5/SQRT(CO_A)
-          CO_AD = CO_AD + CO_ACOdCOzp_AD*CO_A/PAFV%GAzp(k, ABS_CO_IR)                &
-                        + CO_A_AD*SECANG(k)
-          CO_ACOdCOzp_AD = ZERO
-          CO_S_AD        = ZERO
-          CO_R_AD        = ZERO
-          CO_A_AD        = ZERO
-
-          N2O_A_AD = N2O_A_AD + N2O_R_AD * POINT_5 / SQRT(N2O_A)                    &
-                              + N2O_S_AD * TWO * N2O_A
-          N2O_AD = N2O_AD + N2O_A_AD * SECANG(k)
-          N2O_A_AD = ZERO
-          N2O_R_AD = ZERO
-          N2O_S_AD = ZERO
-
-          Absorber_AD(k,ABS_CH4_IR) = Absorber_AD(k,ABS_CH4_IR)                      &
-                                    + CH4_AD/Ref_absorber(k,ABS_CH4_IR)
-          Absorber_AD(k,ABS_N2O_IR) = Absorber_AD(k,ABS_N2O_IR)                      &
-                                    + N2O_AD/Ref_absorber(k,ABS_N2O_IR)
-          Absorber_AD(k,ABS_CO_IR)  = Absorber_AD(k,ABS_CO_IR)                       &
-                                    + CO_AD/Ref_absorber(k, ABS_CO_IR)
-          CO_AD  = ZERO
-          N2O_AD = ZERO
-          CH4_AD = ZERO
-
-        END IF
-
-        ! Combinations of variables common to all predictor groups
-
-        O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
-        O3_AD = O3_AD + O3_A_AD * SECANG(k)
-        O3_A_AD = ZERO
-        O3_R_AD = ZERO
-
-        GATzp_AD(k, ABS_H2O_IR) = GATzp_AD(k, ABS_H2O_IR)                            &
-                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ABS_H2O_IR)**2
-        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
-        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
-                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
-        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
-               + H2OdH2OTzp_AD / PAFV%GATzp(k, ABS_H2O_IR)
-
-        H2O_A_AD      = ZERO
-        H2O_R_AD      = ZERO
-        H2O_S_AD      = ZERO
-        H2O_R4_AD     = ZERO
-        H2OdH2OTzp_AD = ZERO
-
-        IF( DT > ZERO) THEN
-          DT_AD = DT_AD + DT2_AD*TWO*DT
-        ELSE
-          DT_AD = DT_AD - DT2_AD*TWO*DT
-        ENDIF
-        T_AD = T_AD + T2_AD*TWO*T
-        T2_AD   = ZERO
-        DT2_AD  = ZERO
-
-        !-------------------------------------------
-        !  Abosrber amount scalled by the reference
-        !-------------------------------------------
-        Absorber_AD(k,ABS_CO2_IR) = Absorber_AD(k,ABS_CO2_IR)            &
-                                  + CO2_AD / Ref_absorber(k,ABS_CO2_IR)
-        Absorber_AD(k,ABS_O3_IR)  = Absorber_AD(k,ABS_O3_IR)             &
-                                  + O3_AD / Ref_absorber(k,ABS_O3_IR)
-        Absorber_AD(k,ABS_H2O_IR) = Absorber_AD(k,ABS_H2O_IR)            &
-                                  + H2O_AD / Ref_Absorber(k, ABS_H2O_IR)
-        H2O_AD = ZERO
-        O3_AD  = ZERO
-        CO2_AD = ZERO
-
-        !------------------------------------------
-        !  Relative Temperature
-        !------------------------------------------
-        Temperature_AD(k) = Temperature_AD(k) + T_AD/Ref_Temperature(k) &
-                          + dT_AD
-        dT_AD = ZERO
-        T_AD  = ZERO
-
-      END DO Layer_Loop
-
-    END SUBROUTINE ODPS_Compute_Predictor_IR_AD
-
-    SUBROUTINE ODPS_Compute_Predictor_MW_AD()
-
-      ! ---------------
-      ! Local variables
-      ! ---------------
-      INTEGER  :: k ! n_Layers, n_Levels
-      REAL(fp) :: DT,           DT_AD
-      REAL(fp) :: T,            T_AD
-      REAL(fp) :: T2,           T2_AD
-      REAL(fp) :: DT2,          DT2_AD
-      REAL(fp) :: H2O,          H2O_AD
-      REAL(fp) :: H2O_A,        H2O_A_AD
-      REAL(fp) :: H2O_R,        H2O_R_AD
-      REAL(fp) :: H2O_S,        H2O_S_AD
-      REAL(fp) :: H2O_R4,       H2O_R4_AD
-      REAL(fp) :: H2OdH2OTzp,   H2OdH2OTzp_AD
-      REAL(fp) :: O3,           O3_AD
-      REAL(fp) :: O3_A,         O3_A_AD
-      REAL(fp) :: O3_R,         O3_R_AD
-
-      DT_AD         = ZERO
-      T_AD          = ZERO
-      T2_AD         = ZERO
-      DT2_AD        = ZERO
-      H2O_AD        = ZERO
-      H2O_A_AD      = ZERO
-      H2O_R_AD      = ZERO
-      H2O_S_AD      = ZERO
-      H2O_R4_AD     = ZERO
-      H2OdH2OTzp_AD = ZERO
-      O3_AD         = ZERO
-      O3_A_AD       = ZERO
-      O3_R_AD       = ZERO
-
-      Layer_Loop : DO k = n_Layers, 1, -1
-
-        !------------------------------------------
-        !  Relative Temperature
-        !------------------------------------------
-        dT = Temperature(k) - Ref_Temperature(k)
-        T = Temperature(k) / Ref_Temperature(k)
-
-        !-------------------------------------------
-        !  Abosrber amount scalled by the reference
-        !-------------------------------------------
-        H2O = Absorber(k,ABS_H2O_MW)/Ref_Absorber(k, ABS_H2O_MW)
-
-        ! Combinations of variables common to all predictor groups
-        T2  = T*T
-        DT2 = DT*ABS( DT )
-
-        H2O_A = SECANG(k)*H2O
-        H2O_R  = SQRT( H2O_A )
-        H2O_S  = H2O_A*H2O_A
-        H2O_R4 = SQRT( H2O_R )
-        H2OdH2OTzp = H2O/PAFV%GATzp(k, ABS_H2O_MW)
-
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          O3   = Absorber(k,ABS_O3_MW)/Ref_Absorber(k, ABS_O3_MW)
-          O3_A = SECANG(k)*O3
-          O3_R = SQRT( O3_A )
-        END IF
-
-       !#-------------------------------------------------------------------#
-       !#        -- Predictors --                                           #
-       !#-------------------------------------------------------------------#
-
-       ! set number of predictors
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-          Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        ELSE
-          Predictor_AD%n_CP = GROUP_REGISTRY(Group_ID)%n_Predictors(1:GROUP_REGISTRY(Group_ID)%n_Components)
-        END IF
-
-        !  ----------------------
-        !   Fixed (Dry) predictors
-        !  ----------------------
-
-        T_AD  = T_AD                                                          &
-                + Predictor_AD%X(k, 2, COMP_DRY_MW)*SECANG(k)                 &
-                + Predictor_AD%X(k, 4, COMP_DRY_MW)
-
-        T2_AD = T2_AD                                                         &
-                + Predictor_AD%X(k, 3, COMP_DRY_MW)*SECANG(k)                 &
-                + Predictor_AD%X(k, 6, COMP_DRY_MW)
-
-        Tz_AD(k) = Tz_AD(k) + Predictor_AD%X(k, 7, COMP_DRY_MW)
-
-        Predictor_AD%X(k, 1, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 2, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 3, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 4, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 5, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 6, COMP_DRY_MW)  = ZERO
-        Predictor_AD%X(k, 7, COMP_DRY_MW)  = ZERO
-
-       !  --------------------------------
-       !  Water vapor (line and continuum)
-       !  --------------------------------
-
-        H2O_A_AD = H2O_A_AD                                                   &
-                   + Predictor_AD%X(k, 1, COMP_WET_MW)/T                      &
-                   + Predictor_AD%X(k, 2, COMP_WET_MW)*H2O/T                  &
-                   + Predictor_AD%X(k, 3, COMP_WET_MW)*H2O/T2**2              &
-                   + Predictor_AD%X(k, 4, COMP_WET_MW)/T2                     &
-                   + Predictor_AD%X(k, 5, COMP_WET_MW)*H2O/T2                 &
-                   + Predictor_AD%X(k, 6, COMP_WET_MW)/T2**2                  &
-                   + Predictor_AD%X(k, 7, COMP_WET_MW)                        &
-                   + Predictor_AD%X(k, 8, COMP_WET_MW)*DT                     &
-                   + Predictor_AD%X(k,12, COMP_WET_MW)*H2O_S
-
-        T_AD     = T_AD                                                       &
-                   - Predictor_AD%X(k, 1, COMP_WET_MW)*H2O_A/T**2             &
-                   - Predictor_AD%X(k, 2, COMP_WET_MW)*H2O_A*H2O/T**2
-
-        H2O_AD   = H2O_AD                                                     &
-                   + Predictor_AD%X(k, 2, COMP_WET_MW)*H2O_A/T                &
-                   + Predictor_AD%X(k, 3, COMP_WET_MW)*H2O_A/T2**2            &
-                   + Predictor_AD%X(k, 5, COMP_WET_MW)*H2O_A/T2
-
-        T2_AD    = T2_AD                                                      &
-                   - Predictor_AD%X(k, 3, COMP_WET_MW)*Two*H2O_A*H2O/T2**3    &
-                   - Predictor_AD%X(k, 4, COMP_WET_MW)*H2O_A/T2**2            &
-                   - Predictor_AD%X(k, 5, COMP_WET_MW)*H2O_A*H2O/T2**2        &
-                   - Predictor_AD%X(k, 6, COMP_WET_MW)*TWO*H2O_A/T2**3
-
-        DT_AD    = DT_AD + Predictor_AD%X(k, 8, COMP_WET_MW)*H2O_A
-
-        GAzp_AD(k,ABS_H2O_MW) = GAzp_AD(k,ABS_H2O_MW)                                           &
-                   + Predictor_AD%X(k, 9, COMP_WET_MW)*TWO*SECANG(k)**2*PAFV%GAzp(k,ABS_H2O_MW) &
-                   + Predictor_AD%X(k, 10,COMP_WET_MW)*SECANG(k)
-
-        H2O_S_AD = H2O_S_AD                                                   &
-                   + Predictor_AD%X(k, 12,COMP_WET_MW)*H2O_A                  &
-                   + Predictor_AD%X(k, 13,COMP_WET_MW)*TWO*H2O_S
-
-        H2OdH2OTzp_AD = H2OdH2OTzp_AD + Predictor_AD%X(k, 14,COMP_WET_MW)
-
-        Predictor_AD%X(k, 1, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 2, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 3, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 4, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 5, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 6, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 7, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 8, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 9, COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 10,COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 11,COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 12,COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 13,COMP_WET_MW) = ZERO
-        Predictor_AD%X(k, 14,COMP_WET_MW) = ZERO
-
-        !  -----------------------
-        !  Ozone predictors (GROUP_MW_O3 only)
-        !  -----------------------
-        IF ( Group_ID == GROUP_MW_O3 ) THEN
-
-          O3_A_AD = O3_A_AD                                                       &
-                    + Predictor_AD%X(k, 1, COMP_OZO_MW)                           &
-                    + Predictor_AD%X(k, 2, COMP_OZO_MW)*DT                        &
-                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3*PAFV%GAzp(k,ABS_O3_MW) &
-                    + Predictor_AD%X(k, 4, COMP_OZO_MW)*TWO*O3_A                  &
-                    + Predictor_AD%X(k, 5, COMP_OZO_MW)*PAFV%GAzp(k,ABS_O3_MW)    &
-                    + Predictor_AD%X(k, 6, COMP_OZO_MW)*SQRT(SECANG(k)*PAFV%GAzp(k,ABS_O3_MW))
-
-          DT_AD   = DT_AD                                                         &
-                    + Predictor_AD%X(k, 2, COMP_OZO_MW)*O3_A                      &
-                    + Predictor_AD%X(k, 7, COMP_OZO_MW)*O3_R
-
-          O3_AD   = O3_AD                                                         &
-                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3_A*PAFV%GAzp(k,ABS_O3_MW) &
-                    + Predictor_AD%X(k, 9, COMP_OZO_MW)*O3_R/PAFV%GAzp(k,ABS_O3_MW)
-
-          GAzp_AD(k,ABS_O3_MW) = GAzp_AD(k,ABS_O3_MW)                             &
-                    + Predictor_AD%X(k, 3, COMP_OZO_MW)*O3_A*O3                   &
-                    + Predictor_AD%X(k, 5, COMP_OZO_MW)*O3_A                      &
-                    + Predictor_AD%X(k, 6, COMP_OZO_MW)*POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ABS_O3_MW)) &
-                    - Predictor_AD%X(k, 9, COMP_OZO_MW)*O3_R*O3/PAFV%GAzp(k,ABS_O3_MW)**2 &
-                    + Predictor_AD%X(k,10, COMP_OZO_MW)*SECANG(k)                 &
-                    + Predictor_AD%X(k,11, COMP_OZO_MW)*TWO*SECANG(k)**2*PAFV%GAzp(k,ABS_O3_MW)
-
-          O3_R_AD = O3_R_AD                                                       &
-                    + Predictor_AD%X(k, 7, COMP_OZO_MW)*DT                        &
-                    + Predictor_AD%X(k, 8, COMP_OZO_MW)                           &
-                    + Predictor_AD%X(k, 9, COMP_OZO_MW)*O3/PAFV%GAzp(k,ABS_O3_MW)
-
-          Predictor_AD%X(k, 1:11, COMP_OZO_MW) = ZERO
-
-          O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
-          O3_AD   = O3_AD + O3_A_AD * SECANG(k)
-          O3_R_AD = ZERO
-          O3_A_AD = ZERO
-          Absorber_AD(k,ABS_O3_MW) = Absorber_AD(k,ABS_O3_MW)            &
-                                   + O3_AD / Ref_Absorber(k, ABS_O3_MW)
-          O3_AD   = ZERO
-
-        END IF
-
-        !-------------------------------------------
-        !  Abosrber amount scalled by the reference
-        !-------------------------------------------
-
-        ! Combinations of variables common to all predictor groups
-
-        GATzp_AD(k, ABS_H2O_MW) = GATzp_AD(k, ABS_H2O_MW)                            &
-                                - H2OdH2OTzp_AD*H2O/PAFV%GATzp(k, ABS_H2O_MW)**2
-        H2O_R_AD = H2O_R_AD + H2O_R4_AD * POINT_5 / SQRT(H2O_R)
-        H2O_A_AD = H2O_A_AD + H2O_S_AD * TWO * H2O_A                                 &
-                 + H2O_R_AD * POINT_5 / SQRT(H2O_A)
-        H2O_AD = H2O_AD + H2O_A_AD * SECANG(k)                                       &
-               + H2OdH2OTzp_AD / PAFV%GATzp(k, ABS_H2O_MW)
-        H2O_A_AD      = ZERO
-        H2O_R_AD      = ZERO
-        H2O_S_AD      = ZERO
-        H2O_R4_AD     = ZERO
-        H2OdH2OTzp_AD = ZERO
-
-        IF( DT > ZERO) THEN
-          DT_AD = DT_AD + DT2_AD*TWO*DT
-        ELSE
-          DT_AD = DT_AD - DT2_AD*TWO*DT
-        ENDIF
-        T_AD = T_AD + T2_AD*TWO*T
-        T2_AD   = ZERO
-        DT2_AD  = ZERO
-
-        Absorber_AD(k,ABS_H2O_MW) = Absorber_AD(k,ABS_H2O_MW)            &
-                                  + H2O_AD / Ref_Absorber(k, ABS_H2O_MW)
-        H2O_AD = ZERO
-
-        !------------------------------------------
-        !  Relative Temperature
-        !------------------------------------------
-        Temperature_AD(k) = Temperature_AD(k) + T_AD/Ref_Temperature(k) &
-                          + dT_AD
-        dT_AD = ZERO
-        T_AD  = ZERO
-
-      END DO Layer_Loop
-
-    END SUBROUTINE ODPS_Compute_Predictor_MW_AD
+      END DO
+    END FUNCTION Component_Position
+
+    !  ----------------------
+    !   Fixed (Dry) predictors (IR and MW use the same formulation)
+    !  ----------------------
+    SUBROUTINE AD_Kernel_DRY( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      T_AD     = T_AD                                    &
+                 + Predictor_AD%X(k, 2, ic) * SECANG(k)  &
+                 + Predictor_AD%X(k, 4, ic)
+      T2_AD    = T2_AD                                   &
+                 + Predictor_AD%X(k, 3, ic) * SECANG(k)  &
+                 + Predictor_AD%X(k, 6, ic)
+      Tz_AD(k) = Tz_AD(k) + Predictor_AD%X(k, 7, ic)
+
+      Predictor_AD%X(k, 1, ic)  = ZERO
+      Predictor_AD%X(k, 2, ic)  = ZERO
+      Predictor_AD%X(k, 3, ic)  = ZERO
+      Predictor_AD%X(k, 4, ic)  = ZERO
+      Predictor_AD%X(k, 5, ic)  = ZERO
+      Predictor_AD%X(k, 6, ic)  = ZERO
+      Predictor_AD%X(k, 7, ic)  = ZERO
+    END SUBROUTINE AD_Kernel_DRY
+
+    !  --------------------------
+    !  Water vapor continuum predictors
+    !  --------------------------
+    SUBROUTINE AD_Kernel_WCO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      H2O_A_AD = H2O_A_AD                                &
+                 + Predictor_AD%X(k, 1, ic)/T            &
+                 + Predictor_AD%X(k, 2, ic)*H2O/T        &
+                 + Predictor_AD%X(k, 3, ic)*H2O/T2**2    &
+                 + Predictor_AD%X(k, 4, ic)/T2           &
+                 + Predictor_AD%X(k, 5, ic)*H2O/T2       &
+                 + Predictor_AD%X(k, 6, ic)/T2**2        &
+                 + Predictor_AD%X(k, 7, ic)
+      T_AD     = T_AD                                       &
+                 - Predictor_AD%X(k, 1, ic)*H2O_A/T**2      &
+                 - Predictor_AD%X(k, 2, ic)*H2O_A*H2O/T**2
+      H2O_AD   = H2O_AD                                 &
+                 + Predictor_AD%X(k, 2, ic)*H2O_A/T     &
+                 + Predictor_AD%X(k, 3, ic)*H2O_A/T2**2 &
+                 + Predictor_AD%X(k, 5, ic)*H2O_A/T2
+      T2_AD    = T2_AD                                          &
+                 - Predictor_AD%X(k, 3, ic)*TWO*H2O_A*H2O/T2**3 &
+                 - Predictor_AD%X(k, 4, ic)*H2O_A/T2**2         &
+                 - Predictor_AD%X(k, 5, ic)*H2O_A*H2O/T2**2     &
+                 - Predictor_AD%X(k, 6, ic)*TWO*H2O_A/T2**3
+
+      Predictor_AD%X(k, 1, ic) = ZERO
+      Predictor_AD%X(k, 2, ic) = ZERO
+      Predictor_AD%X(k, 3, ic) = ZERO
+      Predictor_AD%X(k, 4, ic) = ZERO
+      Predictor_AD%X(k, 5, ic) = ZERO
+      Predictor_AD%X(k, 6, ic) = ZERO
+      Predictor_AD%X(k, 7, ic) = ZERO
+    END SUBROUTINE AD_Kernel_WCO
+
+    !  -----------------------
+    !  NO2 predictors AD (GROUP_UV_NO2); adjoint of the compact set
+    !  X1=NO2_A, X2=NO2_A*DT, X3=NO2_A*DT2, NO2_A=secang*NO2, NO2=Abs/Ref.
+    !  Self-contained through to Absorber_AD, as in the heritage code.
+    !  -----------------------
+    SUBROUTINE AD_Kernel_NO2( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      NO2   = Absorber(k,ja_no2)/Ref_Absorber(k, ja_no2)
+      NO2_A = SECANG(k)*NO2
+
+      NO2_A_AD = NO2_A_AD                            &
+                 + Predictor_AD%X(k, 1, ic)          &
+                 + Predictor_AD%X(k, 2, ic)*DT       &
+                 + Predictor_AD%X(k, 3, ic)*DT2
+      DT_AD    = DT_AD  + Predictor_AD%X(k, 2, ic)*NO2_A
+      DT2_AD   = DT2_AD + Predictor_AD%X(k, 3, ic)*NO2_A
+      Predictor_AD%X(k, 1, ic) = ZERO
+      Predictor_AD%X(k, 2, ic) = ZERO
+      Predictor_AD%X(k, 3, ic) = ZERO
+
+      NO2_AD   = NO2_AD + NO2_A_AD*SECANG(k)
+      NO2_A_AD = ZERO
+      Absorber_AD(k,ja_no2) = Absorber_AD(k,ja_no2)     &
+                                + NO2_AD/Ref_Absorber(k, ja_no2)
+      NO2_AD   = ZERO
+    END SUBROUTINE AD_Kernel_NO2
+
+    !  -----------------------
+    !  Ozone predictors (IR groups; chain propagation happens in the
+    !  common epilogue)
+    !  -----------------------
+    SUBROUTINE AD_Kernel_OZO_IR( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      O3_A_AD = O3_A_AD                                                       &
+                + Predictor_AD%X(k, 1, ic)                                    &
+                + Predictor_AD%X(k, 2, ic)*DT                                 &
+                + Predictor_AD%X(k, 3, ic)*O3*PAFV%GAzp(k,ja_o3)              &
+                + Predictor_AD%X(k, 4, ic)*TWO*O3_A                           &
+                + Predictor_AD%X(k, 5, ic)*PAFV%GAzp(k,ja_o3)                 &
+                + Predictor_AD%X(k, 6, ic)*SQRT(SECANG(k)*PAFV%GAzp(k,ja_o3))
+
+      DT_AD   = DT_AD                                                         &
+                + Predictor_AD%X(k, 2, ic)*O3_A                               &
+                + Predictor_AD%X(k, 7, ic)*O3_R
+
+      O3_AD   = O3_AD                                                         &
+                + Predictor_AD%X(k, 3, ic)*O3_A*PAFV%GAzp(k,ja_o3)            &
+                + Predictor_AD%X(k, 9, ic)*O3_R/PAFV%GAzp(k,ja_o3)
+
+      GAzp_AD(k,ja_o3) = GAzp_AD(k,ja_o3)                                     &
+                + Predictor_AD%X(k, 3, ic)*O3_A*O3                            &
+                + Predictor_AD%X(k, 5, ic)*O3_A                               &
+                + Predictor_AD%X(k, 6, ic)*POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ja_o3)) &
+                - Predictor_AD%X(k, 9, ic)*O3_R*O3/PAFV%GAzp(k,ja_o3)**2      &
+                + Predictor_AD%X(k,10, ic)*SECANG(k)                          &
+                + Predictor_AD%X(k,11, ic)*TWO*SECANG(k)**2*PAFV%GAzp(k,ja_o3)
+
+      O3_R_AD = O3_R_AD                                                       &
+                + Predictor_AD%X(k, 7, ic)*DT                                 &
+                + Predictor_AD%X(k, 8, ic)                                    &
+                + Predictor_AD%X(k, 9, ic)*O3/PAFV%GAzp(k,ja_o3)
+
+      Predictor_AD%X(k, 1, ic)  = ZERO
+      Predictor_AD%X(k, 2, ic)  = ZERO
+      Predictor_AD%X(k, 3, ic)  = ZERO
+      Predictor_AD%X(k, 4, ic)  = ZERO
+      Predictor_AD%X(k, 5, ic)  = ZERO
+      Predictor_AD%X(k, 6, ic)  = ZERO
+      Predictor_AD%X(k, 7, ic)  = ZERO
+      Predictor_AD%X(k, 8, ic)  = ZERO
+      Predictor_AD%X(k, 9, ic)  = ZERO
+      Predictor_AD%X(k,10, ic)  = ZERO
+      Predictor_AD%X(k,11, ic)  = ZERO
+
+      Predictor_AD%X(k,12, ic)  = ZERO
+      Predictor_AD%X(k,13, ic)  = ZERO
+    END SUBROUTINE AD_Kernel_OZO_IR
+
+    !  -----------------------
+    !  Ozone predictors (GROUP_MW_O3; self-contained through to
+    !  Absorber_AD, as in the heritage code)
+    !  -----------------------
+    SUBROUTINE AD_Kernel_OZO_MW( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      O3_A_AD = O3_A_AD                                                  &
+                + Predictor_AD%X(k, 1, ic)                               &
+                + Predictor_AD%X(k, 2, ic)*DT                            &
+                + Predictor_AD%X(k, 3, ic)*O3*PAFV%GAzp(k,ja_o3)         &
+                + Predictor_AD%X(k, 4, ic)*TWO*O3_A                      &
+                + Predictor_AD%X(k, 5, ic)*PAFV%GAzp(k,ja_o3)            &
+                + Predictor_AD%X(k, 6, ic)*SQRT(SECANG(k)*PAFV%GAzp(k,ja_o3))
+
+      DT_AD   = DT_AD                                                    &
+                + Predictor_AD%X(k, 2, ic)*O3_A                          &
+                + Predictor_AD%X(k, 7, ic)*O3_R
+
+      O3_AD   = O3_AD                                                    &
+                + Predictor_AD%X(k, 3, ic)*O3_A*PAFV%GAzp(k,ja_o3)       &
+                + Predictor_AD%X(k, 9, ic)*O3_R/PAFV%GAzp(k,ja_o3)
+
+      GAzp_AD(k,ja_o3) = GAzp_AD(k,ja_o3)                                &
+                + Predictor_AD%X(k, 3, ic)*O3_A*O3                       &
+                + Predictor_AD%X(k, 5, ic)*O3_A                          &
+                + Predictor_AD%X(k, 6, ic)*POINT_5*O3_A*SQRT(SECANG(k)/PAFV%GAzp(k,ja_o3)) &
+                - Predictor_AD%X(k, 9, ic)*O3_R*O3/PAFV%GAzp(k,ja_o3)**2 &
+                + Predictor_AD%X(k,10, ic)*SECANG(k)                     &
+                + Predictor_AD%X(k,11, ic)*TWO*SECANG(k)**2*PAFV%GAzp(k,ja_o3)
+
+      O3_R_AD = O3_R_AD                                                  &
+                + Predictor_AD%X(k, 7, ic)*DT                            &
+                + Predictor_AD%X(k, 8, ic)                               &
+                + Predictor_AD%X(k, 9, ic)*O3/PAFV%GAzp(k,ja_o3)
+
+      Predictor_AD%X(k, 1:11, ic) = ZERO
+
+      O3_A_AD = O3_A_AD + O3_R_AD * POINT_5 / SQRT(O3_A)
+      O3_AD   = O3_AD + O3_A_AD * SECANG(k)
+      O3_R_AD = ZERO
+      O3_A_AD = ZERO
+      Absorber_AD(k,ja_o3) = Absorber_AD(k,ja_o3)            &
+                               + O3_AD / Ref_Absorber(k, ja_o3)
+      O3_AD   = ZERO
+    END SUBROUTINE AD_Kernel_OZO_MW
+
+    !  -----------------------
+    !  Carbon dioxide predictors (1 - 10; the group-1 predictor 11 adjoint
+    !  is handled with the WLO extension to preserve the heritage
+    !  accumulation order)
+    !  -----------------------
+    SUBROUTINE AD_Kernel_CO2( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      T_AD      = T_AD                                          &
+                  + Predictor_AD%X(k, 1, ic)*SECANG(k)          &
+                  + Predictor_AD%X(k, 3, ic)                    &
+                  + Predictor_AD%X(k, 10, ic)*SECANG(k)*(POINT_5*PAFV%Tzp(k)/SQRT(T))
+
+      T2_AD     = T2_AD                                         &
+                  + Predictor_AD%X(k, 2, ic)*SECANG(k)          &
+                  + Predictor_AD%X(k, 4, ic)
+
+      CO2_AD    = CO2_AD + Predictor_AD%X(k, 6, ic)*SECANG(k)
+
+      Tzp_AD(k) = Tzp_AD(k)                                     &
+                  + Predictor_AD%X(k, 7, ic)*SECANG(k)          &
+                  + Predictor_AD%X(k, 9, ic)*THREE*PAFV%Tzp(k)**2 &
+                  + Predictor_AD%X(k, 10, ic)*SECANG(k)*SQRT(T)
+
+      GAzp_AD(k, ja_co2) = GAzp_AD(k, ja_co2)                   &
+                  + Predictor_AD%X(k, 8, ic)*TWO*SECANG(k)**2*PAFV%GAzp(k, ja_co2)
+
+
+      Predictor_AD%X(k, 1, ic)  = ZERO
+      Predictor_AD%X(k, 2, ic)  = ZERO
+      Predictor_AD%X(k, 3, ic)  = ZERO
+      Predictor_AD%X(k, 4, ic)  = ZERO
+      Predictor_AD%X(k, 5, ic)  = ZERO
+      Predictor_AD%X(k, 6, ic)  = ZERO
+      Predictor_AD%X(k, 7, ic)  = ZERO
+      Predictor_AD%X(k, 8, ic)  = ZERO
+      Predictor_AD%X(k, 9, ic)  = ZERO
+      Predictor_AD%X(k,10, ic)  = ZERO
+    END SUBROUTINE AD_Kernel_CO2
+
+    !  --------------------------
+    !  Water-line predictors (1 - 15), plus the group-1 extension
+    !  (WLO predictors 16 - 18 AND the CO2 component's predictor 11)
+    !  when the roster requests 18 WLO predictors. The CO2 predictor-11
+    !  adjoint lives here, not in AD_Kernel_CO2, because the heritage
+    !  monolith accumulates it at exactly this point in the sequence.
+    !  --------------------------
+    SUBROUTINE AD_Kernel_WLO( k, ic, np )
+      INTEGER, INTENT(IN) :: k, ic, np
+      H2O_A_AD = H2O_A_AD                                 &
+                 + Predictor_AD%X(k, 1, ic)               &
+                 + Predictor_AD%X(k, 2, ic)*DT            &
+                 + Predictor_AD%X(k, 4, ic)*DT2           &
+                 + Predictor_AD%X(k, 6, ic)*H2O_S
+
+      DT_AD    = DT_AD                                    &
+                 + Predictor_AD%X(k, 2, ic)*H2O_A         &
+                 + Predictor_AD%X(k, 8, ic)*H2O_R
+
+      H2O_S_AD = H2O_S_AD                                 &
+                 + Predictor_AD%X(k, 3, ic)               &
+                 + Predictor_AD%X(k, 6, ic)*H2O_A         &
+                 + Predictor_AD%X(k, 9, ic)*TWO*H2O_S
+
+      DT2_AD   = DT2_AD + Predictor_AD%X(k, 4, ic)*H2O_A
+
+      H2O_R4_AD= H2O_R4_AD + Predictor_AD%X(k, 5, ic)
+
+      H2O_R_AD = H2O_R_AD                                 &
+                 + Predictor_AD%X(k, 7, ic)               &
+                 + Predictor_AD%X(k, 8, ic)*DT            &
+                 + Predictor_AD%X(k,11, ic)*H2OdH2OTzp
+
+      H2OdH2OTzp_AD = H2OdH2OTzp_AD                       &
+                 + Predictor_AD%X(k,10, ic)               &
+                 + Predictor_AD%X(k,11, ic)*H2O_R
+
+      GAzp_AD(k,ja_h2o) = GAzp_AD(k,ja_h2o)                                            &
+                 + Predictor_AD%X(k,12, ic)*TWO*SECANG(k)**2*PAFV%GAzp(k,ja_h2o)  &
+                 + Predictor_AD%X(k,13, ic)*SECANG(k)
+
+      CO2_AD   = CO2_AD + Predictor_AD%X(k,15, ic)*SECANG(k)
+
+      Predictor_AD%X(k, 1, ic) = ZERO
+      Predictor_AD%X(k, 2, ic) = ZERO
+      Predictor_AD%X(k, 3, ic) = ZERO
+      Predictor_AD%X(k, 4, ic) = ZERO
+      Predictor_AD%X(k, 5, ic) = ZERO
+      Predictor_AD%X(k, 6, ic) = ZERO
+      Predictor_AD%X(k, 7, ic) = ZERO
+      Predictor_AD%X(k, 8, ic) = ZERO
+      Predictor_AD%X(k, 9, ic) = ZERO
+      Predictor_AD%X(k,10, ic) = ZERO
+      Predictor_AD%X(k,11, ic) = ZERO
+      Predictor_AD%X(k,12, ic) = ZERO
+      Predictor_AD%X(k,13, ic) = ZERO
+      Predictor_AD%X(k,14, ic) = ZERO
+      Predictor_AD%X(k,15, ic) = ZERO
+
+      ! Addtional predictors for group 1
+      IF ( np >= 18 ) THEN
+
+        CO_A_AD  = CO_A_AD   + Predictor_AD%X(k, 18, ic)          &
+                             + Predictor_AD%X(k, 11, ic_co2)
+        CH4_A_AD = CH4_A_AD                                       &
+                   + Predictor_AD%X(k, 16, ic)                    &
+                   + Predictor_AD%X(k, 17, ic)*TWO*CH4_A*DT
+        DT_AD    = DT_AD + Predictor_AD%X(k, 17, ic)*CH4_A*CH4_A
+
+        Predictor_AD%X(k, 16, ic) = ZERO
+        Predictor_AD%X(k, 17, ic) = ZERO
+        Predictor_AD%X(k, 18, ic) = ZERO
+        Predictor_AD%X(k, 11, ic_co2) = ZERO
+
+      END IF
+    END SUBROUTINE AD_Kernel_WLO
+
+    !  -----------------------
+    !  Carbon monoxide
+    !  -----------------------
+    SUBROUTINE AD_Kernel_CO( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      CO_A_AD = CO_A_AD                                               &
+                + Predictor_AD%X(k, 1,  ic)                           &
+                + Predictor_AD%X(k, 2,  ic)*DT                        &
+                + Predictor_AD%X(k, 7,  ic)*DT2
+
+      DT_AD   = DT_AD                                                 &
+                + Predictor_AD%X(k, 2,  ic)*CO_A                      &
+                + Predictor_AD%X(k, 4,  ic)*CO_R
+
+      CO_R_AD = CO_R_AD                                               &
+                + Predictor_AD%X(k, 3,  ic)*POINT_5/SQRT(CO_R)        &
+                + Predictor_AD%X(k, 4,  ic)*DT                        &
+                + Predictor_AD%X(k, 6,  ic)                           &
+                - Predictor_AD%X(k, 9,  ic)*CO_ACOdCOzp/CO_R**2
+
+      CO_S_AD = CO_S_AD + Predictor_AD%X(k, 5,  ic)
+
+      DT2_AD  = DT2_AD + Predictor_AD%X(k, 7,  ic)*CO_A
+
+      CO_ACOdCOzp_AD = CO_ACOdCOzp_AD                                 &
+                 + Predictor_AD%X(k, 8,  ic)                          &
+                 + Predictor_AD%X(k, 9,  ic)/CO_R                     &
+                 + Predictor_AD%X(k,10,  ic)*SQRT(PAFV%GAzp(k, ja_co))
+
+      GAzp_AD(k, ja_co) = GAzp_AD(k, ja_co)                           &
+                 + Predictor_AD%X(k, 10, ic)*                         &
+                   POINT_5*CO_ACOdCOzp/SQRT(PAFV%GAzp(k, ja_co))
+
+      Predictor_AD%X(k, 1,  ic)   = ZERO
+      Predictor_AD%X(k, 2,  ic)   = ZERO
+      Predictor_AD%X(k, 3,  ic)   = ZERO
+      Predictor_AD%X(k, 4,  ic)   = ZERO
+      Predictor_AD%X(k, 5,  ic)   = ZERO
+      Predictor_AD%X(k, 6,  ic)   = ZERO
+      Predictor_AD%X(k, 7,  ic)   = ZERO
+      Predictor_AD%X(k, 8,  ic)   = ZERO
+      Predictor_AD%X(k, 9,  ic)   = ZERO
+      Predictor_AD%X(k, 10, ic)   = ZERO
+    END SUBROUTINE AD_Kernel_CO
+
+    !  -----------------------
+    !  Methane predictors
+    !  -----------------------
+    SUBROUTINE AD_Kernel_CH4( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      CH4_A_AD = CH4_A_AD                                                &
+                 + Predictor_AD%X(k, 1,  ic)*DT                          &
+                 + Predictor_AD%X(k, 3,  ic)*TWO*CH4_A                   &
+                 + Predictor_AD%X(k, 4,  ic)
+
+      DT_AD    = DT_AD                                                   &
+                 + Predictor_AD%X(k, 1,  ic)*CH4_A                       &
+                 + Predictor_AD%X(k, 5,  ic)*CH4
+
+      CH4_R_AD = CH4_R_AD                                                &
+                 + Predictor_AD%X(k, 2,  ic)                             &
+                 + Predictor_AD%X(k, 8,  ic)*POINT_5/SQRT(CH4_R)         &
+                 + Predictor_AD%X(k, 11, ic)*CH4/PAFV%GAzp(k, ja_ch4)
+
+      CH4_AD   = CH4_AD                                                  &
+                 + Predictor_AD%X(k, 5,  ic)*DT                          &
+                 + Predictor_AD%X(k, 11, ic)*CH4_R/PAFV%GAzp(k, ja_ch4)
+
+      CH4_ACH4zp_AD = CH4_ACH4zp_AD                                      &
+                 + Predictor_AD%X(k, 6,  ic)                             &
+                 + Predictor_AD%X(k, 7,  ic)*TWO*CH4_ACH4zp
+
+      GATzp_AD(k, ja_ch4) = GATzp_AD(k, ja_ch4)                          &
+                 + Predictor_AD%X(k, 9,  ic)                             &
+                 + Predictor_AD%X(k,10,  ic)*SECANG(k)
+
+      GAzp_AD(k, ja_ch4) = GAzp_AD(k, ja_ch4)                            &
+                 - Predictor_AD%X(k, 11, ic)*                            &
+                   CH4_R*CH4/PAFV%GAzp(k, ja_ch4)**2
+
+      Predictor_AD%X(k, 1,  ic)  = ZERO
+      Predictor_AD%X(k, 2,  ic)  = ZERO
+      Predictor_AD%X(k, 3,  ic)  = ZERO
+      Predictor_AD%X(k, 4,  ic)  = ZERO
+      Predictor_AD%X(k, 5,  ic)  = ZERO
+      Predictor_AD%X(k, 6,  ic)  = ZERO
+      Predictor_AD%X(k, 7,  ic)  = ZERO
+      Predictor_AD%X(k, 8,  ic)  = ZERO
+      Predictor_AD%X(k, 9,  ic)  = ZERO
+      Predictor_AD%X(k, 10, ic)  = ZERO
+      Predictor_AD%X(k, 11, ic)  = ZERO
+    END SUBROUTINE AD_Kernel_CH4
+
+    !  -----------------------
+    !    N2O predictors
+    !  -----------------------
+    SUBROUTINE AD_Kernel_N2O( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      N2O_A_AD = N2O_A_AD                                                 &
+                 + Predictor_AD%X(k, 1, ic)*DT                            &
+                 + Predictor_AD%X(k, 4, ic)*POINT_25*N2O_A**(-POINT_75)   &
+                 + Predictor_AD%X(k, 5, ic)
+
+      DT_AD    = DT_AD                                                    &
+                 + Predictor_AD%X(k, 1, ic)*N2O_A                         &
+                 + Predictor_AD%X(k, 3, ic)*N2O
+
+      N2O_R_AD = N2O_R_AD                                                 &
+                 + Predictor_AD%X(k, 2, ic)                               &
+                 + Predictor_AD%X(k,10, ic)*N2O/PAFV%GAzp(k, ja_n2o)
+
+      N2O_AD   = N2O_AD                                                   &
+                 + Predictor_AD%X(k, 3, ic)*DT                            &
+                 + Predictor_AD%X(k,10, ic)*N2O_R/PAFV%GAzp(k, ja_n2o)
+
+      GAzp_AD(k, ja_n2o) = GAzp_AD(k, ja_n2o)                             &
+                 + Predictor_AD%X(k, 6, ic)*SECANG(k)                     &
+                 - Predictor_AD%X(k,10, ic)*N2O_R*N2O/PAFV%GAzp(k, ja_n2o)**2
+
+      GATzp_AD(k, ja_n2o) = GATzp_AD(k, ja_n2o)                           &
+                 + Predictor_AD%X(k, 7, ic)*SECANG(k)                     &
+                 + Predictor_AD%X(k, 9, ic)
+
+      N2O_S_AD = N2O_S_AD + Predictor_AD%X(k, 8, ic)
+
+      CH4_A_AD = CH4_A_AD                                                 &
+                 + Predictor_AD%X(k,11, ic)                               &
+                 + Predictor_AD%X(k,12, ic)*PAFV%GAzp(k, ja_ch4)
+
+      GAzp_AD(k, ja_ch4) = GAzp_AD(k, ja_ch4)                             &
+                 + Predictor_AD%X(k,12, ic)*CH4_A
+
+      CO_A_AD = CO_A_AD                                                   &
+                + Predictor_AD%X(k,13, ic)                                &
+                + Predictor_AD%X(k,14, ic)*SECANG(k)*PAFV%GAzp(k, ja_co)
+
+      GAzp_AD(k, ja_co) = GAzp_AD(k, ja_co)                               &
+                + Predictor_AD%X(k,14, ic)*CO_A*SECANG(k)
+
+      Predictor_AD%X(k, 1, ic)   = ZERO
+      Predictor_AD%X(k, 2, ic)   = ZERO
+      Predictor_AD%X(k, 3, ic)   = ZERO
+      Predictor_AD%X(k, 4, ic)   = ZERO
+      Predictor_AD%X(k, 5, ic)   = ZERO
+      Predictor_AD%X(k, 6, ic)   = ZERO
+      Predictor_AD%X(k, 7, ic)   = ZERO
+      Predictor_AD%X(k, 8, ic)   = ZERO
+      Predictor_AD%X(k, 9, ic)   = ZERO
+      Predictor_AD%X(k,10, ic)   = ZERO
+
+      Predictor_AD%X(k,11, ic)   = ZERO
+      Predictor_AD%X(k,12, ic)   = ZERO
+      Predictor_AD%X(k,13, ic)   = ZERO
+      Predictor_AD%X(k,14, ic)   = ZERO
+    END SUBROUTINE AD_Kernel_N2O
+
+    !  --------------------------------
+    !  Water vapor, MW (line and continuum together)
+    !  --------------------------------
+    SUBROUTINE AD_Kernel_WET_MW( k, ic )
+      INTEGER, INTENT(IN) :: k, ic
+      H2O_A_AD = H2O_A_AD                                            &
+                 + Predictor_AD%X(k, 1, ic)/T                        &
+                 + Predictor_AD%X(k, 2, ic)*H2O/T                    &
+                 + Predictor_AD%X(k, 3, ic)*H2O/T2**2                &
+                 + Predictor_AD%X(k, 4, ic)/T2                       &
+                 + Predictor_AD%X(k, 5, ic)*H2O/T2                   &
+                 + Predictor_AD%X(k, 6, ic)/T2**2                    &
+                 + Predictor_AD%X(k, 7, ic)                          &
+                 + Predictor_AD%X(k, 8, ic)*DT                       &
+                 + Predictor_AD%X(k,12, ic)*H2O_S
+
+      T_AD     = T_AD                                                &
+                 - Predictor_AD%X(k, 1, ic)*H2O_A/T**2               &
+                 - Predictor_AD%X(k, 2, ic)*H2O_A*H2O/T**2
+
+      H2O_AD   = H2O_AD                                              &
+                 + Predictor_AD%X(k, 2, ic)*H2O_A/T                  &
+                 + Predictor_AD%X(k, 3, ic)*H2O_A/T2**2              &
+                 + Predictor_AD%X(k, 5, ic)*H2O_A/T2
+
+      T2_AD    = T2_AD                                               &
+                 - Predictor_AD%X(k, 3, ic)*Two*H2O_A*H2O/T2**3      &
+                 - Predictor_AD%X(k, 4, ic)*H2O_A/T2**2              &
+                 - Predictor_AD%X(k, 5, ic)*H2O_A*H2O/T2**2          &
+                 - Predictor_AD%X(k, 6, ic)*TWO*H2O_A/T2**3
+
+      DT_AD    = DT_AD + Predictor_AD%X(k, 8, ic)*H2O_A
+
+      GAzp_AD(k,ja_h2o) = GAzp_AD(k,ja_h2o)                                       &
+                 + Predictor_AD%X(k, 9, ic)*TWO*SECANG(k)**2*PAFV%GAzp(k,ja_h2o)  &
+                 + Predictor_AD%X(k, 10,ic)*SECANG(k)
+
+      H2O_S_AD = H2O_S_AD                                            &
+                 + Predictor_AD%X(k, 12,ic)*H2O_A                    &
+                 + Predictor_AD%X(k, 13,ic)*TWO*H2O_S
+
+      H2OdH2OTzp_AD = H2OdH2OTzp_AD + Predictor_AD%X(k, 14,ic)
+
+      Predictor_AD%X(k, 1, ic) = ZERO
+      Predictor_AD%X(k, 2, ic) = ZERO
+      Predictor_AD%X(k, 3, ic) = ZERO
+      Predictor_AD%X(k, 4, ic) = ZERO
+      Predictor_AD%X(k, 5, ic) = ZERO
+      Predictor_AD%X(k, 6, ic) = ZERO
+      Predictor_AD%X(k, 7, ic) = ZERO
+      Predictor_AD%X(k, 8, ic) = ZERO
+      Predictor_AD%X(k, 9, ic) = ZERO
+      Predictor_AD%X(k, 10,ic) = ZERO
+      Predictor_AD%X(k, 11,ic) = ZERO
+      Predictor_AD%X(k, 12,ic) = ZERO
+      Predictor_AD%X(k, 13,ic) = ZERO
+      Predictor_AD%X(k, 14,ic) = ZERO
+    END SUBROUTINE AD_Kernel_WET_MW
 
   END SUBROUTINE  ODPS_Compute_Predictor_AD
 

--- a/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
+++ b/src/AtmAbsorption/ODPS/ODPS_Predictor.f90
@@ -67,6 +67,7 @@ MODULE ODPS_Predictor
   PUBLIC :: ODPS_Get_Absorber_ID
   PUBLIC :: ODPS_Get_Ozone_Component_ID
   PUBLIC :: ODPS_Get_SaveFWVFlag
+  PUBLIC :: ODPS_Validate_Group
   ! Parameters
   PUBLIC :: TOT_ComID
   PUBLIC :: WLO_ComID
@@ -77,6 +78,9 @@ MODULE ODPS_Predictor
   PUBLIC :: GROUP_3
   PUBLIC :: GROUP_MW_O3
   PUBLIC :: GROUP_UV_NO2
+  PUBLIC :: RESERVED_ZSSMIS_GROUP
+  PUBLIC :: RESERVED_ZAMSUA_GROUP
+  PUBLIC :: ODPS_INVALID_ID
   PUBLIC :: ALLOW_OPTRAN
 
 
@@ -93,12 +97,26 @@ MODULE ODPS_Predictor
   INTEGER, PARAMETER  :: N_COMPONENTS_G(N_G)     = (/8,   5, 2, 0, 0, 0, 3, 6/)
   INTEGER, PARAMETER  :: N_ABSORBERS_G(N_G)      = (/6,   3, 1, 0, 0, 0, 2, 4/)
   INTEGER, PARAMETER  :: MAX_N_PREDICTORS_G(N_G) = (/18, 15, 14, 0, 0, 0, 14, 15/)
-  ! Group index (note, group indexes 4 - 6 are reserved for Zeeman sub-algorithms
+  INTEGER, PARAMETER  :: MAX_COMPONENTS_ANY_GROUP = MAXVAL(N_COMPONENTS_G)
+  INTEGER, PARAMETER  :: MAX_ABSORBERS_ANY_GROUP  = MAXVAL(N_ABSORBERS_G)
+  ! Group index. Group indexes 4 - 6 are RESERVED for the Zeeman sub-algorithms
+  ! and are never valid in a standard ODPS TauCoeff file: 4 is Zeeman SSMIS,
+  ! 5 is Zeeman AMSU-A, 6 is an unassigned Zeeman reserve. This module is the
+  ! single owner of the group index space; the ODZeeman code derives its
+  ! ODPS_gINDEX_* constants from the RESERVED_* parameters below. The zero
+  ! entries at positions 4 - 6 in the dimension tables above are placeholders
+  ! for these reserved indexes (Zeeman has its own predictor module and never
+  ! reaches these tables).
   INTEGER, PARAMETER :: GROUP_1 = 1
   INTEGER, PARAMETER :: GROUP_2 = 2
   INTEGER, PARAMETER :: GROUP_3 = 3
+  INTEGER, PARAMETER :: RESERVED_ZSSMIS_GROUP = 4  ! Zeeman SSMIS (ODZeeman only)
+  INTEGER, PARAMETER :: RESERVED_ZAMSUA_GROUP = 5  ! Zeeman AMSU-A (ODZeeman only)
   INTEGER, PARAMETER :: GROUP_MW_O3 = 7   ! MW with a scene-ozone component
   INTEGER, PARAMETER :: GROUP_UV_NO2 = 8  ! UV/VIS with a scene-NO2 component
+  ! The groups a standard ODPS TauCoeff file may legitimately carry
+  INTEGER, PARAMETER :: VALID_GROUPS(5) = &
+    (/ GROUP_1, GROUP_2, GROUP_3, GROUP_MW_O3, GROUP_UV_NO2 /)
 
   ! Number of predictors for each component
   INTEGER, PARAMETER :: N_PREDICTORS_G1(8) = (/ &
@@ -139,7 +157,24 @@ MODULE ODPS_Predictor
                      3 /)  ! NO2 (scene component: amount*secant, and its T, T^2 terms)
 
 
-  ! Component IDs
+  ! Component IDs.
+  !
+  ! REGISTRY NOTE: component IDs are inherited from the heritage transmittance
+  ! production "molecule set" numbering (see CRTM_coef,
+  ! src/apps/TauProd/Infrared/Check_ProcessControl_File/Tau_Production_Parameters.f90):
+  !   1 - 7   individual molecules (HITRAN order; 7 is O2)
+  !   8/9/10  all-no-continua / continua-only / all-with-continua
+  !   12      wet (water vapor, line and continua)
+  !   13      dry
+  !   14      ozone
+  !   15      wco (water vapor continua only)
+  !   20      dry, group-2 formulation
+  !   101     effective molecule 1 (water vapor line only, "wlo")
+  !   112-121 effective single-gas components (112 wet, 113 dry, 114 ozone,
+  !           118 CH4, 119 CO, 120 N2O, 121 CO2)
+  !   122     NO2 (CRTM extension, added with GROUP_UV_NO2)
+  ! New component IDs must be coordinated with the coefficient generation
+  ! package (crtm-coeffgen) and recorded here.
   INTEGER,  PARAMETER :: TOT_ComID = 10    ! total tau
   INTEGER,  PARAMETER :: DRY_ComID_G1 =  7   ! dry gas for Group-1 sensors
   INTEGER,  PARAMETER :: DRY_ComID_G2 = 20   ! dry gas, for Gorup-2 sensors
@@ -151,6 +186,8 @@ MODULE ODPS_Predictor
   INTEGER,  PARAMETER :: CO_ComID  = 119  ! CO
   INTEGER,  PARAMETER :: CH4_ComID = 118  ! CH4
   INTEGER,  PARAMETER :: NO2_ComID = 122  ! NO2 (scene component, UV/VIS group 8)
+  ! Sentinel returned by the ID accessors for an out-of-range query
+  INTEGER,  PARAMETER :: ODPS_INVALID_ID = -1
 
   ! Microwave sensors
   INTEGER,  PARAMETER :: EDRY_ComID = 113  ! Effective dry
@@ -3515,7 +3552,7 @@ CONTAINS
       CASE( GROUP_UV_NO2 )
          Component_ID = COMPONENT_ID_MAP_G8(Component_Index)
       CASE DEFAULT
-         Component_ID = HUGE(Component_ID)  ! Entry not found: Hopefully induce code to fail 
+         Component_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
     END SELECT
   END FUNCTION ODPS_Get_Component_ID
 
@@ -3536,7 +3573,7 @@ CONTAINS
       CASE( GROUP_UV_NO2 )
           Absorber_ID = ABSORBER_ID_MAP_G8(Absorber_Index)
       CASE DEFAULT
-          Absorber_ID = HUGE(Absorber_ID)  ! Entry not found: Hopefully induce code to fail 
+          Absorber_ID = ODPS_INVALID_ID  ! Out-of-range query; see ODPS_Validate_Group
       END SELECT
   END FUNCTION ODPS_Get_Absorber_ID
 
@@ -3548,9 +3585,127 @@ CONTAINS
         Group_Index == GROUP_MW_O3 .OR. Group_Index == GROUP_UV_NO2 )THEN
       Ozone_Component_ID = OZO_ComID
     ELSE
-      Ozone_Component_ID = -1
+      Ozone_Component_ID = ODPS_INVALID_ID
     END IF
   END FUNCTION ODPS_Get_Ozone_Component_ID
+
+
+!------------------------------------------------------------------------------
+!:sdoc+:
+!
+! NAME:
+!       ODPS_Validate_Group
+!
+! PURPOSE:
+!       Validate the group metadata of a loaded ODPS TauCoeff structure
+!       against the supported group definitions: the Group_Index must be a
+!       supported (non-Zeeman-reserved) group, and the file's Component_ID
+!       and Absorber_ID rosters must match that group's compiled maps
+!       exactly, in content and order (the predictor code addresses
+!       components positionally).
+!
+! CALLING SEQUENCE:
+!       Is_Valid = ODPS_Validate_Group( Group_Index,  &
+!                                       Component_ID, &
+!                                       Absorber_ID,  &
+!                                       Message       )
+!
+! INPUTS:
+!       Group_Index:   The file's ODPS group index.
+!       Component_ID:  The file's component ID roster.
+!       Absorber_ID:   The file's absorber ID roster.
+!
+! OUTPUTS:
+!       Message:       Explanation of the failure (blank when valid).
+!
+! FUNCTION RESULT:
+!       Is_Valid:      .TRUE. when the metadata is consistent with a
+!                      supported group; .FALSE. otherwise.
+!
+!:sdoc-:
+!------------------------------------------------------------------------------
+
+  FUNCTION ODPS_Validate_Group( Group_Index, Component_ID, Absorber_ID, Message ) &
+    RESULT( Is_Valid )
+    INTEGER,      INTENT(IN)  :: Group_Index
+    INTEGER,      INTENT(IN)  :: Component_ID(:)
+    INTEGER,      INTENT(IN)  :: Absorber_ID(:)
+    CHARACTER(*), INTENT(OUT) :: Message
+    LOGICAL :: Is_Valid
+    ! Local variables
+    INTEGER :: Expected_Component_ID(MAX_COMPONENTS_ANY_GROUP)
+    INTEGER :: Expected_Absorber_ID(MAX_ABSORBERS_ANY_GROUP)
+    INTEGER :: nc, na
+
+    Is_Valid = .FALSE.
+    Message  = ''
+
+    ! Reserved (Zeeman) indexes get a specific explanation
+    IF ( Group_Index >= RESERVED_ZSSMIS_GROUP .AND. &
+         Group_Index <= RESERVED_ZAMSUA_GROUP + 1 ) THEN
+      WRITE( Message, '("Group_Index ",i0," is reserved for the Zeeman ", &
+        &"sub-algorithms. Zeeman companion coefficients (z*.TauCoeff) are ", &
+        &"loaded via the ODZeeman path for SSMIS/AMSU-A sensors only; a ", &
+        &"standard ODPS TauCoeff must use group 1, 2, 3, 7, or 8.")' ) &
+        Group_Index
+      RETURN
+    END IF
+
+    ! Unknown group index
+    IF ( .NOT. ANY( VALID_GROUPS == Group_Index ) ) THEN
+      WRITE( Message, '("Group_Index ",i0," is not a supported ODPS group ", &
+        &"(supported: 1, 2, 3, 7, 8).")' ) Group_Index
+      RETURN
+    END IF
+
+    ! Fetch the expected rosters for this group
+    SELECT CASE ( Group_Index )
+      CASE ( GROUP_1 )
+        nc = SIZE(COMPONENT_ID_MAP_G1); na = SIZE(ABSORBER_ID_MAP_G1)
+        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G1
+        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G1
+      CASE ( GROUP_2 )
+        nc = SIZE(COMPONENT_ID_MAP_G2); na = SIZE(ABSORBER_ID_MAP_G2)
+        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G2
+        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G2
+      CASE ( GROUP_3 )
+        nc = SIZE(COMPONENT_ID_MAP_G3); na = SIZE(ABSORBER_ID_MAP_G3)
+        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G3
+        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G3
+      CASE ( GROUP_MW_O3 )
+        nc = SIZE(COMPONENT_ID_MAP_G7); na = SIZE(ABSORBER_ID_MAP_G7)
+        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G7
+        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G7
+      CASE ( GROUP_UV_NO2 )
+        nc = SIZE(COMPONENT_ID_MAP_G8); na = SIZE(ABSORBER_ID_MAP_G8)
+        Expected_Component_ID(1:nc) = COMPONENT_ID_MAP_G8
+        Expected_Absorber_ID(1:na)  = ABSORBER_ID_MAP_G8
+    END SELECT
+
+    ! Roster sizes
+    IF ( SIZE(Component_ID) /= nc .OR. SIZE(Absorber_ID) /= na ) THEN
+      WRITE( Message, '("Group ",i0," expects ",i0," components and ",i0, &
+        &" absorbers; file has ",i0," and ",i0,".")' ) &
+        Group_Index, nc, na, SIZE(Component_ID), SIZE(Absorber_ID)
+      RETURN
+    END IF
+
+    ! Roster content and order (the predictor code is positional)
+    IF ( ANY( Component_ID /= Expected_Component_ID(1:nc) ) ) THEN
+      WRITE( Message, '("Group ",i0," Component_ID mismatch: expected ", &
+        &8(i0,:,", "))' ) Group_Index, Expected_Component_ID(1:nc)
+      Message = TRIM(Message)//'; file order must match exactly.'
+      RETURN
+    END IF
+    IF ( ANY( Absorber_ID /= Expected_Absorber_ID(1:na) ) ) THEN
+      WRITE( Message, '("Group ",i0," Absorber_ID mismatch: expected ", &
+        &6(i0,:,", "))' ) Group_Index, Expected_Absorber_ID(1:na)
+      Message = TRIM(Message)//'; file order must match exactly.'
+      RETURN
+    END IF
+
+    Is_Valid = .TRUE.
+  END FUNCTION ODPS_Validate_Group
 
 
   ! This function gets a flag (true or false) indicating the

--- a/src/AtmAbsorption/ODZeeman/ODZeeman_Predictor.f90
+++ b/src/AtmAbsorption/ODZeeman/ODZeeman_Predictor.f90
@@ -19,6 +19,8 @@ MODULE ODZeeman_Predictor
   USE Message_Handler,       ONLY: SUCCESS, FAILURE, Display_Message
   USE ODPS_Predictor_Define, ONLY: ODPS_Predictor_type
   USE ODPS_Define,           ONLY: ODPS_type
+  USE ODPS_Predictor,        ONLY: RESERVED_ZSSMIS_GROUP, &
+                                   RESERVED_ZAMSUA_GROUP
 
   ! Disable implicit typing
   IMPLICIT NONE
@@ -60,7 +62,8 @@ MODULE ODZeeman_Predictor
   !----------------------------------------------------------------
   !  ZSSMIS parameters (SSMIS channels 19 - 22)
   !----------------------------------------------------------------
-  INTEGER, PARAMETER :: ODPS_gINDEX_ZSSMIS = 4  ! ODPS group index
+  ! ODPS group index; the reserved value is owned by ODPS_Predictor
+  INTEGER, PARAMETER :: ODPS_gINDEX_ZSSMIS = RESERVED_ZSSMIS_GROUP
   INTEGER, PARAMETER :: MAX_N_PREDICTORS_ZSSMIS = 18
   ! Global to ZSSMIS channel index mapping
   INTEGER, PARAMETER :: N_CHANNELS_SSMIS = 24
@@ -74,7 +77,8 @@ MODULE ODZeeman_Predictor
   !  ZAMSUA parameters (AMSUA channel 14)
   !----------------------------------------------------------------
   INTEGER, PARAMETER :: MAX_N_PREDICTORS_ZAMSUA = 7
-  INTEGER, PARAMETER :: ODPS_gINDEX_ZAMSUA = 5  ! ODPS group index
+  ! ODPS group index; the reserved value is owned by ODPS_Predictor
+  INTEGER, PARAMETER :: ODPS_gINDEX_ZAMSUA = RESERVED_ZAMSUA_GROUP
   ! Global to ZAMSUA channel index mapping
   INTEGER, PARAMETER :: N_CHANNELS_AMSUA = 15
   INTEGER, PARAMETER :: ZAMSUA_ChannelMap(N_CHANNELS_AMSUA) = (/&

--- a/src/Coefficients/CRTM_TauCoeff.f90
+++ b/src/Coefficients/CRTM_TauCoeff.f90
@@ -232,6 +232,7 @@ CONTAINS
     INTEGER            :: Algorithm_ID
     CHARACTER(SL), ALLOCATABLE :: SensorIDs(:)
     CHARACTER(SL), ALLOCATABLE :: zfnames(:)
+    LOGICAL,       ALLOCATABLE :: zeeman_candidate(:)
     INTEGER,       ALLOCATABLE :: SensorIndex(:)
     LOGICAL :: binary
     LOGICAL :: use_netCDF
@@ -368,6 +369,7 @@ CONTAINS
     ! Allocate memory for the local arrays    
     ALLOCATE( SensorIDs( n_Sensors ),   &                                                                 
               zfnames( n_Sensors ),     & 
+              zeeman_candidate( n_Sensors ), & 
               SensorIndex( n_Sensors ), &                                                                
               STAT = Allocate_Status )                                                                    
     IF ( Allocate_Status /= 0 ) THEN                                                                      
@@ -671,9 +673,24 @@ CONTAINS
     ! and no .bin) silently lose its Zeeman correction, because the per-file
     ! existence guard below would then find no zssmis*.TauCoeff.bin. Sensors
     ! with no Zeeman file in either format are simply skipped by that guard.
+    ! A sensor is a Zeeman candidate through the heritage WMO gate (SSMIS,
+    ! AMSU-A) OR, dual-acceptance, when a netCDF companion z-file exists and
+    ! opts in via the global attribute Zeeman_Algorithm = 1. Existing
+    ! coefficient sets carry no such attribute and behave exactly as before;
+    ! future Zeeman-corrected sensors can opt in via metadata instead of
+    ! having their WMO IDs hardwired here.
+    DO n = 1, n_Sensors
+      zeeman_candidate(n) = ( TC%WMO_Sensor_ID(n) == WMO_SSMIS .OR. &
+                              TC%WMO_Sensor_ID(n) == WMO_AMSUA )
+      IF ( .NOT. zeeman_candidate(n) ) THEN
+        zeeman_candidate(n) = Zeeman_Metadata_OptIn( &
+          TRIM(local_path)//'z'//TRIM(TC%Sensor_ID(n))//'.TauCoeff.nc' )
+      END IF
+    END DO
+
     zeeman_use_netCDF = .TRUE.
     DO n = 1, n_Sensors
-      IF ( TC%WMO_Sensor_ID(n) == WMO_SSMIS .OR. TC%WMO_Sensor_ID(n) == WMO_AMSUA ) THEN
+      IF ( zeeman_candidate(n) ) THEN
         zeeman_nc_exists  = File_Exists( TRIM(local_path) // 'z' // TRIM(TC%Sensor_ID(n)) // '.TauCoeff.nc'  )
         zeeman_bin_exists = File_Exists( TRIM(local_path) // 'z' // TRIM(TC%Sensor_ID(n)) // '.TauCoeff.bin' )
         IF ( ( .NOT. zeeman_nc_exists ) .AND. zeeman_bin_exists ) THEN
@@ -695,7 +712,7 @@ CONTAINS
     END IF
 
     DO n = 1, n_Sensors
-      IF(TC%WMO_Sensor_ID(n) == WMO_SSMIS .OR. TC%WMO_Sensor_ID(n) == WMO_AMSUA )THEN
+      IF( zeeman_candidate(n) )THEN
 
           ! file name: e.g. zssmis_f16.TauCoeff.nc (or .bin if NetCDF set incomplete)
         zfnames(i) = 'z'//TRIM(TC%Sensor_ID(n))//TRIM(zeeman_ext)
@@ -742,6 +759,7 @@ CONTAINS
 
     DEALLOCATE(SensorIDs,   &                 
                zfnames,     &
+               zeeman_candidate, &
                SensorIndex, &                                                                
                 STAT  = Deallocate_Status)
     IF ( Deallocate_Status /= 0 ) THEN                                   
@@ -924,6 +942,25 @@ CONTAINS
     END IF                                                    
 
   END FUNCTION CRTM_Destroy_TauCoeff
+
+  ! Dual-acceptance Zeeman opt-in probe: .TRUE. only when the named netCDF
+  ! companion file exists and carries global attribute Zeeman_Algorithm = 1.
+  ! Any missing file, unreadable file, or absent attribute means .FALSE.
+  ! (the heritage WMO gate then decides alone).
+  FUNCTION Zeeman_Metadata_OptIn( zFilename ) RESULT( OptIn )
+    CHARACTER(*), INTENT(IN) :: zFilename
+    LOGICAL :: OptIn
+    INTEGER :: status, FileID
+    INTEGER(Long) :: zeeman_flag
+    OptIn = .FALSE.
+    IF ( .NOT. File_Exists( zFilename ) ) RETURN
+    status = NF90_OPEN( zFilename, NF90_NOWRITE, FileID )
+    IF ( status /= NF90_NOERR ) RETURN
+    status = NF90_GET_ATT( FileID, NF90_GLOBAL, 'Zeeman_Algorithm', zeeman_flag )
+    IF ( status == NF90_NOERR ) OptIn = ( zeeman_flag == 1 )
+    status = NF90_CLOSE( FileID )
+  END FUNCTION Zeeman_Metadata_OptIn
+
 
   FUNCTION Inquire_AlgorithmID(  Filename        , &  ! Input
                                  Algorithm_ID    , &  ! Output

--- a/src/Coefficients/CRTM_TauCoeff.f90
+++ b/src/Coefficients/CRTM_TauCoeff.f90
@@ -40,6 +40,7 @@ MODULE CRTM_TauCoeff
                                   ODPS_Destroy_TauCoeff => Destroy_TauCoeff, &
                                   ODPS_TC => TC
   USE ODPS_Define         , ONLY: ODPS_type, ODPS_ALGORITHM
+  USE ODPS_Predictor      , ONLY: ODPS_Validate_Group
   USE ODSSU_TauCoeff      , ONLY: ODSSU_Load_TauCoeff    => Load_TauCoeff   , &
                                   ODSSU_Destroy_TauCoeff => Destroy_TauCoeff, &
                                   ODSSU_TC => TC
@@ -225,7 +226,8 @@ CONTAINS
     CHARACTER(:), ALLOCATABLE :: TauCoeff_File(:)
     INTEGER :: Allocate_Status, Deallocate_Status
     INTEGER :: n, n_Sensors
-    INTEGER :: i, j
+    INTEGER :: i, j, k
+    CHARACTER(512) :: GroupMessage
     INTEGER, PARAMETER :: SL = 128
     INTEGER            :: Algorithm_ID
     CHARACTER(SL), ALLOCATABLE :: SensorIDs(:)
@@ -548,15 +550,35 @@ CONTAINS
       ! set the pointer pointing to the local (algorithm specific) TC array
       TC%ODPS => ODPS_TC
 
-      ! Copy over sensor types and IDs 
-      DO i = 1, n  
-        j = SensorIndex(i)   
-        TC%Sensor_ID(j)        = TC%ODPS(i)%Sensor_ID  
+      ! Copy over sensor types and IDs
+      DO i = 1, n
+        j = SensorIndex(i)
+        TC%Sensor_ID(j)        = TC%ODPS(i)%Sensor_ID
         TC%WMO_Satellite_ID(j) = TC%ODPS(i)%WMO_Satellite_ID
         TC%WMO_Sensor_ID(j)    = TC%ODPS(i)%WMO_Sensor_ID
         TC%Sensor_Type(j)      = TC%ODPS(i)%Sensor_Type
-      END DO     
-        
+      END DO
+
+      ! Validate each loaded structure against the supported ODPS group
+      ! definitions (Group_Index plus the Component_ID/Absorber_ID rosters).
+      ! Zeeman companion files (z*.TauCoeff) are loaded separately via the
+      ! ODZeeman path below and are not subject to this check.
+      DO i = 1, n
+        IF ( .NOT. ODPS_Validate_Group( TC%ODPS(i)%Group_Index , &
+                                        TC%ODPS(i)%Component_ID, &
+                                        TC%ODPS(i)%Absorber_ID , &
+                                        GroupMessage ) ) THEN
+          Error_Status = FAILURE
+          CALL Display_Message( ROUTINE_NAME, &
+                                'Invalid ODPS TauCoeff for sensor '// &
+                                TRIM(TC%ODPS(i)%Sensor_ID)//': '// &
+                                TRIM(GroupMessage), &
+                                Error_Status, &
+                                Message_Log=Message_Log )
+          RETURN
+        END IF
+      END DO
+
     END IF
 
     ! *** ODSSU algorithm  ***
@@ -597,15 +619,36 @@ CONTAINS
       ! set the pointer pointing to the local (algorithm specific) TC array
       TC%ODSSU => ODSSU_TC
         
-      ! Copy over sensor types and IDs 
-      DO i = 1, n  
-        j = SensorIndex(i) 
-        TC%Sensor_ID(j)        = TC%ODSSU(i)%Sensor_ID  
+      ! Copy over sensor types and IDs
+      DO i = 1, n
+        j = SensorIndex(i)
+        TC%Sensor_ID(j)        = TC%ODSSU(i)%Sensor_ID
         TC%WMO_Satellite_ID(j) = TC%ODSSU(i)%WMO_Satellite_ID
         TC%WMO_Sensor_ID(j)    = TC%ODSSU(i)%WMO_Sensor_ID
         TC%Sensor_Type(j)      = TC%ODSSU(i)%Sensor_Type
-      END DO   
-        
+      END DO
+
+      ! Validate every nested ODPS sub-structure of each ODSSU sensor
+      ! (ODSSU may instead carry ODAS sub-structures, hence the guard)
+      DO i = 1, n
+        IF ( .NOT. ASSOCIATED(TC%ODSSU(i)%ODPS) ) CYCLE
+        DO k = 1, SIZE(TC%ODSSU(i)%ODPS)
+          IF ( .NOT. ODPS_Validate_Group( TC%ODSSU(i)%ODPS(k)%Group_Index , &
+                                          TC%ODSSU(i)%ODPS(k)%Component_ID, &
+                                          TC%ODSSU(i)%ODPS(k)%Absorber_ID , &
+                                          GroupMessage ) ) THEN
+            Error_Status = FAILURE
+            CALL Display_Message( ROUTINE_NAME, &
+                                  'Invalid ODPS sub-structure in ODSSU TauCoeff for sensor '// &
+                                  TRIM(TC%ODSSU(i)%Sensor_ID)//': '// &
+                                  TRIM(GroupMessage), &
+                                  Error_Status, &
+                                  Message_Log=Message_Log )
+            RETURN
+          END IF
+        END DO
+      END DO
+
     END IF
 
     !----------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,7 +210,6 @@ list( APPEND AOD_Sensor_Ids
 
 # Create list of sensor ids for testing
 list( APPEND Zeeman_Sensor_Ids
-      ssmis_f20
       ssmis_f19
       ssmis_f18
       ssmis_f17
@@ -1077,17 +1076,14 @@ SpcCoeff/netCDF/v.viirs-m_npp.SpcCoeff.nc
 TauCoeff/ODAS/netCDF/v.viirs-m_npp.TauCoeff.nc
 SpcCoeff/netCDF/v.abi_gr.SpcCoeff.nc
 TauCoeff/ODAS/netCDF/v.abi_gr.TauCoeff.nc
-TauCoeff/ODPS/netCDF/zssmis_f20.TauCoeff.nc
 TauCoeff/ODPS/netCDF/zssmis_f19.TauCoeff.nc
 TauCoeff/ODPS/netCDF/zssmis_f18.TauCoeff.nc
 TauCoeff/ODPS/netCDF/zssmis_f17.TauCoeff.nc
 TauCoeff/ODPS/netCDF/zssmis_f16.TauCoeff.nc
-TauCoeff/ODPS/netCDF/ssmis_f20.TauCoeff.nc
 TauCoeff/ODPS/netCDF/ssmis_f19.TauCoeff.nc
 TauCoeff/ODPS/netCDF/ssmis_f18.TauCoeff.nc
 TauCoeff/ODPS/netCDF/ssmis_f17.TauCoeff.nc
 TauCoeff/ODPS/netCDF/ssmis_f16.TauCoeff.nc
-SpcCoeff/netCDF/ssmis_f20.SpcCoeff.nc
 SpcCoeff/netCDF/ssmis_f18.SpcCoeff.nc
 SpcCoeff/netCDF/ssmis_f19.SpcCoeff.nc
 SpcCoeff/netCDF/ssmis_f16.SpcCoeff.nc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -372,6 +372,14 @@ target_link_libraries(Unit_Fastem1_SST_Jacobian PRIVATE crtm)
 add_test(NAME test_Unit_Fastem1_SST_Jacobian
          COMMAND $<TARGET_FILE:Unit_Fastem1_SST_Jacobian>)
 
+# ODPS group modernization (Tier 0): load-time validation of Group_Index and
+# the Component_ID/Absorber_ID rosters, including rejection of the
+# Zeeman-reserved indexes (the OMPS Group-4 failure mode).
+add_executable(Unit_ODPS_Group_Validation mains/unit/Unit_Test/test_ODPS_Group_Validation.f90)
+target_link_libraries(Unit_ODPS_Group_Validation PRIVATE crtm)
+add_test(NAME test_Unit_ODPS_Group_Validation
+         COMMAND $<TARGET_FILE:Unit_ODPS_Group_Validation>)
+
 # Pins the v3.2.0 DDA-ARTS ICE_CLOUD scattering change (ICE_CLOUD now scatters via
 # the full branch / IconCloudIce habit). Registered only when a DDA-ARTS CloudCoeff
 # is present in the staged fix tree.

--- a/test/mains/regression/forward/test_Zeeman/test_Zeeman.f90
+++ b/test/mains/regression/forward/test_Zeeman/test_Zeeman.f90
@@ -15,7 +15,7 @@
 !          zssmis_fxx.TauCoeff.bin
 !        must be present, used together with the coefficient file
 !          ssmis_fxx.TauCoeff.bin
-!        where xx is 16, 17, 18, 19 or 20.  If zssmis_fxx.TauCoeff.bin is
+!        where xx is 16, 17, 18 or 19.  If zssmis_fxx.TauCoeff.bin is
 !        not present, the Forward calculations will use the coefficients
 !        in the file ssmis_fxx.TauCoeff.bin for all channels. In this case,
 !        the Zeeman and Doppler effects will not be taken into account.

--- a/test/mains/regression/k_matrix/test_Zeeman/test_Zeeman.f90
+++ b/test/mains/regression/k_matrix/test_Zeeman/test_Zeeman.f90
@@ -15,7 +15,7 @@
 !          zssmis_fxx.TauCoeff.bin
 !        must be present, used together with the coefficient file
 !          ssmis_fxx.TauCoeff.bin
-!        where xx is 16, 17, 18, 19 or 20.  If zssmis_fxx.TauCoeff.bin is
+!        where xx is 16, 17, 18 or 19.  If zssmis_fxx.TauCoeff.bin is
 !        not present, the Forward calculations will use the coefficients
 !        in the file ssmis_fxx.TauCoeff.bin for all channels. In this case,
 !        the Zeeman and Doppler effects will not be taken into account.

--- a/test/mains/unit/Unit_Test/test_ODPS_Group_Validation.f90
+++ b/test/mains/unit/Unit_Test/test_ODPS_Group_Validation.f90
@@ -63,23 +63,52 @@ PROGRAM test_ODPS_Group_Validation
   CALL Expect_Invalid( -1, (/ 113, 12 /), (/ 1 /), 'negative group' )
 
   ! ---------------------------------------------------------------
-  ! Roster mismatches within a supported group: all must be rejected
+  ! Kernel-capability semantics (Tier 2): well-formed subset, reordered,
+  ! or extended rosters whose components all map to kernels (with their
+  ! required gases) are ACCEPTED; the compute path dispatches by the
+  ! file's own roster.
   ! ---------------------------------------------------------------
-  ! Wrong component count
-  CALL Expect_Invalid( GROUP_3, (/ 113, 12, 114 /), (/ 1 /), &
-    'group 3 with an extra component' )
-  ! Wrong absorber count
-  CALL Expect_Invalid( GROUP_3, (/ 113, 12 /), (/ 1, 3 /), &
-    'group 3 with an extra absorber' )
-  ! Wrong component content (correct count)
+  ! A group-3 file carrying an ozone component with the O3 gas (G7-style)
+  CALL Expect_Valid( GROUP_3, (/ 113, 12, 114 /), (/ 1, 3 /), &
+    'group 3 with an ozone component and the O3 gas' )
+  ! Extra known absorber (harmlessly mapped, consumed by no kernel)
+  CALL Expect_Valid( GROUP_3, (/ 113, 12 /), (/ 1, 3 /), &
+    'group 3 with an extra known absorber' )
+  ! Reordered roster (dispatch is by ID, not position)
+  CALL Expect_Valid( GROUP_3, (/ 12, 113 /), (/ 1 /), &
+    'group 3 roster reordered' )
+  ! A dry+ozone UV subset: the physics the OMPS files actually contain,
+  ! expressible as a legitimate group-8 subset roster
+  CALL Expect_Valid( GROUP_UV_NO2, (/ 20, 114 /), (/ 3 /), &
+    'group 8 dry+ozone subset (regenerated-OMPS shape)' )
+
+  ! ---------------------------------------------------------------
+  ! Malformed rosters: all must be rejected
+  ! ---------------------------------------------------------------
+  ! Unknown component ID (raw molecule set 13 has no CRTM kernel)
   CALL Expect_Invalid( GROUP_3, (/ 13, 12 /), (/ 1 /), &
     'group 3 with molecule-set dry (13) instead of effective dry (113)' )
-  ! Wrong component ORDER (same set; positional dispatch makes this invalid)
-  CALL Expect_Invalid( GROUP_3, (/ 12, 113 /), (/ 1 /), &
-    'group 3 roster out of order' )
-  ! Wrong absorber content
+  ! Component whose required gas is missing
   CALL Expect_Invalid( GROUP_MW_O3, (/ 113, 12, 114 /), (/ 1, 2 /), &
-    'group 7 with CO2 in place of O3' )
+    'group 7 ozone component without the O3 gas' )
+  ! Duplicate component
+  CALL Expect_Invalid( GROUP_3, (/ 113, 113 /), (/ 1 /), &
+    'duplicate component ID' )
+  ! Duplicate absorber
+  CALL Expect_Invalid( GROUP_3, (/ 113, 12 /), (/ 1, 1 /), &
+    'duplicate absorber ID' )
+  ! Unknown absorber ID
+  CALL Expect_Invalid( GROUP_3, (/ 113, 12 /), (/ 1, 99 /), &
+    'unknown absorber ID' )
+  ! Partial trace trio (CO without CH4/N2O)
+  CALL Expect_Invalid( GROUP_1, (/ 7, 101, 15, 114, 121, 119 /), &
+    (/ 1, 3, 2, 5 /), 'partial trace trio (CO without CH4 and N2O)' )
+  ! IR component on the MW basis
+  CALL Expect_Invalid( GROUP_3, (/ 113, 101 /), (/ 1 /), &
+    'IR water-line component (101) on the MW basis' )
+  ! WLO without the CO2 gas its predictor 15 consumes
+  CALL Expect_Invalid( GROUP_2, (/ 20, 101, 15, 114, 121 /), (/ 1, 3 /), &
+    'group 2 WLO without the CO2 gas' )
 
   ! ---------------------------------------------------------------
   ! Report

--- a/test/mains/unit/Unit_Test/test_ODPS_Group_Validation.f90
+++ b/test/mains/unit/Unit_Test/test_ODPS_Group_Validation.f90
@@ -1,0 +1,130 @@
+!
+! test_ODPS_Group_Validation
+!
+! Unit test for ODPS_Validate_Group (Tier 0 of the ODPS group modernization).
+! Exercises: every supported group's canonical roster (must pass), the
+! Zeeman-reserved indexes (must fail with a Zeeman explanation), an unknown
+! group, roster size mismatches, roster content mismatches, and roster order
+! mismatches (the predictor code is positional, so order matters).
+!
+! The failing rosters include the real-world case that motivated the check:
+! the OMPS Group-4 files (Group_Index=4, Component_ID=[13,14], a private
+! convention of an external UV trainer that collides with the Zeeman index).
+!
+PROGRAM test_ODPS_Group_Validation
+
+  USE ODPS_Predictor, ONLY: ODPS_Validate_Group, &
+                            GROUP_1, GROUP_2, GROUP_3, &
+                            GROUP_MW_O3, GROUP_UV_NO2, &
+                            RESERVED_ZSSMIS_GROUP, &
+                            RESERVED_ZAMSUA_GROUP
+  IMPLICIT NONE
+
+  CHARACTER(*), PARAMETER :: PROGRAM_NAME = 'test_ODPS_Group_Validation'
+  CHARACTER(512) :: Message
+  INTEGER :: n_Failed
+
+  n_Failed = 0
+
+  ! ---------------------------------------------------------------
+  ! Supported groups with their canonical rosters: all must validate
+  ! ---------------------------------------------------------------
+  CALL Expect_Valid( GROUP_1, &
+    (/ 7, 101, 15, 114, 121, 120, 119, 118 /), (/ 1, 3, 2, 4, 5, 6 /), &
+    'group 1 canonical roster' )
+  CALL Expect_Valid( GROUP_2, &
+    (/ 20, 101, 15, 114, 121 /), (/ 1, 3, 2 /), &
+    'group 2 canonical roster' )
+  CALL Expect_Valid( GROUP_3, &
+    (/ 113, 12 /), (/ 1 /), &
+    'group 3 canonical roster' )
+  CALL Expect_Valid( GROUP_MW_O3, &
+    (/ 113, 12, 114 /), (/ 1, 3 /), &
+    'group 7 canonical roster' )
+  CALL Expect_Valid( GROUP_UV_NO2, &
+    (/ 20, 101, 15, 114, 121, 122 /), (/ 1, 3, 2, 10 /), &
+    'group 8 canonical roster' )
+
+  ! ---------------------------------------------------------------
+  ! Reserved and unknown group indexes: all must be rejected
+  ! ---------------------------------------------------------------
+  ! The OMPS Group-4 files exactly as shipped (dry=13, ozone=14, O3 absorber)
+  CALL Expect_Invalid( RESERVED_ZSSMIS_GROUP, (/ 13, 14 /), (/ 3 /), &
+    'OMPS-style Group-4 file (Zeeman-reserved index)' )
+  ! A zssmis companion loaded through the wrong (ODPS) path
+  CALL Expect_Invalid( RESERVED_ZSSMIS_GROUP, (/ 13 /), (/ 1 /), &
+    'zssmis companion via the ODPS path (Zeeman-reserved index)' )
+  CALL Expect_Invalid( RESERVED_ZAMSUA_GROUP, (/ 13 /), (/ 1 /), &
+    'Zeeman-reserved AMSU-A index' )
+  CALL Expect_Invalid( 6, (/ 13 /), (/ 1 /), &
+    'Zeeman-reserved index 6' )
+  CALL Expect_Invalid( 0, (/ 113, 12 /), (/ 1 /), 'group 0 (fill value)' )
+  CALL Expect_Invalid( 9, (/ 113, 12 /), (/ 1 /), 'group 9 (beyond table)' )
+  CALL Expect_Invalid( -1, (/ 113, 12 /), (/ 1 /), 'negative group' )
+
+  ! ---------------------------------------------------------------
+  ! Roster mismatches within a supported group: all must be rejected
+  ! ---------------------------------------------------------------
+  ! Wrong component count
+  CALL Expect_Invalid( GROUP_3, (/ 113, 12, 114 /), (/ 1 /), &
+    'group 3 with an extra component' )
+  ! Wrong absorber count
+  CALL Expect_Invalid( GROUP_3, (/ 113, 12 /), (/ 1, 3 /), &
+    'group 3 with an extra absorber' )
+  ! Wrong component content (correct count)
+  CALL Expect_Invalid( GROUP_3, (/ 13, 12 /), (/ 1 /), &
+    'group 3 with molecule-set dry (13) instead of effective dry (113)' )
+  ! Wrong component ORDER (same set; positional dispatch makes this invalid)
+  CALL Expect_Invalid( GROUP_3, (/ 12, 113 /), (/ 1 /), &
+    'group 3 roster out of order' )
+  ! Wrong absorber content
+  CALL Expect_Invalid( GROUP_MW_O3, (/ 113, 12, 114 /), (/ 1, 2 /), &
+    'group 7 with CO2 in place of O3' )
+
+  ! ---------------------------------------------------------------
+  ! Report
+  ! ---------------------------------------------------------------
+  IF ( n_Failed == 0 ) THEN
+    WRITE(*,'(a,": ALL TESTS PASSED")') PROGRAM_NAME
+    STOP 0
+  ELSE
+    WRITE(*,'(a,": ",i0," TEST(S) FAILED")') PROGRAM_NAME, n_Failed
+    STOP 1
+  END IF
+
+CONTAINS
+
+  SUBROUTINE Expect_Valid( Group_Index, Component_ID, Absorber_ID, Label )
+    INTEGER,      INTENT(IN) :: Group_Index
+    INTEGER,      INTENT(IN) :: Component_ID(:)
+    INTEGER,      INTENT(IN) :: Absorber_ID(:)
+    CHARACTER(*), INTENT(IN) :: Label
+    IF ( ODPS_Validate_Group( Group_Index, Component_ID, Absorber_ID, Message ) ) THEN
+      WRITE(*,'("  PASS (valid):   ",a)') Label
+    ELSE
+      WRITE(*,'("  FAIL: expected valid but got invalid: ",a)') Label
+      WRITE(*,'("        message: ",a)') TRIM(Message)
+      n_Failed = n_Failed + 1
+    END IF
+  END SUBROUTINE Expect_Valid
+
+  SUBROUTINE Expect_Invalid( Group_Index, Component_ID, Absorber_ID, Label )
+    INTEGER,      INTENT(IN) :: Group_Index
+    INTEGER,      INTENT(IN) :: Component_ID(:)
+    INTEGER,      INTENT(IN) :: Absorber_ID(:)
+    CHARACTER(*), INTENT(IN) :: Label
+    IF ( .NOT. ODPS_Validate_Group( Group_Index, Component_ID, Absorber_ID, Message ) ) THEN
+      IF ( LEN_TRIM(Message) == 0 ) THEN
+        WRITE(*,'("  FAIL: rejected but with a blank message: ",a)') Label
+        n_Failed = n_Failed + 1
+      ELSE
+        WRITE(*,'("  PASS (invalid): ",a)') Label
+        WRITE(*,'("        message: ",a)') TRIM(Message)
+      END IF
+    ELSE
+      WRITE(*,'("  FAIL: expected invalid but got valid: ",a)') Label
+      n_Failed = n_Failed + 1
+    END IF
+  END SUBROUTINE Expect_Invalid
+
+END PROGRAM test_ODPS_Group_Validation

--- a/test/mains/unit/Unit_Test/test_ODPS_NO2_Predictor_TLAD.f90
+++ b/test/mains/unit/Unit_Test/test_ODPS_NO2_Predictor_TLAD.f90
@@ -42,6 +42,9 @@ PROGRAM test_ODPS_NO2_Predictor_TLAD
   INTEGER,  PARAMETER :: N_COMPONENTS = 6    ! group-8 [Dry,WLO,WCO,OZO,CO2,NO2]
   INTEGER,  PARAMETER :: N_ABSORBERS  = 4    ! group-8 [H2O,O3,CO2,NO2]
   INTEGER,  PARAMETER :: MAX_N_PRED   = 15
+  ! Canonical group-8 rosters [Dry,WLO,WCO,OZO,CO2,NO2] over [H2O,O3,CO2,NO2]
+  INTEGER,  PARAMETER :: COMPONT_IDS(N_COMPONENTS) = (/ 20, 101, 15, 114, 121, 122 /)
+  INTEGER,  PARAMETER :: ABSORBR_IDS(N_ABSORBERS)  = (/ 1, 3, 2, 10 /)
   REAL(fp), PARAMETER :: ZERO = 0.0_fp, ONE = 1.0_fp
   REAL(fp), PARAMETER :: TOL  = 1.0e-13_fp   ! ~1e3 * eps: pure-arithmetic bound
 
@@ -93,7 +96,8 @@ PROGRAM test_ODPS_NO2_Predictor_TLAD
   END IF
 
   ! Forward (fills prd%n_CP and the predictor values the AD recomputation uses)
-  CALL ODPS_Compute_Predictor( GROUP_UV_NO2, t, abs_prof, ref_level_p, &
+  CALL ODPS_Compute_Predictor( GROUP_UV_NO2, COMPONT_IDS, ABSORBR_IDS, &
+                               t, abs_prof, ref_level_p, &
                                ref_t, ref_abs, secang, prd )
 
   ! TL input: relative structure on every absorber, additive on T
@@ -103,7 +107,8 @@ PROGRAM test_ODPS_NO2_Predictor_TLAD
       abs_tl(k,j) = 0.1_fp * abs_prof(k,j) * COS( 0.23_fp*REAL(k,fp) + 1.1_fp*REAL(j,fp) )
     END DO
   END DO
-  CALL ODPS_Compute_Predictor_TL( GROUP_UV_NO2, t, abs_prof, ref_t, ref_abs, &
+  CALL ODPS_Compute_Predictor_TL( GROUP_UV_NO2, COMPONT_IDS, ABSORBR_IDS, &
+                                  t, abs_prof, ref_t, ref_abs, &
                                   secang, prd, t_tl, abs_tl, prd_TL )
 
   ! AD dual: deterministic pseudo-random weights on every active predictor slot
@@ -120,7 +125,8 @@ PROGRAM test_ODPS_NO2_Predictor_TLAD
 
   t_ad   = ZERO
   abs_ad = ZERO
-  CALL ODPS_Compute_Predictor_AD( GROUP_UV_NO2, t, abs_prof, ref_t, ref_abs, &
+  CALL ODPS_Compute_Predictor_AD( GROUP_UV_NO2, COMPONT_IDS, ABSORBR_IDS, &
+                                  t, abs_prof, ref_t, ref_abs, &
                                   secang, prd, prd_AD, t_ad, abs_ad )
 
   ! <X_TL, X_AD>  vs  <(dT,dAbs), (T_AD, Abs_AD)>


### PR DESCRIPTION
# ODPS group system modernization (Tiers 0 through 2)

Full developer documentation, including the design-debt inventory and the per-tier rationale, is in issue #342. This PR is the implementation.

## Summary

The ODPS transmittance group system accumulated six parallel per-group parameter table families, positional dispatch that trusted file metadata without ever checking it, and three near-identical 1000+ line predictor monoliths (FWD, TL, AD). This PR replaces that arrangement in three verified, bit-identical tiers:

- **Tier 0 (guardrails):** every ODPS structure (including ODSSU sub-blocks) is validated at load time by `ODPS_Validate_Group`. Reserved Zeeman group indexes (4 through 6), unknown groups, duplicate IDs, unknown component or absorber IDs, and inconsistent rosters now fail `CRTM_Init` with the sensor name and the specific reason, instead of computing silently wrong radiances or dying in an allocation. The Zeeman reserved indexes are now owned by `ODPS_Predictor` and derived in `ODZeeman_Predictor`, and `ODPS_INVALID_ID` replaces the `HUGE()` sentinels.
- **Tier 1 (registry and kernels):** a single `GROUP_REGISTRY` of `ODPS_Group_Spec_type` replaces the parallel table families, and the FWD/TL/AD predictor monoliths are decomposed into per-component kernels called from per-basis layer loops. The adjoint kernel call order is bit-significant (floating-point accumulation order) and is documented as load-bearing in the source.
- **Tier 2 (file-roster dispatch):** the compute drivers now take the file's own `Component_ID` and `Absorber_ID` rosters. Dispatch, gas positions, and predictor counts come from the file, validated against kernel capability. Subset and reordered rosters are legal if every component maps to a kernel and its required gases are present; unknown component IDs (for example the legacy OMPS `[13, 14]` files, see JCSDA-internal/crtm-coeffgen#43) are still rejected, now with a one-line explanation. Zeeman companions are accepted via the heritage SSMIS/AMSU-A WMO gate or, newly, a `Zeeman_Algorithm = 1` global attribute on the z-file.

## Backward compatibility

No coefficient file changes anywhere. All existing canonical files pass the new validation verbatim (confirmed by an empirical roster sweep over 568 ODPS structures, including ODSSU sub-blocks) and produce bit-identical results. The generator-side contract is recorded in crtm-coeffgen `docs/crtm_odps_group_contract.md`: coeffgen keeps emitting canonical rosters in canonical order so one file serves both released (positional) and modernized (roster-driven) CRTMs.

## Verification

- Full ctest suite green at every tier: 227 of 227 tests passed after each of the four implementation commits.
- New unit test `test_Unit_ODPS_Group_Validation` covers 23 rosters: the five canonical groups, reordered and subset variants that must be accepted, and reserved-group, unknown-group, duplicate, partial trace trio, missing-gas, basis-mismatch, and unknown-absorber rosters that must be rejected.
- `test_ODPS_NO2_Predictor_TLAD` updated for the new driver signatures; TL/AD parity remains at machine precision.
- Bit-identity was enforced throughout: the regression baselines needed no updates.

Also included: removal of ssmis_f20 from the Zeeman test roster and data manifest, since its coefficient files were removed from the distributed test data set.

## Out of scope

Tier 3 (schema recipe tags, ODAS/ODPS/ODSSU/ODZeeman strategy unification, a shared machine-readable registry with crtm-coeffgen) is deferred to v4, as discussed in #342.

Closes #342.
