### PR TITLE
CMake: skip unnecessary re-hashing of coeffs tarball

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,11 +82,10 @@ else() # Download CRTM coefficients
   set(DOWNLOAD_BASE_URL "https://bin.ssec.wisc.edu/pub/s4/CRTM/")
   set(test_files_dirname ${CRTM_COEFFS_BRANCH}.tgz)
   set(checksum "0e5888cae80aa674b2e67ecd4490317d") # MD5SUM of fix_REL-3.1.2.0.tgz
-  
-  # The tarball is used to populate ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}, so skip
-  # acquiring/verifying it (hashing takes 10s of seconds) when that directory already exists.
+
+  # Check if the CRTM binary tarball is already present otherwise download it.
+  message(STATUS "Checking if ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH} already exists...")
   if(NOT EXISTS ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/)
-    # Check if the CRTM binary tarball is already present otherwise download it.
     if (DEFINED ENV{CRTM_BINARY_FILES_TARBALL})
       file(MD5 "$ENV{CRTM_BINARY_FILES_TARBALL}" computed_checksum )
       if (NOT "${computed_checksum}" STREQUAL "${checksum}")
@@ -102,14 +101,7 @@ else() # Download CRTM coefficients
         EXPECTED_MD5 ${checksum}
         SHOW_PROGRESS)
     endif()
-  endif()
 
-  # -- UNTAR -- 
-  
-  # Define the directory to untar into
-  message(STATUS "Checking if ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH} already exists...")
-  # Only untar if the CHECK_PATH does not exist
-  if(NOT EXISTS ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/)
     message(STATUS "Untarring the downloaded file (~2 minutes) to ${CRTM_COEFFS_PATH}")
     # Use the built-in tar feature to work around an issue on Orion with the
     # system tar command. See: https://github.com/JCSDA/spack-stack/issues/1355

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,34 +83,37 @@ else() # Download CRTM coefficients
   set(test_files_dirname ${CRTM_COEFFS_BRANCH}.tgz)
   set(checksum "0e5888cae80aa674b2e67ecd4490317d") # MD5SUM of fix_REL-3.1.2.0.tgz
   
-  # Check if the CRTM binary tarball is already present otherwise download it.
-  if (DEFINED ENV{CRTM_BINARY_FILES_TARBALL})
-    file(MD5 "$ENV{CRTM_BINARY_FILES_TARBALL}" computed_checksum )
-    if (NOT "${computed_checksum}" STREQUAL "${checksum}")
-      message(FATAL_ERROR "Environment provided CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL} had checksum '${computed_checksum}' not matching expected '${checksum}'")
+  # The tarball is used to populate ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}, so skip
+  # acquiring/verifying it (hashing takes 10s of seconds) when that directory already exists.
+  if(NOT EXISTS ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/)
+    # Check if the CRTM binary tarball is already present otherwise download it.
+    if (DEFINED ENV{CRTM_BINARY_FILES_TARBALL})
+      file(MD5 "$ENV{CRTM_BINARY_FILES_TARBALL}" computed_checksum )
+      if (NOT "${computed_checksum}" STREQUAL "${checksum}")
+        message(FATAL_ERROR "Environment provided CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL} had checksum '${computed_checksum}' not matching expected '${checksum}'")
+      endif()
+      message(STATUS "Using CRTM coeffs tarball file CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL}")
+      set(DOWNLOAD_DEST "$ENV{CRTM_BINARY_FILES_TARBALL}")
+    else()
+      set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
+      set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")
+      message(STATUS "Downloading CRTM coeffs files from: ${DOWNLOAD_URL} to ${DOWNLOAD_DEST}")
+      file(DOWNLOAD ${DOWNLOAD_URL} ${DOWNLOAD_DEST}
+        EXPECTED_MD5 ${checksum}
+        SHOW_PROGRESS)
     endif()
-    message(STATUS "Using CRTM coeffs tarball file CRTM_BINARY_FILES_TARBALL=$ENV{CRTM_BINARY_FILES_TARBALL}")
-    set(DOWNLOAD_DEST "$ENV{CRTM_BINARY_FILES_TARBALL}")
-  else()
-    set(DOWNLOAD_URL "${DOWNLOAD_BASE_URL}/${test_files_dirname}")
-    set(DOWNLOAD_DEST "${CRTM_COEFFS_PATH}/${test_files_dirname}")
-    message(STATUS "Downloading CRTM coeffs files from: ${DOWNLOAD_URL} to ${DOWNLOAD_DEST}")
-    file(DOWNLOAD ${DOWNLOAD_URL} ${DOWNLOAD_DEST}
-      EXPECTED_MD5 ${checksum}
-      SHOW_PROGRESS)
   endif()
 
   # -- UNTAR -- 
   
   # Define the directory to untar into
-  set(UNTAR_DEST "${CMAKE_SOURCE_DIR}/test-data-release")
-    message(STATUS "Checking if ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH} already exists...")
+  message(STATUS "Checking if ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH} already exists...")
   # Only untar if the CHECK_PATH does not exist
-  if(NOT EXISTS ${UNTAR_DEST}/${CRTM_COEFFS_BRANCH}/)
-    message(STATUS "Untarring the downloaded file (~2 minutes) to ${UNTAR_DEST}")
+  if(NOT EXISTS ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/)
+    message(STATUS "Untarring the downloaded file (~2 minutes) to ${CRTM_COEFFS_PATH}")
     # Use the built-in tar feature to work around an issue on Orion with the
     # system tar command. See: https://github.com/JCSDA/spack-stack/issues/1355
-    execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${UNTAR_DEST}
+    execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${CRTM_COEFFS_PATH}
                     ${CMAKE_COMMAND} -E tar xzf ${DOWNLOAD_DEST}
                     RESULT_VARIABLE result
                     OUTPUT_QUIET ERROR_QUIET)
@@ -122,9 +125,9 @@ else() # Download CRTM coefficients
   endif()
 endif()
 
-  set (CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
-  message(STATUS "Downloaded CRTM files are placed at ${CRTM_TESTFILES_PATH} ")
-  set_property (GLOBAL PROPERTY CRTM_TESTFILES_PATH ${CRTM_TESTFILES_PATH})
+set (CRTM_TESTFILES_PATH ${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}/fix)
+message(STATUS "Downloaded CRTM files are placed at ${CRTM_TESTFILES_PATH} ")
+set_property (GLOBAL PROPERTY CRTM_TESTFILES_PATH ${CRTM_TESTFILES_PATH})
 
 # Create list of sensor ids for testing
 list( APPEND Simple_Sensor_Ids


### PR DESCRIPTION
## Description

This PR adds logic so that the coeff tarball is only hashed and verified _when the tarball will be untarred_.

In more detail, the coeffs tarball is only untarred when `${CRTM_COEFFS_PATH}/${CRTM_COEFFS_BRANCH}` does _not_ exist. Verifying the tarball when the directory _does_ exist is wasting time (and ~30+ seconds of it). So, this PR adds the same directory as guard for the acquire/verification step.

## Issue(s) addressed

Resolves #353 

## Dependencies

## Impact

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
