### PR TITLE
Launch fewer CMake subprocesses

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,9 +17,9 @@ set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 # macro to create a symlink from src to dst
 function(CREATE_SYMLINK src dst)
     foreach (FILENAME ${ARGN})
-        execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+        file( CREATE_LINK
             ${src}/${FILENAME}
-            ${dst}/${FILENAME} )
+            ${dst}/${FILENAME} SYMBOLIC )
         endforeach(FILENAME)
 endfunction(CREATE_SYMLINK)
 
@@ -27,9 +27,9 @@ endfunction(CREATE_SYMLINK)
 function(CREATE_SYMLINK_FILENAME src dst)
     foreach (FILENAME ${ARGN})
         get_filename_component(filename ${FILENAME} NAME )
-        execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+        file( CREATE_LINK
             ${src}/${FILENAME}
-            ${dst}/${filename} )
+            ${dst}/${filename} SYMBOLIC )
         endforeach(FILENAME)
 endfunction(CREATE_SYMLINK_FILENAME)
 


### PR DESCRIPTION
## Description

This PR updates how symlinks are handled by CRTM, to reduce the number of CMake processes being launched and speed up CMake configuration time. See https://github.com/JCSDA-internal/jedi-bundle/issues/157.

- Replace `execute_process( ... -E create_symlink )` with `file( CREATE_LINK ... SYMBOLIC )`

## Issue(s) addressed

Towards https://github.com/JCSDA-internal/jedi-bundle/issues/157

## Dependencies

## Impact

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
